### PR TITLE
perf(preview): eliminate per-frame re-renders and fix paused-video seek storm during playback

### DIFF
--- a/qcut/apps/web/src/components/editor/effects/effect-companion-audio-players.tsx
+++ b/qcut/apps/web/src/components/editor/effects/effect-companion-audio-players.tsx
@@ -25,10 +25,12 @@ function EffectCompanionAudioPlayer({
 	element,
 	trackId,
 	trackMuted,
+	timelineTime,
 }: ElementEffectAudioCompanion & {
 	element: TimelineElement;
 	trackId: string;
 	trackMuted: boolean;
+	timelineTime?: number;
 }) {
 	const duration = resolvePlaybackDuration({ companion, element });
 	const startTime = element.startTime + companion.offsetSeconds;
@@ -84,6 +86,7 @@ function EffectCompanionAudioPlayer({
 				trackId={trackId}
 				playbackWindow={{ startTime, endTime: startTime + duration }}
 				element={audioElement}
+				timelineTime={timelineTime}
 			/>
 			<span
 				hidden
@@ -100,11 +103,13 @@ export function EffectCompanionAudioPlayers({
 	element,
 	trackId,
 	trackMuted = false,
+	timelineTime,
 }: {
 	companions: readonly ElementEffectAudioCompanion[];
 	element: TimelineElement;
 	trackId: string;
 	trackMuted?: boolean;
+	timelineTime?: number;
 }) {
 	return (
 		<>
@@ -115,6 +120,7 @@ export function EffectCompanionAudioPlayers({
 					element={element}
 					trackId={trackId}
 					trackMuted={trackMuted}
+					timelineTime={timelineTime}
 				/>
 			))}
 		</>

--- a/qcut/apps/web/src/components/editor/preview-panel.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel.tsx
@@ -103,6 +103,10 @@ import {
 } from "./preview-panel/jianying-text-playback-overlay";
 import type { BrowserColorGradeLayer } from "@/lib/color/browser-color-rendering";
 import { ensureTimelineLocalFontsLoaded } from "@/lib/fonts/local-font-runtime";
+import {
+	installPlaybackDiagnostics,
+	recordPreviewPanelRender,
+} from "@/lib/debug/playback-diagnostics";
 
 function getPreviewElementDuration(element: TimelineElement): number {
 	return element.type === "media"
@@ -112,6 +116,7 @@ function getPreviewElementDuration(element: TimelineElement): number {
 
 /** Main preview panel component for video playback, MCP apps, and element overlays. */
 export function PreviewPanel() {
+	recordPreviewPanelRender();
 	useAudioMixMonitor();
 	usePlaybackHealthPreviewQuality();
 	const {
@@ -178,6 +183,10 @@ export function PreviewPanel() {
 			}),
 		[tracks, activeProject?.fps]
 	);
+
+	useEffect(() => {
+		installPlaybackDiagnostics();
+	}, []);
 
 	useEffect(() => {
 		void ensureTimelineLocalFontsLoaded({ tracks }).catch((cause) => {

--- a/qcut/apps/web/src/components/editor/preview-panel.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel.tsx
@@ -260,18 +260,8 @@ export function PreviewPanel() {
 			fps: activeProject?.fps ?? 30,
 			zoomActive: zoomPreviewActive,
 			cursorOverlayActive: cursorOverlayPreviewActive,
-			previewQuality,
-			runtimePreviewQuality,
-			canvasWidth: canvasSize.width,
-			canvasHeight: canvasSize.height,
 			hasElementEffects: (elementId) =>
 				effectsRenderingByElementId.has(elementId),
-			getMediaInfo: (mediaId) => {
-				const item = mediaItems.find((candidate) => candidate.id === mediaId);
-				return item
-					? { type: item.type, width: item.width, height: item.height }
-					: undefined;
-			},
 			jianyingPrefetchWindows,
 		});
 	}, [
@@ -282,12 +272,7 @@ export function PreviewPanel() {
 		activeProject?.fps,
 		zoomPreviewActive,
 		cursorOverlayPreviewActive,
-		previewQuality,
-		runtimePreviewQuality,
-		canvasSize.width,
-		canvasSize.height,
 		effectsRenderingByElementId,
-		mediaItems,
 		jianyingPrefetchWindows,
 	]);
 	const smoothTime = useSmoothPlaybackTime({

--- a/qcut/apps/web/src/components/editor/preview-panel.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel.tsx
@@ -66,6 +66,14 @@ import { PreviewAgentView } from "./preview-panel/preview-agent-view";
 import { CursorOverlay } from "./preview-panel/cursor-overlay";
 import { RecordingBackground } from "./preview-panel/recording-background";
 import { useScreenRecordingPreview } from "./preview-panel/use-screen-recording-preview";
+import { useSmoothPlaybackTime } from "./preview-panel/use-smooth-playback-time";
+import {
+	findJianyingPrefetchWindowIndex,
+	PREVIEW_SMOOTH_TIME_NOT_NEEDED,
+	resolveJianyingTransitionPrefetchWindows,
+	resolvePreviewSmoothTimeNeed,
+} from "@/lib/preview/preview-smooth-time";
+import { useScreenRecordingEnhancementStore } from "@/stores/screen-recording-store";
 import { resolveActiveClipTransitionPreview } from "@/lib/transitions/clip-transition-preview";
 import { useAudioMixMonitor } from "@/lib/audio/use-audio-mix-monitor";
 import { resolveActiveAudioCrossfadePreview } from "@/lib/audio/audio-crossfade-preview";
@@ -151,6 +159,25 @@ export function PreviewPanel() {
 	// the set of active elements changes (not every frame).
 	const [playbackTime, setPlaybackTime] = useState(currentTime);
 	const lastActiveIdsRef = useRef<string>("");
+	const renderTracks = useMemo(
+		() => expandCompoundMediaTracks({ tracks }),
+		[tracks]
+	);
+	const effectsRenderingByElementId = useEffectsRendering(EFFECTS_ENABLED);
+	const zoomPreviewActive = useScreenRecordingEnhancementStore(
+		(state) => state.zoomRegions.length > 0
+	);
+	const cursorOverlayPreviewActive = useScreenRecordingEnhancementStore(
+		(state) => Boolean(state.showCursorOverlay && state.cursorTelemetry)
+	);
+	const jianyingPrefetchWindows = useMemo(
+		() =>
+			resolveJianyingTransitionPrefetchWindows({
+				tracks,
+				fps: activeProject?.fps ?? 30,
+			}),
+		[tracks, activeProject?.fps]
+	);
 
 	useEffect(() => {
 		void ensureTimelineLocalFontsLoaded({ tracks }).catch((cause) => {
@@ -194,6 +221,15 @@ export function PreviewPanel() {
 			for (const elementId of audioCrossfadePreview.forceActiveElementIds) {
 				activeIds += `audio-crossfade:${elementId},`;
 			}
+			// Entering a jianying prefetch window must trigger a render so the
+			// smooth-time gate (and proxy prefetch) re-evaluate in time.
+			const prefetchWindowIndex = findJianyingPrefetchWindowIndex({
+				windows: jianyingPrefetchWindows,
+				time,
+			});
+			if (prefetchWindowIndex >= 0) {
+				activeIds += `jyprefetch:${prefetchWindowIndex},`;
+			}
 			if (activeIds !== lastActiveIdsRef.current) {
 				lastActiveIdsRef.current = activeIds;
 				setPlaybackTime(time);
@@ -203,7 +239,62 @@ export function PreviewPanel() {
 		window.addEventListener("playback-update", handlePlaybackUpdate);
 		return () =>
 			window.removeEventListener("playback-update", handlePlaybackUpdate);
-	}, [activeProject?.fps, isPlaying, currentTime, tracks]);
+	}, [
+		activeProject?.fps,
+		isPlaying,
+		currentTime,
+		tracks,
+		jianyingPrefetchWindows,
+	]);
+
+	// Per-frame React re-renders during playback are opt-in: only content that
+	// visibly animates through React (keyframes, transitions, captions, zoom,
+	// chunked proxies, …) turns them on. Static clips play back with zero
+	// preview re-renders — video/audio elements sync via window events.
+	const smoothTimeNeed = useMemo(() => {
+		if (!isPlaying) return PREVIEW_SMOOTH_TIME_NOT_NEEDED;
+		return resolvePreviewSmoothTimeNeed({
+			tracks: renderTracks,
+			transitionTracks: tracks,
+			time: playbackTime,
+			fps: activeProject?.fps ?? 30,
+			zoomActive: zoomPreviewActive,
+			cursorOverlayActive: cursorOverlayPreviewActive,
+			previewQuality,
+			runtimePreviewQuality,
+			canvasWidth: canvasSize.width,
+			canvasHeight: canvasSize.height,
+			hasElementEffects: (elementId) =>
+				effectsRenderingByElementId.has(elementId),
+			getMediaInfo: (mediaId) => {
+				const item = mediaItems.find((candidate) => candidate.id === mediaId);
+				return item
+					? { type: item.type, width: item.width, height: item.height }
+					: undefined;
+			},
+			jianyingPrefetchWindows,
+		});
+	}, [
+		isPlaying,
+		renderTracks,
+		tracks,
+		playbackTime,
+		activeProject?.fps,
+		zoomPreviewActive,
+		cursorOverlayPreviewActive,
+		previewQuality,
+		runtimePreviewQuality,
+		canvasSize.width,
+		canvasSize.height,
+		effectsRenderingByElementId,
+		mediaItems,
+		jianyingPrefetchWindows,
+	]);
+	const smoothTime = useSmoothPlaybackTime({
+		isPlaying,
+		enabled: smoothTimeNeed.needsSmoothTime,
+		fallbackTime: isPlaying ? playbackTime : currentTime,
+	});
 	const previewScale = usePreviewViewStore((state) => state.previewScale);
 	const setPreviewScale = usePreviewViewStore((state) => state.setPreviewScale);
 	const showSafeAreas = usePreviewViewStore((state) => state.showSafeAreas);
@@ -246,7 +337,6 @@ export function PreviewPanel() {
 	});
 
 	const {
-		smoothTime,
 		zoomStyle,
 		cursorTelemetry,
 		cursorConfig,
@@ -255,6 +345,7 @@ export function PreviewPanel() {
 	} = useScreenRecordingPreview({
 		isPlaying,
 		currentTime,
+		smoothTime,
 		previewWidth: previewDimensions.width || canvasSize.width,
 		previewHeight: previewDimensions.height || canvasSize.height,
 	});
@@ -429,10 +520,6 @@ export function PreviewPanel() {
 		]
 	);
 	const hasAnyElements = tracks.some((track) => track.elements.length > 0);
-	const renderTracks = useMemo(
-		() => expandCompoundMediaTracks({ tracks }),
-		[tracks]
-	);
 	const jianyingTimelinePreview = useJianyingTimelineTransitionPreview({
 		tracks,
 		mediaItems,
@@ -625,8 +712,6 @@ export function PreviewPanel() {
 		mediaItems,
 		activeProject,
 	});
-
-	const effectsRenderingByElementId = useEffectsRendering(EFFECTS_ENABLED);
 
 	useEffect(() => {
 		const seekTime = lastSeekEventTimeRef.current;
@@ -1012,6 +1097,7 @@ export function PreviewPanel() {
 								ref={previewCaptureRef}
 								className="absolute inset-0 overflow-hidden"
 								data-testid="preview-capture-surface"
+								data-smooth-time-reason={smoothTimeNeed.reason ?? "none"}
 							>
 								{(() => {
 									const pw = previewDimensions.width || canvasSize.width;

--- a/qcut/apps/web/src/components/editor/preview-panel.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel.tsx
@@ -108,6 +108,10 @@ import {
 	recordPreviewPanelRender,
 } from "@/lib/debug/playback-diagnostics";
 
+/** Seconds ahead of the playhead at which upcoming media clips are mounted
+ * hidden, so their video is buffered and seeked before the cut. */
+const CLIP_PRELOAD_LOOKAHEAD_SECONDS = 2;
+
 function getPreviewElementDuration(element: TimelineElement): number {
 	return element.type === "media"
 		? getMediaTimelineDuration(element)
@@ -211,6 +215,14 @@ export function PreviewPanel() {
 					const end = el.startTime + getPreviewElementDuration(el);
 					if (time >= el.startTime && time < end) {
 						activeIds += el.id + ",";
+					} else if (
+						el.type === "media" &&
+						time >= el.startTime - CLIP_PRELOAD_LOOKAHEAD_SECONDS &&
+						time < el.startTime
+					) {
+						// Entering the preload window must trigger a render so the
+						// upcoming clip mounts (hidden) before the cut.
+						activeIds += `preload:${el.id},`;
 					}
 				}
 			}
@@ -544,13 +556,41 @@ export function PreviewPanel() {
 			});
 			const layers = [...plan.visualLayers, ...plan.audioElements];
 
-			return layers.map(({ element, track }) => {
+			const active: ActiveElement[] = layers.map(({ element, track }) => {
 				const mediaItem =
 					element.type === "media" && element.mediaId !== TEST_MEDIA_ID
 						? (mediaItems.find((item) => item.id === element.mediaId) ?? null)
 						: null;
 				return { element, track, mediaItem };
 			});
+
+			// While playing, mount upcoming media clips hidden so their video
+			// buffers and seeks before the cut — the boundary flip then paints
+			// a ready frame instead of a black loading gap.
+			if (isPlaying) {
+				const activeIds = new Set(active.map(({ element }) => element.id));
+				for (const track of renderTracks) {
+					if (track.hidden) continue;
+					for (const element of track.elements) {
+						if (
+							element.hidden ||
+							element.type !== "media" ||
+							element.mediaId === TEST_MEDIA_ID ||
+							activeIds.has(element.id) ||
+							effectiveTime >= element.startTime ||
+							element.startTime - effectiveTime > CLIP_PRELOAD_LOOKAHEAD_SECONDS
+						) {
+							continue;
+						}
+						const mediaItem =
+							mediaItems.find((item) => item.id === element.mediaId) ?? null;
+						if (!mediaItem) continue;
+						active.push({ element, track, mediaItem, preload: true });
+					}
+				}
+			}
+
+			return active;
 		} catch {
 			return [];
 		}
@@ -688,7 +728,8 @@ export function PreviewPanel() {
 				(candidate) =>
 					candidate.track.id === trackId && candidate.element.id === elementId
 			);
-			if (!active || active.element.type !== "media") return [];
+			if (!active || active.preload || active.element.type !== "media")
+				return [];
 			return [{ trackId, element: active.element }];
 		});
 	}, [activeElements, selectedElements]);
@@ -892,13 +933,18 @@ export function PreviewPanel() {
 			const effectRendering = effectsRenderingByElementId.get(
 				elementData.element.id
 			);
+			const isPreload = elementData.preload === true;
 			return (
 				<div
 					key={`${elementData.element.id}-${elementData.track.id}`}
-					className="contents"
+					className={isPreload ? undefined : "contents"}
+					style={isPreload ? { visibility: "hidden" } : undefined}
+					aria-hidden={isPreload || undefined}
 				>
 					<EffectCompanionAudioPlayers
-						companions={effectRendering?.audioCompanions ?? []}
+						companions={
+							isPreload ? [] : (effectRendering?.audioCompanions ?? [])
+						}
 						element={elementData.element}
 						trackId={elementData.track.id}
 						trackMuted={elementData.track.muted}

--- a/qcut/apps/web/src/components/editor/preview-panel.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel.tsx
@@ -207,9 +207,12 @@ export function PreviewPanel() {
 
 		const handlePlaybackUpdate = (e: Event) => {
 			const time = (e as CustomEvent).detail.time as number;
-			// Check if active elements changed by testing element boundaries
+			// Check if active elements changed by testing element boundaries.
+			// Scan the EXPANDED tracks (compound children included) so the
+			// boundary set matches what getActiveElements mounts and what the
+			// smooth-time gate evaluates.
 			let activeIds = "";
-			for (const track of tracks) {
+			for (const track of renderTracks) {
 				for (const el of track.elements) {
 					if (el.hidden) continue;
 					const end = el.startTime + getPreviewElementDuration(el);
@@ -265,6 +268,7 @@ export function PreviewPanel() {
 		isPlaying,
 		currentTime,
 		tracks,
+		renderTracks,
 		jianyingPrefetchWindows,
 	]);
 

--- a/qcut/apps/web/src/components/editor/preview-panel.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel.tsx
@@ -869,6 +869,7 @@ export function PreviewPanel() {
 				blurBackgroundElements={blurBackgroundElements}
 				blurBackgroundSource={blurBackgroundSource}
 				effectsRenderingByElementId={effectsRenderingByElementId}
+				timelineTime={isPlaying ? playbackTime : currentTime}
 			/>
 		),
 		[
@@ -876,6 +877,9 @@ export function PreviewPanel() {
 			blurBackgroundElements,
 			blurBackgroundSource,
 			effectsRenderingByElementId,
+			isPlaying,
+			playbackTime,
+			currentTime,
 		]
 	);
 
@@ -898,6 +902,7 @@ export function PreviewPanel() {
 						element={elementData.element}
 						trackId={elementData.track.id}
 						trackMuted={elementData.track.muted}
+						timelineTime={isPlaying ? smoothTime : currentTime}
 					/>
 					<PreviewElementRenderer
 						elementData={elementData}

--- a/qcut/apps/web/src/components/editor/preview-panel/preview-element-renderer.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel/preview-element-renderer.tsx
@@ -144,6 +144,7 @@ interface PreviewBlurBackgroundProps {
 	blurBackgroundElements: ActiveElement[];
 	blurBackgroundSource: VideoSource;
 	effectsRenderingByElementId: ReadonlyMap<string, ElementEffectsRendering>;
+	timelineTime?: number;
 }
 
 /** Renders a blurred background video layer behind the main preview content. */
@@ -152,6 +153,7 @@ export function PreviewBlurBackground({
 	blurBackgroundElements,
 	blurBackgroundSource,
 	effectsRenderingByElementId,
+	timelineTime,
 }: PreviewBlurBackgroundProps): React.ReactNode {
 	try {
 		if (activeProject?.backgroundType !== "blur") {
@@ -201,6 +203,7 @@ export function PreviewBlurBackground({
 						videoId={`${mediaItem.id}-blur-background`}
 						videoSource={blurBackgroundSource}
 						poster={mediaItem.thumbnailUrl}
+						timelineTime={timelineTime}
 						clipStartTime={element.startTime}
 						trimStart={element.trimStart}
 						trimEnd={element.trimEnd}
@@ -347,6 +350,7 @@ export function PreviewElementRenderer({
 		enhancements: previewEnhancements,
 		forceProxy: previewQualityOption.forceProxy,
 		maxDimension: previewQualityOption.maxDimension ?? 960,
+		prefetchWindow: proxyWindow.prefetch,
 	});
 	const nativeEnhancementPreview = useNativeVideoEnhancementPreview({
 		enabled:
@@ -372,10 +376,10 @@ export function PreviewElementRenderer({
 	});
 	const enhancementProxyVideoSource = useMemo<VideoSource>(
 		() =>
-			enhancementProxy.status === "ready" && enhancementProxy.url
+			enhancementProxy.url
 				? { type: "remote", src: enhancementProxy.url }
 				: null,
-		[enhancementProxy.status, enhancementProxy.url]
+		[enhancementProxy.url]
 	);
 	try {
 		const { element, mediaItem } = elementData;
@@ -782,6 +786,7 @@ export function PreviewElementRenderer({
 									previewGain={previewAudioGain}
 									playbackWindow={audioPlaybackWindow}
 									element={previewDerivedElement}
+									timelineTime={currentTime}
 								/>,
 							];
 						})
@@ -805,8 +810,10 @@ export function PreviewElementRenderer({
 					dragState.isDragging && dragState.elementId === element.id;
 				const visual = previewMediaVisual;
 				if (!visual) return null;
-				const proxyReady =
-					enhancementProxy.status === "ready" && Boolean(enhancementProxy.url);
+				// A url during "generating" is the previous chunk kept alive
+				// through its overlap — keep playing it instead of flapping
+				// back to the original source at every boundary.
+				const proxyReady = Boolean(enhancementProxy.url);
 				const previewSource = resolvePreviewVideoSource({
 					source,
 					proxySource: enhancementProxyVideoSource,
@@ -1009,6 +1016,7 @@ export function PreviewElementRenderer({
 								playbackWindow={audioPlaybackWindow}
 								videoId={sourceVideoId}
 								sourceTimeOffset={previewSource.sourceTimeOffset}
+								timelineTime={currentTime}
 								style={{
 									objectFit: visual.fitMode,
 									filter: combinedFilter || undefined,
@@ -1142,6 +1150,7 @@ export function PreviewElementRenderer({
 									previewGain={previewAudioGain}
 									playbackWindow={audioPlaybackWindow}
 									videoId={`${mediaItem.id}-mask-audio`}
+									timelineTime={currentTime}
 									className="pointer-events-none absolute inset-0 opacity-0"
 								/>
 							) : null}
@@ -1506,6 +1515,7 @@ export function PreviewElementRenderer({
 						) : (
 							<AudioPlayer
 								src={mediaItem.url || mediaItem.originalUrl || ""}
+								timelineTime={currentTime}
 								clipStartTime={previewAudioElement.startTime}
 								trimStart={previewAudioElement.trimStart}
 								trimEnd={previewAudioElement.trimEnd}

--- a/qcut/apps/web/src/components/editor/preview-panel/preview-element-renderer.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel/preview-element-renderer.tsx
@@ -74,8 +74,8 @@ import { TimelineStickerLayer } from "./timeline-sticker-layer";
 import type { AudioCrossfadePreviewState } from "@/lib/audio/audio-crossfade-preview";
 import { useNativeVideoEnhancementPreview } from "@/hooks/preview/use-native-video-enhancement-preview";
 import {
-	getVideoEnhancementProxyWindow,
 	useVideoEnhancementProxy,
+	useVideoEnhancementProxyWindow,
 } from "@/hooks/preview/use-video-enhancement-proxy";
 import { LoaderCircle, TriangleAlert } from "lucide-react";
 import {
@@ -326,13 +326,11 @@ export function PreviewElementRenderer({
 	const renderCompositePreviewEffects = previewEffectRenderMode !== "minimal";
 	const renderHighCostPreviewEffects = previewEffectRenderMode === "full";
 	const renderDecorativePreviewEffects = previewEffectRenderMode !== "minimal";
-	const proxyWindow =
-		elementData.element.type === "media"
-			? getVideoEnhancementProxyWindow({
-					element: elementData.element,
-					currentTime,
-				})
-			: { sourceStart: 0, sourceDuration: 0 };
+	const proxyWindow = useVideoEnhancementProxyWindow({
+		element: elementData.element.type === "media" ? elementData.element : null,
+		currentTime,
+		isPlaying,
+	});
 	const enhancementProxy = useVideoEnhancementProxy({
 		enabled:
 			elementData.element.type === "media" &&

--- a/qcut/apps/web/src/components/editor/preview-panel/types.ts
+++ b/qcut/apps/web/src/components/editor/preview-panel/types.ts
@@ -5,6 +5,12 @@ export interface ActiveElement {
 	element: TimelineElement;
 	track: TimelineTrack;
 	mediaItem: MediaItem | null;
+	/**
+	 * Mounted ahead of the playhead (hidden) so its media is buffered and
+	 * seeked before the cut — the boundary flip then shows a ready frame
+	 * instead of a black loading gap. Excluded from "current element" logic.
+	 */
+	preload?: boolean;
 }
 
 export interface PreviewDimensions {

--- a/qcut/apps/web/src/components/editor/preview-panel/use-preview-media.ts
+++ b/qcut/apps/web/src/components/editor/preview-panel/use-preview-media.ts
@@ -38,6 +38,7 @@ export function usePreviewMedia({
 		try {
 			for (let index = activeElements.length - 1; index >= 0; index--) {
 				const item = activeElements[index];
+				if (item.preload) continue;
 				if (item.element.type === "media" && item.mediaItem?.type === "video") {
 					return item;
 				}
@@ -106,8 +107,8 @@ export function usePreviewMedia({
 
 	const blurBackgroundElements = useMemo(() => {
 		try {
-			return activeElements.filter(({ element, mediaItem }) => {
-				if (element.type !== "media" || !mediaItem) {
+			return activeElements.filter(({ element, mediaItem, preload }) => {
+				if (preload || element.type !== "media" || !mediaItem) {
 					return false;
 				}
 

--- a/qcut/apps/web/src/components/editor/preview-panel/use-screen-recording-preview.ts
+++ b/qcut/apps/web/src/components/editor/preview-panel/use-screen-recording-preview.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useScreenRecordingEnhancementStore } from "@/stores/screen-recording-store";
 import { computeZoomTransform } from "@/lib/screen-recording/zoom-transform";
 import type { ZoomTransform } from "@/lib/screen-recording/zoom-transform";
@@ -10,13 +10,13 @@ import type { BackgroundConfig } from "@/lib/screen-recording/wallpapers";
 interface ScreenRecordingPreviewParams {
 	isPlaying: boolean;
 	currentTime: number;
+	/** Continuous playback time from useSmoothPlaybackTime (gated per-frame). */
+	smoothTime: number;
 	previewWidth: number;
 	previewHeight: number;
 }
 
 interface ScreenRecordingPreviewResult {
-	/** Continuous time (seconds) that updates every frame during playback. */
-	smoothTime: number;
 	/** Current zoom transform, or null when no zoom is active. */
 	zoomTransform: ZoomTransform | null;
 	/** CSS style to apply zoom, or undefined when identity. */
@@ -29,12 +29,14 @@ interface ScreenRecordingPreviewResult {
 }
 
 /**
- * Encapsulates screen-recording preview state: smooth playback time,
- * zoom transform computation, and store selectors.
+ * Encapsulates screen-recording preview state: zoom transform computation
+ * and store selectors. Smooth playback time is supplied by the caller
+ * (useSmoothPlaybackTime) so per-frame updates stay gated in one place.
  */
 export function useScreenRecordingPreview({
 	isPlaying,
 	currentTime,
+	smoothTime,
 	previewWidth,
 	previewHeight,
 }: ScreenRecordingPreviewParams): ScreenRecordingPreviewResult {
@@ -51,22 +53,6 @@ export function useScreenRecordingPreview({
 		(s) => s.background
 	);
 	const zoomRegions = useScreenRecordingEnhancementStore((s) => s.zoomRegions);
-
-	// Continuous time for smooth zoom/cursor animation during playback.
-	// The main playbackTime only updates on element boundary crossings,
-	// so we listen to every playback-update event for per-frame fidelity.
-	const [smoothTime, setSmoothTime] = useState(currentTime);
-	useEffect(() => {
-		if (!isPlaying) {
-			setSmoothTime(currentTime);
-			return;
-		}
-		const handleUpdate = (e: Event) => {
-			setSmoothTime((e as CustomEvent).detail.time as number);
-		};
-		window.addEventListener("playback-update", handleUpdate);
-		return () => window.removeEventListener("playback-update", handleUpdate);
-	}, [isPlaying, currentTime]);
 
 	// Compute zoom transform using preview dimensions (not canvas dimensions)
 	// so translation values match the CSS-sized preview container.
@@ -97,7 +83,6 @@ export function useScreenRecordingPreview({
 			: undefined;
 
 	return {
-		smoothTime,
 		zoomTransform,
 		zoomStyle,
 		cursorTelemetry,

--- a/qcut/apps/web/src/components/editor/preview-panel/use-smooth-playback-time.ts
+++ b/qcut/apps/web/src/components/editor/preview-panel/use-smooth-playback-time.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Continuous playback time (seconds) sourced from per-frame
+ * "playback-update" events.
+ *
+ * The subscription is gated: when `enabled` is false nothing on the canvas
+ * needs per-frame React updates, so no listener is attached and the hook
+ * returns `fallbackTime` — playback then runs without re-rendering the
+ * preview tree every animation frame (video/audio elements keep syncing via
+ * window events, see playback-store).
+ *
+ * `fallbackTime` should be the coarse playback time (boundary-crossing
+ * `playbackTime` while playing, store `currentTime` otherwise) so consumers
+ * stay consistent across enable/disable flips.
+ */
+export function useSmoothPlaybackTime({
+	isPlaying,
+	enabled,
+	fallbackTime,
+}: {
+	isPlaying: boolean;
+	enabled: boolean;
+	fallbackTime: number;
+}): number {
+	const [smoothTime, setSmoothTime] = useState(fallbackTime);
+	const active = isPlaying && enabled;
+
+	useEffect(() => {
+		if (!active) {
+			setSmoothTime(fallbackTime);
+			return;
+		}
+		// On enable flips mid-playback the stored time may predate the render
+		// that enabled us; never move backwards past the fresh fallback.
+		setSmoothTime((previous) =>
+			fallbackTime > previous ? fallbackTime : previous
+		);
+		const handleUpdate = (event: Event) => {
+			setSmoothTime((event as CustomEvent).detail.time as number);
+		};
+		window.addEventListener("playback-update", handleUpdate);
+		return () => window.removeEventListener("playback-update", handleUpdate);
+	}, [active, fallbackTime]);
+
+	return active ? smoothTime : fallbackTime;
+}

--- a/qcut/apps/web/src/components/ui/audio-player.tsx
+++ b/qcut/apps/web/src/components/ui/audio-player.tsx
@@ -104,9 +104,17 @@ export function AudioPlayer({
 		const audio = audioRef.current;
 		if (!audio) return;
 
+		// The store's currentTime freezes during playback, so track the latest
+		// event time for handlers (speed changes) that need a fresh position.
+		let latestTimelineTime = usePlaybackStore.getState().currentTime;
+		// A rejected play() leaves `paused` true; without a backoff every
+		// playback-update would spawn another rejected promise.
+		let resumeBlockedUntil = 0;
+
 		const handleSeekEvent = (e: CustomEvent) => {
+			latestTimelineTime = e.detail.time as number;
 			syncAudioTiming({
-				timelineTime: e.detail.time,
+				timelineTime: latestTimelineTime,
 				playbackSpeed: usePlaybackStore.getState().speed,
 				forcePosition: true,
 			});
@@ -114,6 +122,7 @@ export function AudioPlayer({
 
 		const handleUpdateEvent = (e: CustomEvent) => {
 			const time = e.detail.time as number;
+			latestTimelineTime = time;
 			syncAudioTiming({
 				timelineTime: time,
 				playbackSpeed: usePlaybackStore.getState().speed,
@@ -127,15 +136,18 @@ export function AudioPlayer({
 				!trackMuted &&
 				time >= clipRangeStart &&
 				time < clipEndTime &&
+				performance.now() >= resumeBlockedUntil &&
 				usePlaybackStore.getState().isPlaying
 			) {
-				audio.play().catch(() => {});
+				audio.play().catch(() => {
+					resumeBlockedUntil = performance.now() + 1000;
+				});
 			}
 		};
 
 		const handleSpeed = (e: CustomEvent) => {
 			syncAudioTiming({
-				timelineTime: usePlaybackStore.getState().currentTime,
+				timelineTime: latestTimelineTime,
 				playbackSpeed: e.detail.speed,
 				forcePosition: false,
 			});

--- a/qcut/apps/web/src/components/ui/audio-player.tsx
+++ b/qcut/apps/web/src/components/ui/audio-player.tsx
@@ -21,6 +21,13 @@ interface AudioPlayerProps {
 	previewGain?: number;
 	playbackWindow?: { startTime: number; endTime: number };
 	element: MediaElement;
+	/**
+	 * Fresh timeline time from the preview panel. The playback store's
+	 * currentTime freezes during playback, so a player mounted mid-playback
+	 * (every clip after a cut) would otherwise judge itself out of range and
+	 * stay paused.
+	 */
+	timelineTime?: number;
 }
 
 export function AudioPlayer({
@@ -31,9 +38,11 @@ export function AudioPlayer({
 	previewGain = 1,
 	playbackWindow,
 	element,
+	timelineTime,
 }: AudioPlayerProps) {
 	const audioRef = useRef<HTMLAudioElement>(null);
 	const { isPlaying, currentTime, speed } = usePlaybackStore();
+	const effectiveTimelineTime = timelineTime ?? currentTime;
 	const fps = useProjectStore((state) => state.activeProject?.fps ?? 30);
 	const reversed = useReversedAudioUrl({
 		source: src,
@@ -55,7 +64,8 @@ export function AudioPlayer({
 	const clipEndTime =
 		playbackWindow?.endTime ?? element.startTime + timelineDuration;
 	const isInClipRange =
-		currentTime >= clipRangeStart && currentTime < clipEndTime;
+		effectiveTimelineTime >= clipRangeStart &&
+		effectiveTimelineTime < clipEndTime;
 	const syncAudioTiming = useCallback(
 		({
 			timelineTime,
@@ -103,11 +113,24 @@ export function AudioPlayer({
 		};
 
 		const handleUpdateEvent = (e: CustomEvent) => {
+			const time = e.detail.time as number;
 			syncAudioTiming({
-				timelineTime: e.detail.time,
+				timelineTime: time,
 				playbackSpeed: usePlaybackStore.getState().speed,
 				forcePosition: false,
 			});
+			// Self-heal: resume an element that should be audible but sits
+			// paused (mounted mid-playback, or an src reload reset it).
+			if (
+				audio.paused &&
+				!audio.ended &&
+				!trackMuted &&
+				time >= clipRangeStart &&
+				time < clipEndTime &&
+				usePlaybackStore.getState().isPlaying
+			) {
+				audio.play().catch(() => {});
+			}
 		};
 
 		const handleSpeed = (e: CustomEvent) => {
@@ -139,11 +162,16 @@ export function AudioPlayer({
 				handleSpeed as EventListener
 			);
 		};
-	}, [syncAudioTiming]);
+	}, [syncAudioTiming, clipRangeStart, clipEndTime, trackMuted]);
 
+	// Force-sync position on mount and on real seeks/pauses (store time),
+	// but seed with the fresh panel time so a player mounted mid-playback
+	// starts at the playhead instead of the store's frozen value. Boundary
+	// crossings alone must NOT force-seek a continuously playing element.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: effectiveTimelineTime is intentionally read without being a trigger
 	useEffect(() => {
 		syncAudioTiming({
-			timelineTime: currentTime,
+			timelineTime: effectiveTimelineTime,
 			playbackSpeed: speed,
 			forcePosition: true,
 		});
@@ -192,7 +220,7 @@ export function AudioPlayer({
 			data-audio-reverse-error={reversed.error}
 			onLoadedMetadata={() =>
 				syncAudioTiming({
-					timelineTime: usePlaybackStore.getState().currentTime,
+					timelineTime: effectiveTimelineTime,
 					playbackSpeed: usePlaybackStore.getState().speed,
 					forcePosition: true,
 				})

--- a/qcut/apps/web/src/components/ui/video-player.tsx
+++ b/qcut/apps/web/src/components/ui/video-player.tsx
@@ -264,6 +264,7 @@ export function VideoPlayer({
 		const handleUpdateEvent = (e: CustomEvent) => {
 			// Always update video time, even if outside clip range
 			const timelineTime = e.detail.time;
+			timelineTimeRef.current = timelineTime;
 			const targetTime = getVideoTime(timelineTime);
 
 			if (
@@ -271,6 +272,23 @@ export function VideoPlayer({
 				Math.abs(video.currentTime - targetTime) > 0.5
 			) {
 				video.currentTime = targetTime;
+			}
+
+			// Self-heal: a proxy-chunk reload or a rejected play() leaves the
+			// element paused while the master clock keeps running; without this
+			// the drift corrector above degrades playback into a 2fps slideshow.
+			if (
+				!requiresManualTiming &&
+				video.paused &&
+				video.readyState >= 2 &&
+				usePlaybackStore.getState().isPlaying
+			) {
+				video.play().catch((cause) => {
+					console.warn(
+						`[VideoPlayer] resume play() failed for ${videoId ?? "video"}:`,
+						cause
+					);
+				});
 			}
 		};
 
@@ -303,15 +321,24 @@ export function VideoPlayer({
 				handleSpeed as EventListener
 			);
 		};
-	}, [isInClipRange, requiresManualTiming, getVideoTime, syncVideoTiming]);
+	}, [
+		isInClipRange,
+		requiresManualTiming,
+		getVideoTime,
+		syncVideoTiming,
+		videoId,
+	]);
 
 	// Sync playback state with readyState check
 	useEffect(() => {
 		const video = videoRef.current;
 		if (!video) return;
 
-		const handlePlayError = (_err: any) => {
-			// Silently handle play errors
+		const handlePlayError = (cause: unknown) => {
+			console.warn(
+				`[VideoPlayer] play() failed for ${videoId ?? "video"}:`,
+				cause
+			);
 		};
 
 		const tryPlay = () => {
@@ -346,7 +373,7 @@ export function VideoPlayer({
 		return () => {
 			window.removeEventListener("playback-play", handleDirectPlay);
 		};
-	}, [isPlaying, isInClipRange, requiresManualTiming]);
+	}, [isPlaying, isInClipRange, requiresManualTiming, videoId]);
 
 	// Sync global playback speed with clip-local timing.
 	useEffect(() => {

--- a/qcut/apps/web/src/components/ui/video-player.tsx
+++ b/qcut/apps/web/src/components/ui/video-player.tsx
@@ -272,6 +272,11 @@ export function VideoPlayer({
 			return;
 		}
 
+		// A rejected play() leaves `paused` true; without a backoff every
+		// playback-update would spawn another rejected promise plus a warning
+		// at the animation frame rate.
+		let resumeBlockedUntil = 0;
+
 		const handleSeekEvent = (e: CustomEvent) => {
 			// Always update video time, even if outside clip range
 			const timelineTime = e.detail.time;
@@ -333,9 +338,11 @@ export function VideoPlayer({
 				video.paused &&
 				!video.ended &&
 				video.readyState >= 2 &&
+				performance.now() >= resumeBlockedUntil &&
 				usePlaybackStore.getState().isPlaying
 			) {
 				video.play().catch((cause) => {
+					resumeBlockedUntil = performance.now() + 1000;
 					console.warn(
 						`[VideoPlayer] resume play() failed for ${videoId ?? "video"}:`,
 						cause
@@ -450,6 +457,7 @@ export function VideoPlayer({
 	}, []);
 
 	// Video source tracking with cached blob URLs and ref-counted cleanup
+	// biome-ignore lint/correctness/useExhaustiveDependencies: protocolSourceEpoch intentionally re-runs this effect after a local-media stream failure
 	useEffect(() => {
 		const video = videoRef.current;
 		if (!video || !videoSource) return;

--- a/qcut/apps/web/src/components/ui/video-player.tsx
+++ b/qcut/apps/web/src/components/ui/video-player.tsx
@@ -42,6 +42,13 @@ interface VideoPlayerProps {
 	trackMuted?: boolean;
 	previewGain?: number;
 	sourceTimeOffset?: number;
+	/**
+	 * Fresh timeline time from the preview panel (boundary-crossing
+	 * playbackTime / smoothTime). The playback store's currentTime freezes
+	 * during playback, so a player mounted mid-playback (every clip after a
+	 * cut) would otherwise judge itself out of range and pause forever.
+	 */
+	timelineTime?: number;
 }
 
 function getVideoPlaybackRate({
@@ -89,6 +96,7 @@ export function VideoPlayer({
 	trackMuted = false,
 	previewGain = 1,
 	sourceTimeOffset = 0,
+	timelineTime,
 }: VideoPlayerProps) {
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const blobUrlRef = useRef<string | null>(null);
@@ -99,11 +107,12 @@ export function VideoPlayer({
 	const lastPresentedFrameCallbackAtRef = useRef<number | null>(null);
 	const MAX_RECOVERY_ATTEMPTS = 2;
 	const { isPlaying, currentTime, speed } = usePlaybackStore();
-	const timelineTimeRef = useRef(currentTime);
+	const effectiveTimelineTime = timelineTime ?? currentTime;
+	const timelineTimeRef = useRef(effectiveTimelineTime);
 
 	useEffect(() => {
-		timelineTimeRef.current = currentTime;
-	}, [currentTime]);
+		timelineTimeRef.current = effectiveTimelineTime;
+	}, [effectiveTimelineTime]);
 
 	const timelineDuration = timingElement
 		? getMediaTimelineDuration(timingElement)
@@ -112,7 +121,8 @@ export function VideoPlayer({
 	const clipEndTime =
 		playbackWindow?.endTime ?? clipStartTime + timelineDuration;
 	const isInClipRange =
-		currentTime >= clipRangeStart && currentTime < clipEndTime;
+		effectiveTimelineTime >= clipRangeStart &&
+		effectiveTimelineTime < clipEndTime;
 	const shouldReportPlaybackHealth = isPlaying && isInClipRange;
 	useEffect(() => {
 		if (!shouldReportPlaybackHealth) {
@@ -233,11 +243,11 @@ export function VideoPlayer({
 		if (!video || !isInClipRange) return;
 		syncVideoTiming({
 			video,
-			timelineTime: currentTime,
+			timelineTime: effectiveTimelineTime,
 			syncPosition: !isPlaying || requiresManualTiming,
 		});
 	}, [
-		currentTime,
+		effectiveTimelineTime,
 		isInClipRange,
 		isPlaying,
 		requiresManualTiming,
@@ -277,9 +287,11 @@ export function VideoPlayer({
 			// Self-heal: a proxy-chunk reload or a rejected play() leaves the
 			// element paused while the master clock keeps running; without this
 			// the drift corrector above degrades playback into a 2fps slideshow.
+			// Never resume an ended element — play() would restart it from 0.
 			if (
 				!requiresManualTiming &&
 				video.paused &&
+				!video.ended &&
 				video.readyState >= 2 &&
 				usePlaybackStore.getState().isPlaying
 			) {
@@ -379,8 +391,8 @@ export function VideoPlayer({
 	useEffect(() => {
 		const video = videoRef.current;
 		if (!video) return;
-		syncVideoTiming({ video, timelineTime: currentTime });
-	}, [currentTime, syncVideoTiming]);
+		syncVideoTiming({ video, timelineTime: effectiveTimelineTime });
+	}, [effectiveTimelineTime, syncVideoTiming]);
 
 	// Check video element dimensions on mount
 	useEffect(() => {

--- a/qcut/apps/web/src/components/ui/video-player.tsx
+++ b/qcut/apps/web/src/components/ui/video-player.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useEffect, useCallback, useState } from "react";
 import type { CSSProperties } from "react";
 import { usePlaybackStore } from "@/stores/editor/playback-store";
 import type { VideoSource } from "@/lib/media/media-source";
@@ -76,6 +76,10 @@ function getVideoPlaybackRate({
 	);
 }
 
+/** Seek-driven playback (reverse / freeze) quantises to this grid, capping
+ * decoder seeks per second regardless of the display refresh rate. */
+const MANUAL_SEEK_GRID_FPS = 30;
+
 export function VideoPlayer({
 	videoId,
 	videoSource,
@@ -103,6 +107,8 @@ export function VideoPlayer({
 	const pendingCleanupRef = useRef<string | null>(null);
 	const videoLoadedRef = useRef(false);
 	const recoveryAttemptRef = useRef(0);
+	const failedProtocolSrcRef = useRef<Set<string>>(new Set());
+	const [protocolSourceEpoch, setProtocolSourceEpoch] = useState(0);
 	const presentedFramesRef = useRef(0);
 	const lastPresentedFrameCallbackAtRef = useRef<number | null>(null);
 	const MAX_RECOVERY_ATTEMPTS = 2;
@@ -141,12 +147,16 @@ export function VideoPlayer({
 		fallbackFadeIn: fadeIn,
 		fallbackFadeOut: fadeOut,
 	});
+	// Reverse and freeze frames cannot be expressed by a playing element, so
+	// they stay seek-driven (deduped on a frame grid). Speed keyframes alone
+	// let the element PLAY with a per-tick playbackRate plus a tight drift
+	// corrector — far smoother than a seek per animation frame.
 	const requiresManualTiming = Boolean(
 		timingElement &&
-			(timingElement.reverse ||
-				(timingElement.freezeFrameDuration ?? 0) > 0 ||
-				(timingElement.speedKeyframes?.length ?? 0) > 0)
+			(timingElement.reverse || (timingElement.freezeFrameDuration ?? 0) > 0)
 	);
+	const hasKeyframedSpeed =
+		!requiresManualTiming && (timingElement?.speedKeyframes?.length ?? 0) > 0;
 	const getVideoTime = useCallback(
 		(timelineTime: number) => {
 			if (!timingElement) {
@@ -277,10 +287,41 @@ export function VideoPlayer({
 			timelineTimeRef.current = timelineTime;
 			const targetTime = getVideoTime(timelineTime);
 
-			if (
-				requiresManualTiming ||
-				Math.abs(video.currentTime - targetTime) > 0.5
-			) {
+			if (requiresManualTiming) {
+				// Quantise seek-driven playback to a frame grid: a freeze holds
+				// with zero further seeks and reverse seeks at most once per
+				// grid step instead of every animation frame. Comparing against
+				// the element's actual position (not a remembered target) keeps
+				// this self-correcting after out-of-band writes like a source
+				// reload or a mount sync.
+				const quantized =
+					Math.round(targetTime * MANUAL_SEEK_GRID_FPS) / MANUAL_SEEK_GRID_FPS;
+				if (
+					Math.abs(video.currentTime - quantized) >
+					0.5 / MANUAL_SEEK_GRID_FPS
+				) {
+					video.currentTime = quantized;
+				}
+				return;
+			}
+
+			if (hasKeyframedSpeed) {
+				const rate = getVideoPlaybackRate({
+					timingElement,
+					clipPlaybackRate,
+					clipStartTime,
+					timelineTime,
+					playbackSpeed: usePlaybackStore.getState().speed,
+				});
+				if (Math.abs(video.playbackRate - rate) > 0.001) {
+					video.playbackRate = rate;
+				}
+			}
+
+			// Rate discretisation drifts faster on speed ramps, so correct them
+			// on a tighter leash than plain playback.
+			const driftLimit = hasKeyframedSpeed ? 0.15 : 0.5;
+			if (Math.abs(video.currentTime - targetTime) > driftLimit) {
 				video.currentTime = targetTime;
 			}
 
@@ -289,7 +330,6 @@ export function VideoPlayer({
 			// the drift corrector above degrades playback into a 2fps slideshow.
 			// Never resume an ended element — play() would restart it from 0.
 			if (
-				!requiresManualTiming &&
 				video.paused &&
 				!video.ended &&
 				video.readyState >= 2 &&
@@ -336,6 +376,10 @@ export function VideoPlayer({
 	}, [
 		isInClipRange,
 		requiresManualTiming,
+		hasKeyframedSpeed,
+		clipPlaybackRate,
+		clipStartTime,
+		timingElement,
 		getVideoTime,
 		syncVideoTiming,
 		videoId,
@@ -353,15 +397,15 @@ export function VideoPlayer({
 			);
 		};
 
+		const handleCanPlay = () => {
+			if (usePlaybackStore.getState().isPlaying) {
+				video.play().catch(handlePlayError);
+			}
+		};
 		const tryPlay = () => {
 			if (video.readyState >= 3) {
 				video.play().catch(handlePlayError);
 			} else {
-				const handleCanPlay = () => {
-					if (usePlaybackStore.getState().isPlaying) {
-						video.play().catch(handlePlayError);
-					}
-				};
 				video.addEventListener("canplay", handleCanPlay, { once: true });
 			}
 		};
@@ -384,6 +428,9 @@ export function VideoPlayer({
 
 		return () => {
 			window.removeEventListener("playback-play", handleDirectPlay);
+			// Drop any pending canplay trigger so a later manual-timing or
+			// out-of-range state cannot be started by a stale listener.
+			video.removeEventListener("canplay", handleCanPlay);
 		};
 	}, [isPlaying, isInClipRange, requiresManualTiming, videoId]);
 
@@ -415,6 +462,25 @@ export function VideoPlayer({
 		video.removeAttribute("data-qcut-presented-at");
 
 		if (videoSource.type === "file") {
+			// Prefer the disk-streaming protocol source: the element then reads
+			// via Range requests instead of the in-memory File blob. Errors mark
+			// the URL failed and re-run this effect onto the blob path.
+			const protocolSrc = videoSource.protocolSrc;
+			if (protocolSrc && !failedProtocolSrcRef.current.has(protocolSrc)) {
+				video.src = protocolSrc;
+				if (pendingCleanupRef.current) {
+					releaseObjectURL(
+						pendingCleanupRef.current,
+						"VideoPlayer-protocol-switch"
+					);
+					pendingCleanupRef.current = null;
+				}
+				blobUrlRef.current = null;
+				return () => {
+					if (video) video.src = "";
+				};
+			}
+
 			// Release reference to previous blob URL (if any)
 			const previousBlobUrl = pendingCleanupRef.current;
 
@@ -464,7 +530,7 @@ export function VideoPlayer({
 				video.src = "";
 			}
 		};
-	}, [videoSource, videoId]);
+	}, [videoSource, videoId, protocolSourceEpoch]);
 
 	useEffect(() => {
 		const video = videoRef.current;
@@ -580,6 +646,22 @@ export function VideoPlayer({
 						readyState: video.readyState,
 					}
 				);
+
+				// A failed local-media protocol source (e.g. the extracted temp
+				// file was cleaned up) falls back to the in-memory blob path.
+				if (
+					videoSource?.type === "file" &&
+					videoSource.protocolSrc &&
+					video.currentSrc?.startsWith("app://local-media/") &&
+					!failedProtocolSrcRef.current.has(videoSource.protocolSrc)
+				) {
+					console.warn(
+						`[VideoPlayer] Local-media stream failed for ${videoId ?? "video"}; falling back to blob URL`
+					);
+					failedProtocolSrcRef.current.add(videoSource.protocolSrc);
+					setProtocolSourceEpoch((epoch) => epoch + 1);
+					return;
+				}
 
 				// Handle ERR_UPLOAD_FILE_CHANGED by creating fresh blob URL
 				// This error occurs when the File backing a blob URL is invalidated

--- a/qcut/apps/web/src/hooks/preview/__tests__/use-playback-health-preview-quality.test.tsx
+++ b/qcut/apps/web/src/hooks/preview/__tests__/use-playback-health-preview-quality.test.tsx
@@ -1,5 +1,5 @@
 import { act, render } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QCUT_VIDEO_FRAME_EVENT } from "@/lib/preview/preview-health-events";
 import { usePlaybackStore } from "@/stores/editor/playback-store";
 import { usePlaybackHealthPreviewQuality } from "../use-playback-health-preview-quality";
@@ -31,7 +31,11 @@ function presentStalledFrames({
 }
 
 describe("usePlaybackHealthPreviewQuality", () => {
+	let nowValue = 0;
+
 	beforeEach(() => {
+		nowValue = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => nowValue);
 		usePlaybackStore.setState({
 			isPlaying: true,
 			previewQuality: "auto",
@@ -40,8 +44,14 @@ describe("usePlaybackHealthPreviewQuality", () => {
 		});
 	});
 
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("ignores inactive video frames when adapting preview quality", () => {
 		render(<PlaybackHealthHarness />);
+		// Skip past the playback-start warmup window.
+		nowValue = 5000;
 
 		act(() => presentStalledFrames({ isActivePlaybackFrame: false }));
 		expect(usePlaybackStore.getState().runtimePreviewQuality).toBeNull();

--- a/qcut/apps/web/src/hooks/preview/__tests__/use-video-enhancement-proxy-window.test.tsx
+++ b/qcut/apps/web/src/hooks/preview/__tests__/use-video-enhancement-proxy-window.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { MediaElement } from "@/types/timeline";
+import { useVideoEnhancementProxyWindow } from "../use-video-enhancement-proxy";
+
+function makeMediaElement(overrides: Partial<MediaElement> = {}): MediaElement {
+	return {
+		id: "media-1",
+		name: "clip",
+		type: "media",
+		mediaId: "item-1",
+		startTime: 0,
+		duration: 60,
+		trimStart: 0,
+		trimEnd: 0,
+		...overrides,
+	};
+}
+
+function dispatchPlaybackUpdate(time: number): void {
+	window.dispatchEvent(
+		new CustomEvent("playback-update", { detail: { time } })
+	);
+}
+
+describe("useVideoEnhancementProxyWindow", () => {
+	it("returns an empty window without an element", () => {
+		const { result } = renderHook(() =>
+			useVideoEnhancementProxyWindow({
+				element: null,
+				currentTime: 5,
+				isPlaying: false,
+			})
+		);
+		expect(result.current).toEqual({ sourceStart: 0, sourceDuration: 0 });
+	});
+
+	it("derives the window from the rendered time while paused", () => {
+		const element = makeMediaElement();
+		const { result, rerender } = renderHook(
+			({ currentTime }: { currentTime: number }) =>
+				useVideoEnhancementProxyWindow({
+					element,
+					currentTime,
+					isPlaying: false,
+				}),
+			{ initialProps: { currentTime: 0 } }
+		);
+		expect(result.current.sourceStart).toBe(0);
+		expect(result.current.sourceDuration).toBeGreaterThan(0);
+
+		// Seeking far ahead moves to a later stride-aligned chunk.
+		rerender({ currentTime: 25 });
+		expect(result.current.sourceStart).toBeGreaterThan(0);
+	});
+
+	it("advances the chunk from playback-update events, not renders", () => {
+		const element = makeMediaElement();
+		const { result } = renderHook(() =>
+			useVideoEnhancementProxyWindow({
+				element,
+				currentTime: 0,
+				isPlaying: true,
+			})
+		);
+		const initialWindow = result.current;
+
+		// Within the same chunk the state object stays identity-stable.
+		act(() => {
+			dispatchPlaybackUpdate(1);
+			dispatchPlaybackUpdate(5);
+		});
+		expect(result.current).toBe(initialWindow);
+
+		// Crossing the stride boundary advances the chunk.
+		act(() => {
+			dispatchPlaybackUpdate(30);
+		});
+		expect(result.current).not.toBe(initialWindow);
+		expect(result.current.sourceStart).toBeGreaterThan(
+			initialWindow.sourceStart
+		);
+	});
+
+	it("does not listen for playback events while paused", () => {
+		const element = makeMediaElement();
+		const { result } = renderHook(() =>
+			useVideoEnhancementProxyWindow({
+				element,
+				currentTime: 0,
+				isPlaying: false,
+			})
+		);
+		const initialWindow = result.current;
+		act(() => {
+			dispatchPlaybackUpdate(30);
+		});
+		expect(result.current).toBe(initialWindow);
+	});
+});

--- a/qcut/apps/web/src/hooks/preview/__tests__/use-video-enhancement-proxy-window.test.tsx
+++ b/qcut/apps/web/src/hooks/preview/__tests__/use-video-enhancement-proxy-window.test.tsx
@@ -32,7 +32,11 @@ describe("useVideoEnhancementProxyWindow", () => {
 				isPlaying: false,
 			})
 		);
-		expect(result.current).toEqual({ sourceStart: 0, sourceDuration: 0 });
+		expect(result.current).toEqual({
+			sourceStart: 0,
+			sourceDuration: 0,
+			prefetch: null,
+		});
 	});
 
 	it("derives the window from the rendered time while paused", () => {
@@ -50,8 +54,10 @@ describe("useVideoEnhancementProxyWindow", () => {
 		expect(result.current.sourceDuration).toBeGreaterThan(0);
 
 		// Seeking far ahead moves to a later stride-aligned chunk.
-		rerender({ currentTime: 25 });
+		rerender({ currentTime: 35 });
 		expect(result.current.sourceStart).toBeGreaterThan(0);
+		// Paused derivation never requests prefetch.
+		expect(result.current.prefetch).toBeNull();
 	});
 
 	it("advances the chunk from playback-update events, not renders", () => {
@@ -71,6 +77,16 @@ describe("useVideoEnhancementProxyWindow", () => {
 			dispatchPlaybackUpdate(5);
 		});
 		expect(result.current).toBe(initialWindow);
+
+		// Inside the prefetch lead the upcoming chunk is announced once.
+		act(() => {
+			dispatchPlaybackUpdate(20);
+		});
+		expect(result.current.sourceStart).toBe(initialWindow.sourceStart);
+		expect(result.current.prefetch).not.toBeNull();
+		expect(result.current.prefetch?.sourceStart ?? 0).toBeGreaterThan(
+			initialWindow.sourceStart
+		);
 
 		// Crossing the stride boundary advances the chunk.
 		act(() => {

--- a/qcut/apps/web/src/hooks/preview/__tests__/use-video-enhancement-proxy.test.tsx
+++ b/qcut/apps/web/src/hooks/preview/__tests__/use-video-enhancement-proxy.test.tsx
@@ -211,12 +211,12 @@ describe("useVideoEnhancementProxy", () => {
 
 		expect(
 			getVideoEnhancementProxyWindow({ element, currentTime: 16 })
-		).toEqual({ sourceStart: 5, sourceDuration: 12 });
+		).toEqual({ sourceStart: 5, sourceDuration: 30 });
 		expect(
-			getVideoEnhancementProxyWindow({ element, currentTime: 27 })
-		).toEqual({ sourceStart: 15, sourceDuration: 12 });
+			getVideoEnhancementProxyWindow({ element, currentTime: 45 })
+		).toEqual({ sourceStart: 33, sourceDuration: 30 });
 		expect(
 			getVideoEnhancementProxyWindow({ element, currentTime: 100 })
-		).toEqual({ sourceStart: 83, sourceDuration: 12 });
+		).toEqual({ sourceStart: 65, sourceDuration: 30 });
 	});
 });

--- a/qcut/apps/web/src/hooks/preview/use-playback-health-preview-quality.ts
+++ b/qcut/apps/web/src/hooks/preview/use-playback-health-preview-quality.ts
@@ -11,6 +11,14 @@ const SAMPLE_SIZE = 24;
 const STUTTER_INTERVAL_MS = 50;
 const PRESENTED_FRAME_STALL_INTERVAL_MS = 80;
 const STABLE_INTERVAL_MS = 34;
+/** Playback-start warmup: mounting/seeking costs in the first moments of
+ * playback are one-off, not sustained pressure — sampling them causes a
+ * downgrade→proxy→recover→source flap right at play start. */
+const STARTUP_WARMUP_MS = 1000;
+/** Averages over a nearly-empty ring are dominated by a single spike; only
+ * let a ring's average influence the decision once it is half full. Stall
+ * counts stay live so genuine repeated stalls still downgrade quickly. */
+const MIN_SAMPLES_FOR_AVERAGE = SAMPLE_SIZE / 2;
 
 function average({ values }: { values: number[] }): number {
 	if (values.length === 0) return 0;
@@ -62,6 +70,7 @@ export function usePlaybackHealthPreviewQuality() {
 		const presentedFrameIntervals: number[] = [];
 		let stableFrameCount = 0;
 		let lastFrameTime = performance.now();
+		const warmupUntil = performance.now() + STARTUP_WARMUP_MS;
 
 		const applyRuntimeQuality = () => {
 			const stutterFrameCount = intervals.filter(
@@ -73,12 +82,16 @@ export function usePlaybackHealthPreviewQuality() {
 			const decision = resolveRuntimePreviewQualityDecision({
 				selectedQuality: previewQuality,
 				currentRuntimeQuality: runtimeQualityRef.current,
-				averageFrameIntervalMs: average({ values: intervals }),
+				averageFrameIntervalMs:
+					intervals.length >= MIN_SAMPLES_FOR_AVERAGE
+						? average({ values: intervals })
+						: 0,
 				stutterFrameCount,
 				stableFrameCount,
-				averagePresentedFrameIntervalMs: average({
-					values: presentedFrameIntervals,
-				}),
+				averagePresentedFrameIntervalMs:
+					presentedFrameIntervals.length >= MIN_SAMPLES_FOR_AVERAGE
+						? average({ values: presentedFrameIntervals })
+						: 0,
 				presentedFrameStallCount,
 			});
 
@@ -101,6 +114,7 @@ export function usePlaybackHealthPreviewQuality() {
 			const now = performance.now();
 			const interval = now - lastFrameTime;
 			lastFrameTime = now;
+			if (now < warmupUntil) return;
 			if (!Number.isFinite(interval) || interval <= 0) return;
 
 			intervals.push(interval);
@@ -120,6 +134,7 @@ export function usePlaybackHealthPreviewQuality() {
 		const handleVideoFrame = (event: Event) => {
 			if (!isQcutVideoFrameEvent(event)) return;
 			if (!event.detail.isActivePlaybackFrame) return;
+			if (performance.now() < warmupUntil) return;
 			const interval = event.detail.intervalMs;
 			if (typeof interval !== "number" || interval <= 0) return;
 			presentedFrameIntervals.push(interval);

--- a/qcut/apps/web/src/hooks/preview/use-video-enhancement-proxy.ts
+++ b/qcut/apps/web/src/hooks/preview/use-video-enhancement-proxy.ts
@@ -1,5 +1,5 @@
 import { platform } from "@qcut/platform-core";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { hasMediaEnhancements } from "@/lib/video/video-properties";
 import { getMediaSourcePlaybackTime } from "@/lib/video/video-timing";
 import type { MediaElement, MediaEnhancements } from "@/types/timeline";
@@ -57,6 +57,82 @@ export function getVideoEnhancementProxyWindow({
 			Math.min(safeChunkDuration, clipEnd - sourceStart).toFixed(6)
 		),
 	};
+}
+
+export interface VideoEnhancementProxyWindow {
+	sourceStart: number;
+	sourceDuration: number;
+}
+
+const EMPTY_PROXY_WINDOW: VideoEnhancementProxyWindow = {
+	sourceStart: 0,
+	sourceDuration: 0,
+};
+
+function sameProxyWindow(
+	previous: VideoEnhancementProxyWindow,
+	next: VideoEnhancementProxyWindow
+): boolean {
+	return (
+		previous.sourceStart === next.sourceStart &&
+		previous.sourceDuration === next.sourceDuration
+	);
+}
+
+/**
+ * Current proxy chunk window for a media element, advanced by
+ * "playback-update" events during playback instead of per-frame React
+ * renders. State only changes when the stride-aligned chunk changes
+ * (~once per DEFAULT_PROXY_CHUNK_SECONDS), so proxy-backed playback does
+ * not force the preview tree to re-render every frame.
+ */
+export function useVideoEnhancementProxyWindow({
+	element,
+	currentTime,
+	isPlaying,
+}: {
+	element: MediaElement | null;
+	currentTime: number;
+	isPlaying: boolean;
+}): VideoEnhancementProxyWindow {
+	const [proxyWindow, setProxyWindow] =
+		useState<VideoEnhancementProxyWindow>(EMPTY_PROXY_WINDOW);
+	const elementRef = useRef(element);
+
+	useEffect(() => {
+		elementRef.current = element;
+	}, [element]);
+
+	// Seeks, pauses, and element switches resolve from the rendered time.
+	useEffect(() => {
+		const next = element
+			? getVideoEnhancementProxyWindow({ element, currentTime })
+			: EMPTY_PROXY_WINDOW;
+		setProxyWindow((previous) =>
+			sameProxyWindow(previous, next) ? previous : next
+		);
+	}, [element, currentTime]);
+
+	// Playback advances the chunk from the shared clock events.
+	useEffect(() => {
+		if (!isPlaying || !element) return;
+		const handleUpdate = (event: Event) => {
+			const time = (event as CustomEvent).detail.time as number;
+			const currentElement = elementRef.current;
+			if (!currentElement || !Number.isFinite(time)) return;
+			const next = getVideoEnhancementProxyWindow({
+				element: currentElement,
+				currentTime: time,
+			});
+			setProxyWindow((previous) =>
+				sameProxyWindow(previous, next) ? previous : next
+			);
+		};
+		window.addEventListener("playback-update", handleUpdate);
+		return () => window.removeEventListener("playback-update", handleUpdate);
+	}, [isPlaying, element]);
+
+	return proxyWindow;
 }
 
 export function videoEnhancementProxyDimensions({

--- a/qcut/apps/web/src/hooks/preview/use-video-enhancement-proxy.ts
+++ b/qcut/apps/web/src/hooks/preview/use-video-enhancement-proxy.ts
@@ -17,8 +17,11 @@ interface VideoEnhancementProxyState {
 }
 
 let proxyRequestSequence = 0;
-const DEFAULT_PROXY_CHUNK_SECONDS = 12;
+const DEFAULT_PROXY_CHUNK_SECONDS = 30;
 const DEFAULT_PROXY_CHUNK_OVERLAP_SECONDS = 2;
+/** Seconds before a chunk boundary at which the next chunk is pre-generated
+ * into the main-process cache, so the boundary switch never encodes live. */
+const PROXY_PREFETCH_LEAD_SECONDS = 10;
 
 export function getVideoEnhancementProxyWindow({
 	element,
@@ -64,19 +67,51 @@ export interface VideoEnhancementProxyWindow {
 	sourceDuration: number;
 }
 
-const EMPTY_PROXY_WINDOW: VideoEnhancementProxyWindow = {
+export interface VideoEnhancementProxyWindowState
+	extends VideoEnhancementProxyWindow {
+	/** Upcoming chunk to pre-generate, set while inside the prefetch lead. */
+	prefetch: VideoEnhancementProxyWindow | null;
+}
+
+const EMPTY_PROXY_WINDOW: VideoEnhancementProxyWindowState = {
 	sourceStart: 0,
 	sourceDuration: 0,
+	prefetch: null,
 };
 
 function sameProxyWindow(
-	previous: VideoEnhancementProxyWindow,
-	next: VideoEnhancementProxyWindow
+	previous: VideoEnhancementProxyWindowState,
+	next: VideoEnhancementProxyWindowState
 ): boolean {
 	return (
 		previous.sourceStart === next.sourceStart &&
-		previous.sourceDuration === next.sourceDuration
+		previous.sourceDuration === next.sourceDuration &&
+		(previous.prefetch?.sourceStart ?? null) ===
+			(next.prefetch?.sourceStart ?? null) &&
+		(previous.prefetch?.sourceDuration ?? null) ===
+			(next.prefetch?.sourceDuration ?? null)
 	);
+}
+
+function resolveProxyWindowState({
+	element,
+	currentTime,
+	withPrefetch,
+}: {
+	element: MediaElement;
+	currentTime: number;
+	withPrefetch: boolean;
+}): VideoEnhancementProxyWindowState {
+	const window = getVideoEnhancementProxyWindow({ element, currentTime });
+	if (!withPrefetch) return { ...window, prefetch: null };
+	const ahead = getVideoEnhancementProxyWindow({
+		element,
+		currentTime: currentTime + PROXY_PREFETCH_LEAD_SECONDS,
+	});
+	return {
+		...window,
+		prefetch: ahead.sourceStart !== window.sourceStart ? ahead : null,
+	};
 }
 
 /**
@@ -94,9 +129,9 @@ export function useVideoEnhancementProxyWindow({
 	element: MediaElement | null;
 	currentTime: number;
 	isPlaying: boolean;
-}): VideoEnhancementProxyWindow {
+}): VideoEnhancementProxyWindowState {
 	const [proxyWindow, setProxyWindow] =
-		useState<VideoEnhancementProxyWindow>(EMPTY_PROXY_WINDOW);
+		useState<VideoEnhancementProxyWindowState>(EMPTY_PROXY_WINDOW);
 	const elementRef = useRef(element);
 
 	useEffect(() => {
@@ -106,7 +141,7 @@ export function useVideoEnhancementProxyWindow({
 	// Seeks, pauses, and element switches resolve from the rendered time.
 	useEffect(() => {
 		const next = element
-			? getVideoEnhancementProxyWindow({ element, currentTime })
+			? resolveProxyWindowState({ element, currentTime, withPrefetch: false })
 			: EMPTY_PROXY_WINDOW;
 		setProxyWindow((previous) =>
 			sameProxyWindow(previous, next) ? previous : next
@@ -120,9 +155,10 @@ export function useVideoEnhancementProxyWindow({
 			const time = (event as CustomEvent).detail.time as number;
 			const currentElement = elementRef.current;
 			if (!currentElement || !Number.isFinite(time)) return;
-			const next = getVideoEnhancementProxyWindow({
+			const next = resolveProxyWindowState({
 				element: currentElement,
 				currentTime: time,
+				withPrefetch: true,
 			});
 			setProxyWindow((previous) =>
 				sameProxyWindow(previous, next) ? previous : next
@@ -167,6 +203,7 @@ export function useVideoEnhancementProxy({
 	enhancements,
 	forceProxy = false,
 	maxDimension = 960,
+	prefetchWindow = null,
 }: {
 	enabled: boolean;
 	elementId: string;
@@ -179,6 +216,7 @@ export function useVideoEnhancementProxy({
 	enhancements: MediaEnhancements;
 	forceProxy?: boolean;
 	maxDimension?: number;
+	prefetchWindow?: VideoEnhancementProxyWindow | null;
 }): VideoEnhancementProxyState {
 	const [retrySequence, setRetrySequence] = useState(0);
 	const [state, setState] = useState<Omit<VideoEnhancementProxyState, "retry">>(
@@ -229,11 +267,14 @@ export function useVideoEnhancementProxy({
 			height: sourceHeight,
 			maxDimension,
 		});
-		setState({
+		// Keep the previous chunk's url/offset while the next one generates —
+		// the old chunk keeps playing through its overlap instead of flapping
+		// back to the original source (two src reloads per boundary).
+		setState((current) => ({
+			...current,
 			status: "generating",
 			progress: 0,
-			sourceTimeOffset: sourceStart,
-		});
+		}));
 		const removeProgressListener =
 			platform().ffmpeg.onVideoPreviewProxyProgress((progress) => {
 				if (cancelled || progress.requestId !== requestId) return;
@@ -292,6 +333,54 @@ export function useVideoEnhancementProxy({
 		sourceHeight,
 		sourcePath,
 		sourceStart,
+		sourceWidth,
+	]);
+
+	// Warm the main-process cache with the upcoming chunk while the current
+	// one still plays, so the boundary switch resolves from cache instead of
+	// encoding live. Fire-and-forget: failures fall back to the live encode.
+	useEffect(() => {
+		if (
+			!prefetchWindow ||
+			prefetchWindow.sourceDuration <= 0 ||
+			!enabled ||
+			!sourcePath ||
+			!platform().isElectron ||
+			(!forceProxy &&
+				!hasMediaEnhancements({ enhancements: enhancementSnapshot }))
+		) {
+			return;
+		}
+		const dimensions = videoEnhancementProxyDimensions({
+			width: sourceWidth,
+			height: sourceHeight,
+			maxDimension,
+		});
+		const requestId = `video-proxy-prefetch-${elementId}-${++proxyRequestSequence}`;
+		void platform()
+			.ffmpeg.renderVideoPreviewProxy({
+				requestId,
+				sourcePath,
+				sourceStart: prefetchWindow.sourceStart,
+				sourceDuration: prefetchWindow.sourceDuration,
+				width: dimensions.width,
+				height: dimensions.height,
+				fps,
+				enhancements: enhancementSnapshot,
+			})
+			.catch(() => {
+				// Best-effort warmup only.
+			});
+	}, [
+		prefetchWindow,
+		enabled,
+		elementId,
+		enhancementSnapshot,
+		forceProxy,
+		fps,
+		maxDimension,
+		sourceHeight,
+		sourcePath,
 		sourceWidth,
 	]);
 

--- a/qcut/apps/web/src/hooks/preview/use-video-enhancement-proxy.ts
+++ b/qcut/apps/web/src/hooks/preview/use-video-enhancement-proxy.ts
@@ -339,6 +339,9 @@ export function useVideoEnhancementProxy({
 	// Warm the main-process cache with the upcoming chunk while the current
 	// one still plays, so the boundary switch resolves from cache instead of
 	// encoding live. Fire-and-forget: failures fall back to the live encode.
+	const activePrefetchRef = useRef<{ requestId: string; key: string } | null>(
+		null
+	);
 	useEffect(() => {
 		if (
 			!prefetchWindow ||
@@ -357,6 +360,18 @@ export function useVideoEnhancementProxy({
 			maxDimension,
 		});
 		const requestId = `video-proxy-prefetch-${elementId}-${++proxyRequestSequence}`;
+		const key = `${sourcePath}:${prefetchWindow.sourceStart}:${prefetchWindow.sourceDuration}:${dimensions.width}x${dimensions.height}`;
+		// A seek can retarget the prefetch before the previous chunk finished
+		// encoding — cancel the superseded job so it stops competing with live
+		// preview work. The boundary handoff itself is untouched: the window
+		// going null keeps the completed (or completing) prefetch in cache.
+		const previous = activePrefetchRef.current;
+		if (previous && previous.key !== key) {
+			void platform()
+				.ffmpeg.cancelVideoPreviewProxy(previous.requestId)
+				.catch(() => {});
+		}
+		activePrefetchRef.current = { requestId, key };
 		void platform()
 			.ffmpeg.renderVideoPreviewProxy({
 				requestId,
@@ -370,6 +385,11 @@ export function useVideoEnhancementProxy({
 			})
 			.catch(() => {
 				// Best-effort warmup only.
+			})
+			.finally(() => {
+				if (activePrefetchRef.current?.requestId === requestId) {
+					activePrefetchRef.current = null;
+				}
 			});
 	}, [
 		prefetchWindow,

--- a/qcut/apps/web/src/lib/color/__tests__/gpu-color-path.test.ts
+++ b/qcut/apps/web/src/lib/color/__tests__/gpu-color-path.test.ts
@@ -5,6 +5,7 @@ import { sampleCubeLut } from "../color-space-math";
 import {
 	__bakeCountForTests,
 	bakeColorCube,
+	gradeFrameOnGpu,
 	isGpuEligible,
 	resetGpuColorPath,
 } from "../gpu-color-path";
@@ -36,12 +37,21 @@ describe("GPU colour path eligibility", () => {
 		).toBe(true);
 	});
 
-	it("rejects spatial effects a colour cube cannot express", () => {
-		// Each of these reads neighbouring pixels or the pixel's position, so
-		// baking them into a lookup would silently drop them.
+	it("accepts spatial effects now expressed as shader stages", () => {
+		// Vignette, grain and sharpness run inside the fragment shader — they
+		// no longer force the CPU pixel loop.
 		for (const patch of [{ vignette: 40 }, { grain: 25 }, { sharpness: 30 }]) {
-			expect(isGpuEligible({ settings: settingsWith(patch) })).toBe(false);
+			expect(isGpuEligible({ settings: settingsWith(patch) })).toBe(true);
 		}
+	});
+
+	it("rejects multi-pass operations the single-draw shader cannot express", () => {
+		const settings = structuredClone(DEFAULT_MEDIA_COLOR_SETTINGS);
+		settings.multiPass = {
+			...settings.multiPass,
+			enabled: true,
+		} as typeof settings.multiPass;
+		expect(isGpuEligible({ settings })).toBe(false);
 	});
 
 	it("treats disabled basic adjustments as eligible", () => {
@@ -51,21 +61,30 @@ describe("GPU colour path eligibility", () => {
 		expect(isGpuEligible({ settings })).toBe(true);
 	});
 
-	it("rejects an enabled grade mask even when it selects no masks", () => {
-		// The CPU path weights the grade by the mask's alpha whenever the mask
-		// feature is on; an empty selection renders an all-zero mask, so the CPU
-		// grades nowhere while an unmasked GPU grade would land everywhere.
-		const settings = structuredClone(DEFAULT_MEDIA_COLOR_SETTINGS);
-		settings.mask.enabled = true;
-		settings.mask.maskIds = [];
-		expect(isGpuEligible({ settings })).toBe(false);
-	});
-
-	it("rejects an enabled grade mask with a selection", () => {
+	it("accepts an enabled grade mask (weighted via the mask texture)", () => {
+		// The mask's alpha now rides along as a texture the shader mixes by;
+		// callers pass the rasterised pixels through gradeFrameOnGpu.
 		const settings = structuredClone(DEFAULT_MEDIA_COLOR_SETTINGS);
 		settings.mask.enabled = true;
 		settings.mask.maskIds = ["mask-1"];
-		expect(isGpuEligible({ settings })).toBe(false);
+		expect(isGpuEligible({ settings })).toBe(true);
+	});
+
+	it("rejects a grade mask whose pixels do not match the frame", () => {
+		// Without matching mask pixels the shader would grade everywhere while
+		// the CPU path grades nowhere — fall back instead.
+		const settings = structuredClone(DEFAULT_MEDIA_COLOR_SETTINGS);
+		settings.mask.enabled = true;
+		settings.mask.maskIds = ["mask-1"];
+		expect(
+			gradeFrameOnGpu({
+				source: {} as unknown as CanvasImageSource,
+				width: 4,
+				height: 4,
+				settings,
+				gradeMask: new Uint8ClampedArray(8),
+			})
+		).toBeNull();
 	});
 
 	it("ignores stale mask selections while the feature is off", () => {

--- a/qcut/apps/web/src/lib/color/__tests__/gpu-lut-renderer.test.ts
+++ b/qcut/apps/web/src/lib/color/__tests__/gpu-lut-renderer.test.ts
@@ -206,6 +206,7 @@ function createFakeGl(): {
 		texParameteri: noop,
 		uniform1i: noop,
 		uniform1f: noop,
+		uniform2f: noop,
 		drawArrays: noop,
 	};
 	return { context: fake as unknown as WebGL2RenderingContext, state };

--- a/qcut/apps/web/src/lib/color/browser-color-rendering.ts
+++ b/qcut/apps/web/src/lib/color/browser-color-rendering.ts
@@ -100,9 +100,15 @@ async function gradeMaskPixels({
 	});
 	const cached = gradeMaskCache.get(cacheKey);
 	if (cached) return cached;
-	const url = mediaMaskSvgUrl(selected);
-	if (!url) return new Uint8ClampedArray(width * height * 4);
 	if (gradeMaskCache.size >= GRADE_MASK_CACHE_LIMIT) gradeMaskCache.clear();
+	const url = mediaMaskSvgUrl(selected);
+	if (!url) {
+		// Cache the all-zero mask too — a fresh array per frame would defeat
+		// the GPU mask-texture cache keyed on array identity.
+		const empty = Promise.resolve(new Uint8ClampedArray(width * height * 4));
+		gradeMaskCache.set(cacheKey, empty);
+		return empty;
+	}
 	const rendered = (async () => {
 		const canvas = document.createElement("canvas");
 		canvas.width = width;
@@ -185,27 +191,44 @@ export async function drawColorGradedSourceWithMasks({
 		canRenderJianyingLocalPortrait({ settings });
 
 	// Per-pixel grading on the GPU: one 1080p frame costs ~278ms walking pixels
-	// in JS versus ~4ms as a shader lookup. Returns null when the settings need
-	// spatial work (vignette, grain, sharpness) or WebGL2 is unavailable, and
-	// the CPU path below still handles those.
-	if (masks.length === 0 && !usesLocalRuntime) {
-		const graded = gradeFrameOnGpu({
-			source,
-			width: pixelWidth,
-			height: pixelHeight,
-			settings,
-		});
-		if (graded) {
-			await drawMediaSourceWithMasks({
-				context,
-				source: graded,
-				x,
-				y,
-				width,
-				height,
-				masks: outputMasks,
+	// in JS versus ~4ms as a shader pass. Vignette/grain/sharpness run as
+	// shader stages and grade masks ride along as an alpha texture; only
+	// multi-pass operations, jianying local runtimes, WebGL2 absence, or a
+	// failed mask rasterisation fall through to the CPU path below.
+	if (!usesLocalRuntime) {
+		let gradeMask: Uint8ClampedArray | undefined;
+		let maskUnavailable = false;
+		try {
+			gradeMask = await gradeMaskPixels({
+				masks,
+				settings,
+				width: pixelWidth,
+				height: pixelHeight,
 			});
-			return;
+		} catch {
+			maskUnavailable = true;
+		}
+		if (!maskUnavailable) {
+			const graded = gradeFrameOnGpu({
+				source,
+				width: pixelWidth,
+				height: pixelHeight,
+				settings,
+				frameSeed,
+				gradeMask,
+			});
+			if (graded) {
+				await drawMediaSourceWithMasks({
+					context,
+					source: graded,
+					x,
+					y,
+					width,
+					height,
+					masks: outputMasks,
+				});
+				return;
+			}
 		}
 	}
 

--- a/qcut/apps/web/src/lib/color/gpu-color-path.ts
+++ b/qcut/apps/web/src/lib/color/gpu-color-path.ts
@@ -4,8 +4,9 @@
  *
  * `transformColorPixel` is a pure function of the input colour — LUT, curves,
  * HSL, smart tone — so it can be baked into a 3D lookup once per settings
- * change and then applied by the hardware. Vignette, grain, sharpness and
- * masks are spatial and stay on the CPU path.
+ * change and then applied by the hardware. Vignette, grain and sharpness run
+ * as shader stages, and grade masks arrive as an alpha texture; only
+ * multi-pass long-tail operations still force the CPU path.
  *
  * @module lib/color/gpu-color-path
  */
@@ -21,26 +22,15 @@ import { createGpuLutRenderer, type GpuLutRenderer } from "./gpu-lut-renderer";
  */
 const BAKE_SIZE = 33;
 
-/** True when every enabled effect is a per-pixel colour transform. */
+/** True when the shader path can express every enabled effect. */
 export function isGpuEligible({
 	settings,
 }: {
 	settings: MediaColorSettings;
 }): boolean {
-	// An enabled grade mask weights the transform per pixel by position — the
-	// CPU path applies that weighting even when the mask selects nothing (the
-	// grade then lands nowhere), so a colour cube cannot stand in for it.
-	if (settings.mask?.enabled) return false;
-	if (settings.multiPass?.enabled) return false;
-	const basic = settings.basic;
-	if (!basic?.enabled) return true;
-	// These three read neighbouring pixels or the pixel's position, so a colour
-	// cube cannot express them.
-	return (
-		(basic.vignette ?? 0) === 0 &&
-		(basic.grain ?? 0) === 0 &&
-		(basic.sharpness ?? 0) === 0
-	);
+	// Multi-pass long-tail operations mix temporal and iterative work the
+	// single-draw shader cannot express.
+	return !settings.multiPass?.enabled;
 }
 
 /**
@@ -68,9 +58,18 @@ function settingsFingerprint({
 	settings: MediaColorSettings;
 }): string {
 	const cube = settings.lut?.cube;
-	const normalizedSettings = settings.multiPass
-		? { ...settings, multiPass: undefined }
-		: settings;
+	// The bake only captures the per-pixel colour transform; spatial stages
+	// (vignette/grain/sharpness, grade masks, multi-pass) run outside the
+	// cube, so normalising them out keeps the cache warm while their sliders
+	// move.
+	const normalizedSettings: MediaColorSettings = {
+		...settings,
+		multiPass: undefined,
+		mask: { ...settings.mask, enabled: false, maskIds: [] },
+		basic: settings.basic
+			? { ...settings.basic, vignette: 0, grain: 0, sharpness: 0 }
+			: settings.basic,
+	};
 	if (!cube) return JSON.stringify(normalizedSettings);
 	const skinCube = settings.lut.dual?.skinCube;
 	return JSON.stringify({
@@ -168,22 +167,31 @@ function sharedRenderer(): GpuLutRenderer | null {
 
 /**
  * Grades a frame on the GPU, or returns null when the caller should stay on
- * the CPU path (spatial effects present, or no WebGL2).
+ * the CPU path (multi-pass operations present, no WebGL2, or a grade mask
+ * whose pixels do not match the frame dimensions).
  */
 export function gradeFrameOnGpu({
 	source,
 	width,
 	height,
 	settings,
+	frameSeed = 0,
+	gradeMask,
 }: {
 	source: CanvasImageSource;
 	width: number;
 	height: number;
 	settings: MediaColorSettings;
+	frameSeed?: number;
+	/** RGBA pixels (width x height) whose alpha weights the grade. */
+	gradeMask?: Uint8ClampedArray;
 }): HTMLCanvasElement | null {
 	if (!isGpuEligible({ settings })) return null;
+	if (gradeMask && gradeMask.length !== width * height * 4) return null;
 	const gpu = sharedRenderer();
 	if (!gpu) return null;
+	const basic = settings.basic?.enabled ? settings.basic : null;
+	const sharpness = basic?.sharpness ?? 0;
 	try {
 		return gpu.render({
 			source,
@@ -192,6 +200,17 @@ export function gradeFrameOnGpu({
 			cube: bakeColorCube({ settings }),
 			// The bake already carries intensity, so the shader mixes fully.
 			intensity: 1,
+			spatial: {
+				vignette: (basic?.vignette ?? 0) / 100,
+				grain: (basic?.grain ?? 0) / 100,
+				grainSeed: frameSeed,
+				// The CPU kernel needs at least a 3x3 frame to sharpen.
+				sharpness:
+					sharpness > 0 && width >= 3 && height >= 3
+						? Math.min(2, sharpness / 50)
+						: 0,
+				mask: gradeMask,
+			},
 		});
 	} catch {
 		return null;

--- a/qcut/apps/web/src/lib/color/gpu-lut-renderer.ts
+++ b/qcut/apps/web/src/lib/color/gpu-lut-renderer.ts
@@ -27,6 +27,15 @@ void main() {
  * Scaling the lookup into the texel centres is what keeps the edges of the
  * cube from being clamped to half a texel short, which otherwise crushes pure
  * black and pure white.
+ *
+ * The spatial stages mirror processColorImageData in color-pixel-processor:
+ * LUT → vignette (radial multiply) → grain (hash noise) per pixel, then a
+ * cross-kernel sharpen over the graded neighbours, then a grade-mask mix
+ * against the untouched source. Grain uses a range-safe uv hash instead of
+ * the CPU's float64 linear-index sin (whose huge arguments collapse GPU
+ * sin — see the shader comment): a different pattern, same statistics.
+ * Vignette coordinates differ by under half a texel (uv centres vs
+ * index/(dim-1)).
  */
 const FRAGMENT_SHADER = `#version 300 es
 precision highp float;
@@ -34,17 +43,76 @@ precision highp sampler3D;
 in vec2 v_uv;
 uniform sampler2D u_frame;
 uniform sampler3D u_lut;
+uniform sampler2D u_mask;
 uniform float u_lutSize;
 uniform float u_intensity;
+uniform vec2 u_resolution;
+uniform float u_vignette;
+uniform float u_grain;
+uniform float u_grainSeed;
+uniform float u_sharpness;
+uniform float u_useMask;
 out vec4 fragColor;
-void main() {
-  vec4 source = texture(u_frame, v_uv);
+
+vec3 gradeAt(vec2 uv) {
+  vec3 src = texture(u_frame, uv).rgb;
   float scale = (u_lutSize - 1.0) / u_lutSize;
   float offset = 1.0 / (2.0 * u_lutSize);
-  vec3 lutCoord = clamp(source.rgb, 0.0, 1.0) * scale + offset;
-  vec3 graded = texture(u_lut, lutCoord).rgb;
-  fragColor = vec4(mix(source.rgb, graded, u_intensity), source.a);
+  vec3 color = texture(u_lut, clamp(src, 0.0, 1.0) * scale + offset).rgb;
+  if (u_vignette > 0.0) {
+    float distance = length(vec2((uv.x - 0.5) * 1.25, uv.y - 0.5)) / 0.72;
+    color *= 1.0 - pow(max(0.0, distance - 0.45), 1.7) * u_vignette * 0.85;
+  }
+  if (u_grain > 0.0) {
+    // GPU sin() collapses for large arguments (measured broken above ~7e6 on
+    // ANGLE/Metal), so unlike the CPU's linear-index hash this keeps the
+    // argument inside [0, 2pi): normalized coords plus a seed folded to a
+    // 289-frame period. Different noise pattern than the CPU path, same
+    // statistics.
+    float seed = mod(u_grainSeed, 289.0);
+    float argument = mod(
+      dot(uv, vec2(127.1, 311.7)) + seed * 43.7,
+      6.2831853
+    );
+    float hash = fract(sin(argument) * 43758.5453);
+    color += vec3((hash * 2.0 - 1.0) * u_grain * 0.1);
+  }
+  return clamp(color, 0.0, 1.0);
+}
+
+void main() {
+  vec4 source = texture(u_frame, v_uv);
+  vec3 graded = gradeAt(v_uv);
+  if (u_sharpness > 0.0) {
+    vec2 pixel = floor(v_uv * u_resolution);
+    // The CPU kernel leaves a one-pixel border unsharpened.
+    if (pixel.x >= 1.0 && pixel.y >= 1.0 &&
+        pixel.x <= u_resolution.x - 2.0 && pixel.y <= u_resolution.y - 2.0) {
+      vec2 texel = 1.0 / u_resolution;
+      vec3 average = (gradeAt(v_uv + vec2(0.0, -texel.y)) +
+                      gradeAt(v_uv + vec2(0.0, texel.y)) +
+                      gradeAt(v_uv + vec2(-texel.x, 0.0)) +
+                      gradeAt(v_uv + vec2(texel.x, 0.0))) * 0.25;
+      graded = clamp(graded + (graded - average) * u_sharpness, 0.0, 1.0);
+    }
+  }
+  float maskWeight = u_useMask > 0.5 ? texture(u_mask, v_uv).a : 1.0;
+  vec3 effected = mix(source.rgb, graded, u_intensity);
+  fragColor = vec4(mix(source.rgb, effected, maskWeight), source.a);
 }`;
+
+export interface GpuLutRenderSpatial {
+	/** 0..1 vignette strength (settings.basic.vignette / 100). */
+	vignette: number;
+	/** 0..1 grain strength (settings.basic.grain / 100). */
+	grain: number;
+	/** Frame seed driving the grain hash. */
+	grainSeed: number;
+	/** Sharpen strength min(2, sharpness / 50); 0 disables the kernel. */
+	sharpness: number;
+	/** RGBA pixels whose alpha weights the grade per pixel (grade mask). */
+	mask?: Uint8ClampedArray;
+}
 
 export interface GpuLutRenderer {
 	/** Draws `source` through `cube` and returns the canvas holding the result. */
@@ -55,6 +123,7 @@ export interface GpuLutRenderer {
 		cube: ColorCubeLut;
 		/** 0..1; 0 leaves the frame untouched. */
 		intensity: number;
+		spatial?: GpuLutRenderSpatial;
 	}): HTMLCanvasElement;
 	dispose(): void;
 }
@@ -143,9 +212,86 @@ export function createGpuLutRenderer(): GpuLutRenderer | null {
 	const uniforms = {
 		frame: gl.getUniformLocation(program, "u_frame"),
 		lut: gl.getUniformLocation(program, "u_lut"),
+		mask: gl.getUniformLocation(program, "u_mask"),
 		lutSize: gl.getUniformLocation(program, "u_lutSize"),
 		intensity: gl.getUniformLocation(program, "u_intensity"),
+		resolution: gl.getUniformLocation(program, "u_resolution"),
+		vignette: gl.getUniformLocation(program, "u_vignette"),
+		grain: gl.getUniformLocation(program, "u_grain"),
+		grainSeed: gl.getUniformLocation(program, "u_grainSeed"),
+		sharpness: gl.getUniformLocation(program, "u_sharpness"),
+		useMask: gl.getUniformLocation(program, "u_useMask"),
 	};
+
+	// A 1x1 opaque texture keeps the mask sampler valid when no mask is bound.
+	const emptyMaskTexture = gl.createTexture();
+	gl.activeTexture(gl.TEXTURE2);
+	gl.bindTexture(gl.TEXTURE_2D, emptyMaskTexture);
+	gl.texImage2D(
+		gl.TEXTURE_2D,
+		0,
+		gl.RGBA,
+		1,
+		1,
+		0,
+		gl.RGBA,
+		gl.UNSIGNED_BYTE,
+		new Uint8Array([255, 255, 255, 255])
+	);
+
+	// Grade masks are cached upstream per masks+dims fingerprint, so the same
+	// Uint8ClampedArray arrives every frame while the mask is static — key the
+	// uploaded texture on that identity.
+	const MASK_TEXTURE_CACHE_LIMIT = 4;
+	const maskTextures = new Map<
+		Uint8ClampedArray,
+		{ texture: WebGLTexture; width: number; height: number }
+	>();
+
+	function maskTextureFor(
+		mask: Uint8ClampedArray,
+		width: number,
+		height: number
+	): WebGLTexture {
+		const cached = maskTextures.get(mask);
+		if (cached && cached.width === width && cached.height === height) {
+			maskTextures.delete(mask);
+			maskTextures.set(mask, cached);
+			return cached.texture;
+		}
+		if (cached) {
+			gl.deleteTexture(cached.texture);
+			maskTextures.delete(mask);
+		}
+		if (maskTextures.size >= MASK_TEXTURE_CACHE_LIMIT) {
+			const oldest = maskTextures.entries().next().value;
+			if (oldest) {
+				gl.deleteTexture(oldest[1].texture);
+				maskTextures.delete(oldest[0]);
+			}
+		}
+		const texture = gl.createTexture();
+		gl.activeTexture(gl.TEXTURE2);
+		gl.bindTexture(gl.TEXTURE_2D, texture);
+		gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
+		gl.texImage2D(
+			gl.TEXTURE_2D,
+			0,
+			gl.RGBA,
+			width,
+			height,
+			0,
+			gl.RGBA,
+			gl.UNSIGNED_BYTE,
+			new Uint8Array(mask.buffer, mask.byteOffset, mask.byteLength)
+		);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+		maskTextures.set(mask, { texture, width, height });
+		return texture;
+	}
 
 	// Re-uploading a cube every frame would waste most of the win, and two
 	// visible elements alternate cubes within a frame — so keep a small LRU of
@@ -208,7 +354,7 @@ export function createGpuLutRenderer(): GpuLutRenderer | null {
 	}
 
 	return {
-		render({ source, width, height, cube, intensity }) {
+		render({ source, width, height, cube, intensity, spatial }) {
 			canvas.width = width;
 			canvas.height = height;
 			gl.viewport(0, 0, width, height);
@@ -234,19 +380,38 @@ export function createGpuLutRenderer(): GpuLutRenderer | null {
 			gl.activeTexture(gl.TEXTURE1);
 			gl.bindTexture(gl.TEXTURE_3D, lutTextureFor(cube));
 
+			const mask = spatial?.mask;
+			gl.activeTexture(gl.TEXTURE2);
+			gl.bindTexture(
+				gl.TEXTURE_2D,
+				mask ? maskTextureFor(mask, width, height) : emptyMaskTexture
+			);
+
 			gl.uniform1i(uniforms.frame, 0);
 			gl.uniform1i(uniforms.lut, 1);
+			gl.uniform1i(uniforms.mask, 2);
 			gl.uniform1f(uniforms.lutSize, cube.size);
 			gl.uniform1f(uniforms.intensity, Math.min(1, Math.max(0, intensity)));
+			gl.uniform2f(uniforms.resolution, width, height);
+			gl.uniform1f(uniforms.vignette, spatial?.vignette ?? 0);
+			gl.uniform1f(uniforms.grain, spatial?.grain ?? 0);
+			gl.uniform1f(uniforms.grainSeed, spatial?.grainSeed ?? 0);
+			gl.uniform1f(uniforms.sharpness, spatial?.sharpness ?? 0);
+			gl.uniform1f(uniforms.useMask, mask ? 1 : 0);
 			gl.drawArrays(gl.TRIANGLES, 0, 3);
 			return canvas;
 		},
 		dispose() {
 			gl.deleteTexture(frameTexture);
+			gl.deleteTexture(emptyMaskTexture);
 			for (const texture of lutTextures.values()) {
 				gl.deleteTexture(texture);
 			}
 			lutTextures.clear();
+			for (const entry of maskTextures.values()) {
+				gl.deleteTexture(entry.texture);
+			}
+			maskTextures.clear();
 			gl.deleteBuffer(buffer);
 			gl.deleteProgram(program);
 		},

--- a/qcut/apps/web/src/lib/debug/playback-diagnostics.ts
+++ b/qcut/apps/web/src/lib/debug/playback-diagnostics.ts
@@ -79,6 +79,8 @@ interface VideoElementSample {
 interface PlaybackStoreSample {
 	isPlaying: boolean;
 	currentTime: number;
+	duration: number | null;
+	timelineTotalDuration: number | null;
 	previewQuality: string;
 	runtimePreviewQuality: string | null;
 	runtimeDiagnosticReason: string | null;
@@ -165,25 +167,37 @@ function sampleVideos(): VideoElementSample[] {
 }
 
 function samplePlaybackStore(): PlaybackStoreSample | null {
-	const store = (
-		window as unknown as {
-			__playbackStore?: {
-				getState: () => {
-					isPlaying: boolean;
-					currentTime: number;
-					previewQuality: string;
-					runtimePreviewQuality: string | null;
-					runtimePreviewQualityDiagnostic: { reason?: string } | null;
-				};
+	const exposed = window as unknown as {
+		__playbackStore?: {
+			getState: () => {
+				isPlaying: boolean;
+				currentTime: number;
+				duration: number;
+				previewQuality: string;
+				runtimePreviewQuality: string | null;
+				runtimePreviewQualityDiagnostic: { reason?: string } | null;
 			};
-		}
-	).__playbackStore;
+		};
+		__timelineStore?: {
+			getState: () => { getTotalDuration: () => number };
+		};
+	};
+	const store = exposed.__playbackStore;
 	if (!store) return null;
 	try {
 		const snapshot = store.getState();
+		let timelineTotalDuration: number | null = null;
+		try {
+			timelineTotalDuration =
+				exposed.__timelineStore?.getState().getTotalDuration() ?? null;
+		} catch {
+			timelineTotalDuration = null;
+		}
 		return {
 			isPlaying: snapshot.isPlaying,
 			currentTime: snapshot.currentTime,
+			duration: snapshot.duration ?? null,
+			timelineTotalDuration,
 			previewQuality: snapshot.previewQuality,
 			runtimePreviewQuality: snapshot.runtimePreviewQuality,
 			runtimeDiagnosticReason:

--- a/qcut/apps/web/src/lib/debug/playback-diagnostics.ts
+++ b/qcut/apps/web/src/lib/debug/playback-diagnostics.ts
@@ -1,0 +1,326 @@
+/**
+ * Playback diagnostics collector.
+ *
+ * Always-on, near-zero-cost ring buffers that record what actually happens
+ * during preview playback: master-clock tick intervals, main-thread long
+ * tasks, media element lifecycle events (seeks, stalls, source reloads),
+ * presented-frame cadence, and preview re-render counts.
+ *
+ * The snapshot is pulled from outside the app via
+ * `GET /api/claude/playback/diagnostics` (main process executeJavaScript →
+ * `window.__qcutPlaybackDiagnostics.snapshot()`), which powers
+ * `bun scripts/playback-diagnose.ts`.
+ */
+
+import { QCUT_VIDEO_FRAME_EVENT } from "@/lib/preview/preview-health-events";
+
+const CLOCK_RING_SIZE = 900;
+const LONG_TASK_RING_SIZE = 200;
+const MEDIA_EVENT_RING_SIZE = 400;
+const RENDER_RING_SIZE = 900;
+const PRESENTED_RING_SIZE = 300;
+
+const MEDIA_EVENT_TYPES = [
+	"loadstart",
+	"loadedmetadata",
+	"seeking",
+	"seeked",
+	"waiting",
+	"stalled",
+	"playing",
+	"pause",
+	"ended",
+	"error",
+] as const;
+
+interface RingBuffer<T> {
+	values: T[];
+	capacity: number;
+}
+
+function pushRing<T>(ring: RingBuffer<T>, value: T): void {
+	ring.values.push(value);
+	if (ring.values.length > ring.capacity) {
+		ring.values.splice(0, ring.values.length - ring.capacity);
+	}
+}
+
+interface MediaEventRecord {
+	at: number;
+	type: string;
+	videoId: string;
+	src: string;
+}
+
+interface LongTaskRecord {
+	at: number;
+	durationMs: number;
+}
+
+interface PresentedFrameRecord {
+	at: number;
+	videoId: string;
+	intervalMs: number | null;
+}
+
+interface VideoElementSample {
+	videoId: string;
+	srcKind: string;
+	readyState: number;
+	networkState: number;
+	paused: boolean;
+	currentTime: number;
+	playbackRate: number;
+	droppedVideoFrames: number | null;
+	totalVideoFrames: number | null;
+	presentedFramesAttr: number | null;
+}
+
+interface PlaybackStoreSample {
+	isPlaying: boolean;
+	currentTime: number;
+	previewQuality: string;
+	runtimePreviewQuality: string | null;
+	runtimeDiagnosticReason: string | null;
+}
+
+export interface PlaybackDiagnosticsSnapshot {
+	installed: true;
+	now: number;
+	installedAt: number;
+	clockIntervalsMs: number[];
+	lastClockTickAt: number | null;
+	longTasks: LongTaskRecord[];
+	longTaskTotalCount: number;
+	mediaEvents: MediaEventRecord[];
+	previewRenderTimestamps: number[];
+	previewRenderTotalCount: number;
+	presentedFrames: PresentedFrameRecord[];
+	videos: VideoElementSample[];
+	smoothTimeReason: string | null;
+	playbackStore: PlaybackStoreSample | null;
+}
+
+interface CollectorState {
+	installedAt: number;
+	clockIntervals: RingBuffer<number>;
+	lastClockTickAt: number | null;
+	longTasks: RingBuffer<LongTaskRecord>;
+	longTaskTotalCount: number;
+	mediaEvents: RingBuffer<MediaEventRecord>;
+	renderTimestamps: RingBuffer<number>;
+	renderTotalCount: number;
+	presented: RingBuffer<PresentedFrameRecord>;
+}
+
+let state: CollectorState | null = null;
+
+function srcKind(src: string): string {
+	if (!src) return "none";
+	if (src.startsWith("blob:")) return "blob";
+	try {
+		return new URL(src).protocol.replace(":", "");
+	} catch {
+		return "other";
+	}
+}
+
+/** Called from the preview panel render body; safe before installation. */
+export function recordPreviewPanelRender(): void {
+	if (!state) return;
+	state.renderTotalCount++;
+	pushRing(state.renderTimestamps, performance.now());
+}
+
+function sampleVideos(): VideoElementSample[] {
+	const samples: VideoElementSample[] = [];
+	const videos = document.querySelectorAll<HTMLVideoElement>("video");
+	for (const video of videos) {
+		let dropped: number | null = null;
+		let total: number | null = null;
+		try {
+			const quality = video.getVideoPlaybackQuality?.();
+			if (quality) {
+				dropped = quality.droppedVideoFrames;
+				total = quality.totalVideoFrames;
+			}
+		} catch {
+			// Not supported — leave null.
+		}
+		const presentedAttr = video.getAttribute("data-qcut-presented-frames");
+		samples.push({
+			videoId: video.getAttribute("data-video-id") ?? "unknown",
+			srcKind: srcKind(video.currentSrc || video.src || ""),
+			readyState: video.readyState,
+			networkState: video.networkState,
+			paused: video.paused,
+			currentTime: video.currentTime,
+			playbackRate: video.playbackRate,
+			droppedVideoFrames: dropped,
+			totalVideoFrames: total,
+			presentedFramesAttr: presentedAttr ? Number(presentedAttr) : null,
+		});
+	}
+	return samples;
+}
+
+function samplePlaybackStore(): PlaybackStoreSample | null {
+	const store = (
+		window as unknown as {
+			__playbackStore?: {
+				getState: () => {
+					isPlaying: boolean;
+					currentTime: number;
+					previewQuality: string;
+					runtimePreviewQuality: string | null;
+					runtimePreviewQualityDiagnostic: { reason?: string } | null;
+				};
+			};
+		}
+	).__playbackStore;
+	if (!store) return null;
+	try {
+		const snapshot = store.getState();
+		return {
+			isPlaying: snapshot.isPlaying,
+			currentTime: snapshot.currentTime,
+			previewQuality: snapshot.previewQuality,
+			runtimePreviewQuality: snapshot.runtimePreviewQuality,
+			runtimeDiagnosticReason:
+				snapshot.runtimePreviewQualityDiagnostic?.reason ?? null,
+		};
+	} catch {
+		return null;
+	}
+}
+
+function buildSnapshot(): PlaybackDiagnosticsSnapshot {
+	const current = state;
+	if (!current) {
+		throw new Error("Playback diagnostics not installed");
+	}
+	const captureSurface = document.querySelector(
+		'[data-testid="preview-capture-surface"]'
+	);
+	return {
+		installed: true,
+		now: performance.now(),
+		installedAt: current.installedAt,
+		clockIntervalsMs: [...current.clockIntervals.values],
+		lastClockTickAt: current.lastClockTickAt,
+		longTasks: [...current.longTasks.values],
+		longTaskTotalCount: current.longTaskTotalCount,
+		mediaEvents: [...current.mediaEvents.values],
+		previewRenderTimestamps: [...current.renderTimestamps.values],
+		previewRenderTotalCount: current.renderTotalCount,
+		presentedFrames: [...current.presented.values],
+		videos: sampleVideos(),
+		smoothTimeReason:
+			captureSurface?.getAttribute("data-smooth-time-reason") ?? null,
+		playbackStore: samplePlaybackStore(),
+	};
+}
+
+function resetCollector(): void {
+	if (!state) return;
+	state.clockIntervals.values = [];
+	state.lastClockTickAt = null;
+	state.longTasks.values = [];
+	state.longTaskTotalCount = 0;
+	state.mediaEvents.values = [];
+	state.renderTimestamps.values = [];
+	state.renderTotalCount = 0;
+	state.presented.values = [];
+}
+
+/** Idempotent. Installs listeners and exposes window.__qcutPlaybackDiagnostics. */
+export function installPlaybackDiagnostics(): void {
+	if (state || typeof window === "undefined") return;
+	state = {
+		installedAt: performance.now(),
+		clockIntervals: { values: [], capacity: CLOCK_RING_SIZE },
+		lastClockTickAt: null,
+		longTasks: { values: [], capacity: LONG_TASK_RING_SIZE },
+		longTaskTotalCount: 0,
+		mediaEvents: { values: [], capacity: MEDIA_EVENT_RING_SIZE },
+		renderTimestamps: { values: [], capacity: RENDER_RING_SIZE },
+		renderTotalCount: 0,
+		presented: { values: [], capacity: PRESENTED_RING_SIZE },
+	};
+
+	window.addEventListener("playback-update", () => {
+		const current = state;
+		if (!current) return;
+		const now = performance.now();
+		if (current.lastClockTickAt !== null) {
+			pushRing(current.clockIntervals, now - current.lastClockTickAt);
+		}
+		current.lastClockTickAt = now;
+	});
+
+	window.addEventListener("playback-seek", () => {
+		if (state) state.lastClockTickAt = null;
+	});
+
+	window.addEventListener(QCUT_VIDEO_FRAME_EVENT, (event) => {
+		const current = state;
+		if (!current) return;
+		const detail = (event as CustomEvent).detail as
+			| { videoId?: string; intervalMs?: number | null }
+			| undefined;
+		pushRing(current.presented, {
+			at: performance.now(),
+			videoId: detail?.videoId ?? "unknown",
+			intervalMs:
+				typeof detail?.intervalMs === "number" ? detail.intervalMs : null,
+		});
+	});
+
+	for (const type of MEDIA_EVENT_TYPES) {
+		document.addEventListener(
+			type,
+			(event) => {
+				const current = state;
+				if (!current) return;
+				const target = event.target;
+				if (!(target instanceof HTMLVideoElement)) return;
+				pushRing(current.mediaEvents, {
+					at: performance.now(),
+					type,
+					videoId: target.getAttribute("data-video-id") ?? "unknown",
+					src: srcKind(target.currentSrc || target.src || ""),
+				});
+			},
+			true
+		);
+	}
+
+	try {
+		const observer = new PerformanceObserver((list) => {
+			const current = state;
+			if (!current) return;
+			for (const entry of list.getEntries()) {
+				current.longTaskTotalCount++;
+				pushRing(current.longTasks, {
+					at: entry.startTime,
+					durationMs: entry.duration,
+				});
+			}
+		});
+		observer.observe({ entryTypes: ["longtask"] });
+	} catch {
+		// longtask observer unsupported — diagnostics still useful without it.
+	}
+
+	(
+		window as unknown as {
+			__qcutPlaybackDiagnostics?: {
+				snapshot: () => PlaybackDiagnosticsSnapshot;
+				reset: () => void;
+			};
+		}
+	).__qcutPlaybackDiagnostics = {
+		snapshot: buildSnapshot,
+		reset: resetCollector,
+	};
+}

--- a/qcut/apps/web/src/lib/debug/playback-diagnostics.ts
+++ b/qcut/apps/web/src/lib/debug/playback-diagnostics.ts
@@ -94,6 +94,7 @@ export interface PlaybackDiagnosticsSnapshot {
 	lastClockTickAt: number | null;
 	longTasks: LongTaskRecord[];
 	longTaskTotalCount: number;
+	longTaskTotalDurationMs: number;
 	mediaEvents: MediaEventRecord[];
 	previewRenderTimestamps: number[];
 	previewRenderTotalCount: number;
@@ -109,6 +110,7 @@ interface CollectorState {
 	lastClockTickAt: number | null;
 	longTasks: RingBuffer<LongTaskRecord>;
 	longTaskTotalCount: number;
+	longTaskTotalDurationMs: number;
 	mediaEvents: RingBuffer<MediaEventRecord>;
 	renderTimestamps: RingBuffer<number>;
 	renderTotalCount: number;
@@ -224,6 +226,7 @@ function buildSnapshot(): PlaybackDiagnosticsSnapshot {
 		lastClockTickAt: current.lastClockTickAt,
 		longTasks: [...current.longTasks.values],
 		longTaskTotalCount: current.longTaskTotalCount,
+		longTaskTotalDurationMs: current.longTaskTotalDurationMs,
 		mediaEvents: [...current.mediaEvents.values],
 		previewRenderTimestamps: [...current.renderTimestamps.values],
 		previewRenderTotalCount: current.renderTotalCount,
@@ -241,6 +244,7 @@ function resetCollector(): void {
 	state.lastClockTickAt = null;
 	state.longTasks.values = [];
 	state.longTaskTotalCount = 0;
+	state.longTaskTotalDurationMs = 0;
 	state.mediaEvents.values = [];
 	state.renderTimestamps.values = [];
 	state.renderTotalCount = 0;
@@ -256,6 +260,7 @@ export function installPlaybackDiagnostics(): void {
 		lastClockTickAt: null,
 		longTasks: { values: [], capacity: LONG_TASK_RING_SIZE },
 		longTaskTotalCount: 0,
+		longTaskTotalDurationMs: 0,
 		mediaEvents: { values: [], capacity: MEDIA_EVENT_RING_SIZE },
 		renderTimestamps: { values: [], capacity: RENDER_RING_SIZE },
 		renderTotalCount: 0,
@@ -315,6 +320,7 @@ export function installPlaybackDiagnostics(): void {
 			if (!current) return;
 			for (const entry of list.getEntries()) {
 				current.longTaskTotalCount++;
+				current.longTaskTotalDurationMs += entry.duration;
 				pushRing(current.longTasks, {
 					at: entry.startTime,
 					durationMs: entry.duration,

--- a/qcut/apps/web/src/lib/media/media-source.ts
+++ b/qcut/apps/web/src/lib/media/media-source.ts
@@ -1,16 +1,48 @@
+import { platform } from "@qcut/platform-core";
+
 const CSP_ALLOWED = new Set(["fal.media", "v3.fal.media", "v3b.fal.media"]);
 
 export type VideoSource =
-	| { file: File; type: "file" }
+	| {
+			file: File;
+			type: "file";
+			/**
+			 * `app://local-media/…` URL streaming the same media from disk with
+			 * Range support. Preferred over a blob URL when present — the video
+			 * element then reads from disk instead of the in-memory File. Players
+			 * fall back to the blob path when the protocol source errors (e.g.
+			 * the extracted temp file was cleaned up).
+			 */
+			protocolSrc?: string;
+	  }
 	| { src: string; type: "remote" }
 	| null;
+
+/** Builds the `app://local-media` streaming URL for an absolute disk path. */
+export function localMediaUrlForPath(localPath: string): string {
+	const bytes = new TextEncoder().encode(localPath);
+	let binary = "";
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	const token = btoa(binary)
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replace(/=+$/, "");
+	return `app://local-media/${token}`;
+}
 
 export function getVideoSource(mediaItem: {
 	file?: File;
 	url?: string;
+	localPath?: string;
 }): VideoSource {
 	if (mediaItem.file) {
-		return { file: mediaItem.file, type: "file" };
+		const protocolSrc =
+			mediaItem.localPath && platform().isElectron
+				? localMediaUrlForPath(mediaItem.localPath)
+				: undefined;
+		return { file: mediaItem.file, type: "file", protocolSrc };
 	}
 
 	if (mediaItem.url) {

--- a/qcut/apps/web/src/lib/preview/__tests__/preview-quality.test.ts
+++ b/qcut/apps/web/src/lib/preview/__tests__/preview-quality.test.ts
@@ -85,7 +85,9 @@ describe("preview quality options", () => {
 		).toBe("original");
 	});
 
-	it("uses proxy automatically for high-resolution or effect-heavy clips", () => {
+	it("keeps high-resolution clips on the original source until the runtime downgrades", () => {
+		// Resolution alone no longer forces a proxy — the playback health
+		// monitor engages one (via runtimeQuality) only on measured pressure.
 		expect(
 			resolveEffectivePreviewQualityOption({
 				quality: "auto",
@@ -93,15 +95,19 @@ describe("preview quality options", () => {
 				sourceHeight: 2160,
 				hasEnhancements: false,
 			}).value
-		).toBe("smooth");
+		).toBe("original");
 		expect(
 			resolveEffectivePreviewQualityOption({
 				quality: "auto",
-				sourceWidth: 1920,
-				sourceHeight: 1080,
+				sourceWidth: 3840,
+				sourceHeight: 2160,
+				runtimeQuality: "smooth",
 				hasEnhancements: false,
 			}).value
-		).toBe("clear");
+		).toBe("smooth");
+	});
+
+	it("uses the proxy automatically for enhancement-bearing clips", () => {
 		expect(
 			resolveEffectivePreviewQualityOption({
 				quality: "auto",

--- a/qcut/apps/web/src/lib/preview/__tests__/preview-smooth-time.test.ts
+++ b/qcut/apps/web/src/lib/preview/__tests__/preview-smooth-time.test.ts
@@ -72,12 +72,7 @@ function makeNeedParams(
 		fps: 30,
 		zoomActive: false,
 		cursorOverlayActive: false,
-		previewQuality: "original",
-		runtimePreviewQuality: null,
-		canvasWidth: 1920,
-		canvasHeight: 1080,
 		hasElementEffects: () => false,
-		getMediaInfo: () => ({ type: "video", width: 1280, height: 720 }),
 		jianyingPrefetchWindows: [],
 		...overrides,
 	};
@@ -186,24 +181,13 @@ describe("resolvePreviewSmoothTimeNeed", () => {
 		).toMatchObject({ reason: "element-effects" });
 	});
 
-	it("turns on when the effective quality forces a playback proxy", () => {
-		expect(
-			resolvePreviewSmoothTimeNeed(
-				makeNeedParams({
-					previewQuality: "auto",
-					getMediaInfo: () => ({ type: "video", width: 3840, height: 2160 }),
-				})
-			)
-		).toMatchObject({ reason: "playback-proxy" });
-		// Small sources at auto quality stay on the direct source.
-		expect(
-			resolvePreviewSmoothTimeNeed(
-				makeNeedParams({
-					previewQuality: "auto",
-					getMediaInfo: () => ({ type: "video", width: 1280, height: 720 }),
-				})
-			)
-		).toMatchObject({ needsSmoothTime: false });
+	it("stays off for plain high-resolution video (proxy advances via events)", () => {
+		// Proxy-backed playback no longer forces per-frame renders: the chunk
+		// window is advanced by useVideoEnhancementProxyWindow from
+		// playback-update events instead of rendered time.
+		expect(resolvePreviewSmoothTimeNeed(makeNeedParams())).toMatchObject({
+			needsSmoothTime: false,
+		});
 	});
 
 	it("ignores hidden tracks and out-of-range elements", () => {

--- a/qcut/apps/web/src/lib/preview/__tests__/preview-smooth-time.test.ts
+++ b/qcut/apps/web/src/lib/preview/__tests__/preview-smooth-time.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it } from "vitest";
+import type {
+	MediaElement,
+	TextElement,
+	TimelineTrack,
+} from "@/types/timeline";
+import {
+	findJianyingPrefetchWindowIndex,
+	resolveJianyingTransitionPrefetchWindows,
+	resolvePreviewSmoothTimeNeed,
+	timelineElementNeedsSmoothTime,
+} from "../preview-smooth-time";
+
+function makeMediaElement(overrides: Partial<MediaElement> = {}): MediaElement {
+	return {
+		id: "media-1",
+		name: "clip",
+		type: "media",
+		mediaId: "item-1",
+		startTime: 0,
+		duration: 10,
+		trimStart: 0,
+		trimEnd: 0,
+		...overrides,
+	};
+}
+
+function makeTextElement(overrides: Partial<TextElement> = {}): TextElement {
+	return {
+		id: "text-1",
+		name: "text",
+		type: "text",
+		content: "hello",
+		startTime: 0,
+		duration: 10,
+		trimStart: 0,
+		trimEnd: 0,
+		fontSize: 24,
+		fontFamily: "Arial",
+		color: "#fff",
+		backgroundColor: "transparent",
+		textAlign: "center",
+		fontWeight: "normal",
+		fontStyle: "normal",
+		textDecoration: "none",
+		x: 0,
+		y: 0,
+		rotation: 0,
+		opacity: 1,
+		...overrides,
+	} as TextElement;
+}
+
+function makeMediaTrack(overrides: Partial<TimelineTrack> = {}): TimelineTrack {
+	return {
+		id: "track-1",
+		name: "Track",
+		type: "media",
+		elements: [makeMediaElement()],
+		...overrides,
+	};
+}
+
+function makeNeedParams(
+	overrides: Partial<Parameters<typeof resolvePreviewSmoothTimeNeed>[0]> = {}
+): Parameters<typeof resolvePreviewSmoothTimeNeed>[0] {
+	const tracks = overrides.tracks ?? [makeMediaTrack()];
+	return {
+		tracks,
+		transitionTracks: tracks,
+		time: 2,
+		fps: 30,
+		zoomActive: false,
+		cursorOverlayActive: false,
+		previewQuality: "original",
+		runtimePreviewQuality: null,
+		canvasWidth: 1920,
+		canvasHeight: 1080,
+		hasElementEffects: () => false,
+		getMediaInfo: () => ({ type: "video", width: 1280, height: 720 }),
+		jianyingPrefetchWindows: [],
+		...overrides,
+	};
+}
+
+describe("timelineElementNeedsSmoothTime", () => {
+	it("treats a plain media clip as static", () => {
+		expect(
+			timelineElementNeedsSmoothTime({ element: makeMediaElement() })
+		).toBe(false);
+	});
+
+	it("flags keyframed media", () => {
+		expect(
+			timelineElementNeedsSmoothTime({
+				element: makeMediaElement({
+					keyframes: {
+						opacity: [{ id: "k1", frame: 0, value: 1, easing: "linear" }],
+					},
+				}),
+			})
+		).toBe(true);
+	});
+
+	it("flags media entrance animations but not 'none'", () => {
+		expect(
+			timelineElementNeedsSmoothTime({
+				element: makeMediaElement({ animationInType: "fade" }),
+			})
+		).toBe(true);
+		expect(
+			timelineElementNeedsSmoothTime({
+				element: makeMediaElement({ animationInType: "none" }),
+			})
+		).toBe(false);
+	});
+
+	it("flags mask tracking and custom cutouts", () => {
+		expect(
+			timelineElementNeedsSmoothTime({
+				element: makeMediaElement({
+					masks: [
+						{
+							id: "m1",
+							type: "rectangle",
+							tracking: { sourceMaskId: "m0" },
+						} as unknown as NonNullable<MediaElement["masks"]>[number],
+					],
+				}),
+			})
+		).toBe(true);
+	});
+
+	it("treats plain text as static and animated text as smooth", () => {
+		expect(timelineElementNeedsSmoothTime({ element: makeTextElement() })).toBe(
+			false
+		);
+		expect(
+			timelineElementNeedsSmoothTime({
+				element: makeTextElement({ animationType: "fade" }),
+			})
+		).toBe(true);
+		expect(
+			timelineElementNeedsSmoothTime({
+				element: makeTextElement({ trackingTargetId: "media-1" }),
+			})
+		).toBe(true);
+	});
+});
+
+describe("resolvePreviewSmoothTimeNeed", () => {
+	it("returns not-needed for a static clip at original quality", () => {
+		expect(resolvePreviewSmoothTimeNeed(makeNeedParams())).toEqual({
+			needsSmoothTime: false,
+			reason: null,
+		});
+	});
+
+	it("turns on for screen-recording zoom and cursor overlays", () => {
+		expect(
+			resolvePreviewSmoothTimeNeed(makeNeedParams({ zoomActive: true }))
+		).toMatchObject({ needsSmoothTime: true, reason: "zoom-region" });
+		expect(
+			resolvePreviewSmoothTimeNeed(
+				makeNeedParams({ cursorOverlayActive: true })
+			)
+		).toMatchObject({ needsSmoothTime: true, reason: "cursor-overlay" });
+	});
+
+	it("turns on while inside a jianying prefetch window", () => {
+		expect(
+			resolvePreviewSmoothTimeNeed(
+				makeNeedParams({
+					jianyingPrefetchWindows: [{ start: 1, end: 6 }],
+					time: 2,
+				})
+			)
+		).toMatchObject({ reason: "jianying-transition-prefetch" });
+	});
+
+	it("turns on for elements with active effects", () => {
+		expect(
+			resolvePreviewSmoothTimeNeed(
+				makeNeedParams({ hasElementEffects: () => true })
+			)
+		).toMatchObject({ reason: "element-effects" });
+	});
+
+	it("turns on when the effective quality forces a playback proxy", () => {
+		expect(
+			resolvePreviewSmoothTimeNeed(
+				makeNeedParams({
+					previewQuality: "auto",
+					getMediaInfo: () => ({ type: "video", width: 3840, height: 2160 }),
+				})
+			)
+		).toMatchObject({ reason: "playback-proxy" });
+		// Small sources at auto quality stay on the direct source.
+		expect(
+			resolvePreviewSmoothTimeNeed(
+				makeNeedParams({
+					previewQuality: "auto",
+					getMediaInfo: () => ({ type: "video", width: 1280, height: 720 }),
+				})
+			)
+		).toMatchObject({ needsSmoothTime: false });
+	});
+
+	it("ignores hidden tracks and out-of-range elements", () => {
+		const animated = makeMediaElement({ animationInType: "fade" });
+		expect(
+			resolvePreviewSmoothTimeNeed(
+				makeNeedParams({
+					tracks: [makeMediaTrack({ elements: [animated], hidden: true })],
+					transitionTracks: [],
+				})
+			)
+		).toMatchObject({ needsSmoothTime: false });
+		expect(
+			resolvePreviewSmoothTimeNeed(
+				makeNeedParams({
+					tracks: [
+						makeMediaTrack({
+							elements: [makeMediaElement({ startTime: 20, ...{} })],
+						}),
+					],
+					transitionTracks: [],
+					time: 2,
+				})
+			)
+		).toMatchObject({ needsSmoothTime: false });
+	});
+
+	it("turns on inside an active clip transition window", () => {
+		const fromElement = makeMediaElement({
+			id: "from",
+			startTime: 0,
+			duration: 5,
+		});
+		const toElement = makeMediaElement({
+			id: "to",
+			mediaId: "item-2",
+			startTime: 5,
+			duration: 5,
+		});
+		const track = makeMediaTrack({
+			elements: [fromElement, toElement],
+			transitions: [
+				{
+					id: "t1",
+					fromElementId: "from",
+					toElementId: "to",
+					presetId: "fade",
+					type: "dissolve",
+					duration: 1,
+					easing: "linear",
+				},
+			],
+		});
+		const params = makeNeedParams({
+			tracks: [track],
+			transitionTracks: [track],
+		});
+		expect(resolvePreviewSmoothTimeNeed({ ...params, time: 5 })).toMatchObject({
+			reason: "clip-transition",
+		});
+		expect(resolvePreviewSmoothTimeNeed({ ...params, time: 2 })).toMatchObject({
+			needsSmoothTime: false,
+		});
+	});
+});
+
+describe("jianying prefetch windows", () => {
+	it("builds windows with prefetch lead time for jianying-local transitions", () => {
+		const track = makeMediaTrack({
+			elements: [
+				makeMediaElement({ id: "from", startTime: 0, duration: 10 }),
+				makeMediaElement({
+					id: "to",
+					mediaId: "item-2",
+					startTime: 10,
+					duration: 10,
+				}),
+			],
+			transitions: [
+				{
+					id: "t1",
+					fromElementId: "from",
+					toElementId: "to",
+					presetId: "jy",
+					engine: "jianying-local",
+					packageHash: "a".repeat(32),
+					type: "dissolve",
+					duration: 1,
+					easing: "linear",
+				},
+			],
+		});
+		const windows = resolveJianyingTransitionPrefetchWindows({
+			tracks: [track],
+			fps: 30,
+		});
+		expect(windows).toHaveLength(1);
+		expect(windows[0].start).toBeLessThan(windows[0].end);
+		// Prefetch lead time reaches ahead of the transition window itself.
+		expect(windows[0].start).toBeCloseTo(9.5 - 4, 5);
+
+		expect(
+			findJianyingPrefetchWindowIndex({ windows, time: windows[0].start + 0.1 })
+		).toBe(0);
+		expect(findJianyingPrefetchWindowIndex({ windows, time: 0 })).toBe(-1);
+	});
+
+	it("ignores non-jianying transitions", () => {
+		const track = makeMediaTrack({
+			elements: [
+				makeMediaElement({ id: "from", startTime: 0, duration: 5 }),
+				makeMediaElement({
+					id: "to",
+					mediaId: "item-2",
+					startTime: 5,
+					duration: 5,
+				}),
+			],
+			transitions: [
+				{
+					id: "t1",
+					fromElementId: "from",
+					toElementId: "to",
+					presetId: "fade",
+					type: "dissolve",
+					duration: 1,
+					easing: "linear",
+				},
+			],
+		});
+		expect(
+			resolveJianyingTransitionPrefetchWindows({ tracks: [track], fps: 30 })
+		).toHaveLength(0);
+	});
+});

--- a/qcut/apps/web/src/lib/preview/__tests__/preview-smooth-time.test.ts
+++ b/qcut/apps/web/src/lib/preview/__tests__/preview-smooth-time.test.ts
@@ -126,6 +126,29 @@ describe("timelineElementNeedsSmoothTime", () => {
 		).toBe(true);
 	});
 
+	it("ignores disabled default custom cutouts but flags enabled ones", () => {
+		const disabledCutout = {
+			enabled: false,
+			applyStrokes: true,
+			strokes: [],
+			status: "idle",
+		} as unknown as MediaElement["customCutout"];
+		expect(
+			timelineElementNeedsSmoothTime({
+				element: makeMediaElement({ customCutout: disabledCutout }),
+			})
+		).toBe(false);
+		const enabledCutout = {
+			...disabledCutout,
+			enabled: true,
+		} as unknown as MediaElement["customCutout"];
+		expect(
+			timelineElementNeedsSmoothTime({
+				element: makeMediaElement({ customCutout: enabledCutout }),
+			})
+		).toBe(true);
+	});
+
 	it("treats plain text as static and animated text as smooth", () => {
 		expect(timelineElementNeedsSmoothTime({ element: makeTextElement() })).toBe(
 			false

--- a/qcut/apps/web/src/lib/preview/preview-quality.ts
+++ b/qcut/apps/web/src/lib/preview/preview-quality.ts
@@ -52,8 +52,6 @@ export function buildPreviewFrameCacheIdentity({
 	return `preview-quality:${quality}:viewport:${normalizedWidth}x${normalizedHeight}`;
 }
 
-const HIGH_RESOLUTION_EDGE = 2160;
-const LARGE_RESOLUTION_EDGE = 1440;
 const SMOOTH_FRAME_INTERVAL_MS = 45;
 const LOW_FRAME_INTERVAL_MS = 70;
 const SMOOTH_STUTTER_COUNT = 3;
@@ -112,8 +110,6 @@ export function getPreviewQualityOption({
 export function resolveEffectivePreviewQualityOption({
 	quality,
 	runtimeQuality,
-	sourceWidth,
-	sourceHeight,
 	hasEnhancements,
 }: ResolveEffectivePreviewQualityOptionParams): PreviewQualityOption {
 	const selectedOption = getPreviewQualityOption({ quality });
@@ -128,16 +124,15 @@ export function resolveEffectivePreviewQualityOption({
 		return getPreviewQualityOption({ quality: runtimeQuality });
 	}
 
-	const longestEdge = Math.max(
-		Number.isFinite(sourceWidth) ? sourceWidth : 0,
-		Number.isFinite(sourceHeight) ? sourceHeight : 0
-	);
-	if (longestEdge >= HIGH_RESOLUTION_EDGE) {
-		return getPreviewQualityOption({ quality: "smooth" });
-	}
-	if (longestEdge >= LARGE_RESOLUTION_EDGE || hasEnhancements) {
+	// Enhancements are rendered by the ffmpeg proxy, so they always need it.
+	if (hasEnhancements) {
 		return getPreviewQualityOption({ quality: "clear" });
 	}
+	// Resolution no longer forces a proxy up front: playback starts on the
+	// original source and the runtime health monitor downgrades to a proxy
+	// preset (resolveRuntimePreviewQualityDecision) only when real frame
+	// pressure is measured. Machines that decode high-res sources directly
+	// skip the proxy — and its chunk-switch churn — entirely.
 	return getPreviewQualityOption({ quality: "original" });
 }
 

--- a/qcut/apps/web/src/lib/preview/preview-smooth-time.ts
+++ b/qcut/apps/web/src/lib/preview/preview-smooth-time.ts
@@ -1,0 +1,323 @@
+/**
+ * Preview smooth-time gating.
+ *
+ * During playback the preview panel can subscribe to per-frame
+ * "playback-update" events and re-render the whole React preview tree every
+ * animation frame ("smooth time"). That is required for content that animates
+ * through React (keyframes, transitions, captions, Remotion, screen-recording
+ * zoom, chunked playback proxies), but it is pure overhead for static clips.
+ *
+ * These helpers decide whether anything currently on the canvas actually
+ * needs per-frame React updates. When nothing does, the preview panel skips
+ * the per-frame subscription entirely and playback runs without re-rendering
+ * React — video/audio elements keep syncing through lightweight window
+ * events (see playback-store).
+ */
+
+import { resolveActiveAudioCrossfadePreview } from "@/lib/audio/audio-crossfade-preview";
+import { resolveEffectivePreviewQualityOption } from "@/lib/preview/preview-quality";
+import { getTimelineElementDuration } from "@/lib/timeline";
+import { resolveActiveClipTransitionPreview } from "@/lib/transitions/clip-transition-preview";
+import { JIANYING_TIMELINE_PREFETCH_SECONDS } from "@/lib/transitions/jianying-timeline-preview";
+import { hasMediaEnhancements } from "@/lib/video/video-properties";
+import { getMediaTimelineDuration } from "@/lib/video/video-timing";
+import type { PreviewQualityPreset } from "@/types/playback";
+import {
+	resolveClipTransition,
+	type MediaElement,
+	type StickerElement,
+	type TextElement,
+	type TimelineElement,
+	type TimelineTrack,
+} from "@/types/timeline";
+
+export interface PreviewSmoothTimeNeed {
+	needsSmoothTime: boolean;
+	/** Diagnostic label describing what forced per-frame rendering. */
+	reason: string | null;
+}
+
+export const PREVIEW_SMOOTH_TIME_NOT_NEEDED: PreviewSmoothTimeNeed = {
+	needsSmoothTime: false,
+	reason: null,
+};
+
+export interface JianyingPrefetchWindow {
+	start: number;
+	end: number;
+}
+
+/** Minimal media info the gate needs to mirror the playback-proxy decision. */
+export interface PreviewSmoothTimeMediaInfo {
+	type: string;
+	width?: number;
+	height?: number;
+}
+
+function need(reason: string): PreviewSmoothTimeNeed {
+	return { needsSmoothTime: true, reason };
+}
+
+function hasAnyKeyframes(
+	keyframes: Partial<Record<string, readonly unknown[]>> | undefined
+): boolean {
+	if (!keyframes) return false;
+	for (const list of Object.values(keyframes)) {
+		if (Array.isArray(list) && list.length > 0) return true;
+	}
+	return false;
+}
+
+function isActiveAnimationType(type: string | undefined): boolean {
+	return Boolean(type && type !== "none");
+}
+
+function mediaElementNeedsSmoothTime(element: MediaElement): boolean {
+	if (hasAnyKeyframes(element.keyframes)) return true;
+	if (
+		isActiveAnimationType(element.animationInType) ||
+		isActiveAnimationType(element.animationOutType) ||
+		isActiveAnimationType(element.comboAnimationType)
+	) {
+		return true;
+	}
+	const masks = [
+		...(element.masks ?? []),
+		...(element.mask ? [element.mask] : []),
+	];
+	for (const mask of masks) {
+		if (mask.enabled === false) continue;
+		if (hasAnyKeyframes(mask.keyframes) || mask.tracking) return true;
+	}
+	// Custom cutouts are frame-indexed; their style depends on the playhead.
+	if (element.customCutout) return true;
+	if (
+		element.chromaKey?.enabled &&
+		hasAnyKeyframes(element.chromaKey.keyframes)
+	) {
+		return true;
+	}
+	const color = element.color;
+	if (color?.enabled) {
+		if (
+			hasAnyKeyframes(color.keyframes) ||
+			hasAnyKeyframes(color.curveShapeKeyframes)
+		) {
+			return true;
+		}
+		// Animated film grain reseeds from the frame index each frame.
+		if (color.basic.enabled && color.basic.grain !== 0) return true;
+	}
+	return false;
+}
+
+function textElementNeedsSmoothTime(element: TextElement): boolean {
+	return (
+		isActiveAnimationType(element.animationType) ||
+		hasAnyKeyframes(element.keyframes) ||
+		Boolean(element.trackingTargetId) ||
+		// Jianying text playback overlays sync to the smooth clock.
+		Boolean(element.jianyingTextStyle)
+	);
+}
+
+function stickerElementNeedsSmoothTime(element: StickerElement): boolean {
+	return (
+		isActiveAnimationType(element.animationInType) ||
+		isActiveAnimationType(element.animationOutType) ||
+		isActiveAnimationType(element.animationLoopType) ||
+		hasAnyKeyframes(element.keyframes) ||
+		Boolean(element.tracking)
+	);
+}
+
+/**
+ * Whether an element's preview rendering visibly changes with the playhead
+ * within a single clip (i.e. between active-set boundary crossings).
+ */
+export function timelineElementNeedsSmoothTime({
+	element,
+}: {
+	element: TimelineElement;
+}): boolean {
+	switch (element.type) {
+		case "media":
+			return mediaElementNeedsSmoothTime(element);
+		case "text":
+			return textElementNeedsSmoothTime(element);
+		case "sticker":
+			return stickerElementNeedsSmoothTime(element);
+		case "captions":
+			// Word-level highlighting follows the playhead continuously.
+			return true;
+		case "markdown":
+			return element.scrollMode === "auto-scroll";
+		case "remotion":
+			// The composition's externalFrame must advance every frame.
+			return true;
+		case "hyperframes":
+			// Composition time is pushed to the embedded player per update.
+			return true;
+		case "effect":
+			return true;
+		case "adjustment":
+			// Adjustment layers already resolve against the coarse store time.
+			return false;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Timeline windows (with prefetch lead time) around jianying-local
+ * transitions. While the playhead is inside one, per-frame rendering stays on
+ * so the proxy prefetch and overlay keep resolving against fresh time.
+ */
+export function resolveJianyingTransitionPrefetchWindows({
+	tracks,
+	fps,
+}: {
+	tracks: TimelineTrack[];
+	fps: number;
+}): JianyingPrefetchWindow[] {
+	const windows: JianyingPrefetchWindow[] = [];
+	for (const track of tracks) {
+		if (track.type !== "media" || track.hidden) continue;
+		for (const transition of track.transitions ?? []) {
+			if (transition.engine !== "jianying-local") continue;
+			const resolved = resolveClipTransition({
+				track,
+				transition,
+				getElementDuration: ({ element }) =>
+					getTimelineElementDuration({ element, fps }),
+			});
+			if (!resolved) continue;
+			windows.push({
+				start: resolved.windowStart - JIANYING_TIMELINE_PREFETCH_SECONDS,
+				end: resolved.windowEnd,
+			});
+		}
+	}
+	return windows;
+}
+
+export function findJianyingPrefetchWindowIndex({
+	windows,
+	time,
+}: {
+	windows: readonly JianyingPrefetchWindow[];
+	time: number;
+}): number {
+	for (let index = 0; index < windows.length; index++) {
+		const window = windows[index];
+		if (time >= window.start && time < window.end) return index;
+	}
+	return -1;
+}
+
+function previewElementDuration(element: TimelineElement): number {
+	return element.type === "media"
+		? getMediaTimelineDuration(element)
+		: element.duration - element.trimStart - element.trimEnd;
+}
+
+export interface ResolvePreviewSmoothTimeNeedParams {
+	/** Expanded render tracks (compound children included) for element scans. */
+	tracks: TimelineTrack[];
+	/** Raw timeline tracks, matching the transition/crossfade resolvers. */
+	transitionTracks: TimelineTrack[];
+	time: number;
+	fps: number;
+	zoomActive: boolean;
+	cursorOverlayActive: boolean;
+	previewQuality: PreviewQualityPreset;
+	runtimePreviewQuality: PreviewQualityPreset | null;
+	canvasWidth: number;
+	canvasHeight: number;
+	hasElementEffects: (elementId: string) => boolean;
+	getMediaInfo: (mediaId: string) => PreviewSmoothTimeMediaInfo | undefined;
+	jianyingPrefetchWindows: readonly JianyingPrefetchWindow[];
+}
+
+/**
+ * Decides whether the preview needs per-frame React updates at `time`.
+ * Called only on renders (active-set boundary crossings, seeks, pauses),
+ * never per animation frame.
+ */
+export function resolvePreviewSmoothTimeNeed({
+	tracks,
+	transitionTracks,
+	time,
+	fps,
+	zoomActive,
+	cursorOverlayActive,
+	previewQuality,
+	runtimePreviewQuality,
+	canvasWidth,
+	canvasHeight,
+	hasElementEffects,
+	getMediaInfo,
+	jianyingPrefetchWindows,
+}: ResolvePreviewSmoothTimeNeedParams): PreviewSmoothTimeNeed {
+	if (zoomActive) return need("zoom-region");
+	if (cursorOverlayActive) return need("cursor-overlay");
+	if (
+		findJianyingPrefetchWindowIndex({
+			windows: jianyingPrefetchWindows,
+			time,
+		}) >= 0
+	) {
+		return need("jianying-transition-prefetch");
+	}
+
+	for (const track of tracks) {
+		if (track.hidden) continue;
+		for (const element of track.elements) {
+			if (element.hidden) continue;
+			const end = element.startTime + previewElementDuration(element);
+			if (time < element.startTime || time >= end) continue;
+			if (hasElementEffects(element.id)) return need("element-effects");
+			if (timelineElementNeedsSmoothTime({ element })) {
+				return need(`animated-element:${element.type}`);
+			}
+			if (element.type === "media") {
+				const mediaInfo = getMediaInfo(element.mediaId);
+				if (mediaInfo?.type === "video") {
+					const hasEnhancements = element.enhancements
+						? hasMediaEnhancements({ enhancements: element.enhancements })
+						: false;
+					// Enhanced or proxy-forced playback streams from a chunked
+					// proxy whose window advances with the rendered time.
+					if (hasEnhancements) return need("video-enhancements");
+					const qualityOption = resolveEffectivePreviewQualityOption({
+						quality: previewQuality,
+						runtimeQuality: runtimePreviewQuality,
+						sourceWidth: mediaInfo.width ?? canvasWidth,
+						sourceHeight: mediaInfo.height ?? canvasHeight,
+						hasEnhancements,
+					});
+					if (qualityOption.forceProxy) return need("playback-proxy");
+				}
+			}
+		}
+	}
+
+	const transitionPreview = resolveActiveClipTransitionPreview({
+		tracks: transitionTracks,
+		currentTime: time,
+		fps,
+	});
+	if (transitionPreview.statesByElementId.size > 0) {
+		return need("clip-transition");
+	}
+	const crossfadePreview = resolveActiveAudioCrossfadePreview({
+		tracks: transitionTracks,
+		currentTime: time,
+		fps,
+	});
+	if (crossfadePreview.statesByElementId.size > 0) {
+		return need("audio-crossfade");
+	}
+
+	return PREVIEW_SMOOTH_TIME_NOT_NEEDED;
+}

--- a/qcut/apps/web/src/lib/preview/preview-smooth-time.ts
+++ b/qcut/apps/web/src/lib/preview/preview-smooth-time.ts
@@ -5,7 +5,9 @@
  * "playback-update" events and re-render the whole React preview tree every
  * animation frame ("smooth time"). That is required for content that animates
  * through React (keyframes, transitions, captions, Remotion, screen-recording
- * zoom, chunked playback proxies), but it is pure overhead for static clips.
+ * zoom), but it is pure overhead for static clips. Chunked playback proxies
+ * advance their windows from playback events (useVideoEnhancementProxyWindow)
+ * and do not need per-frame renders.
  *
  * These helpers decide whether anything currently on the canvas actually
  * needs per-frame React updates. When nothing does, the preview panel skips
@@ -15,13 +17,10 @@
  */
 
 import { resolveActiveAudioCrossfadePreview } from "@/lib/audio/audio-crossfade-preview";
-import { resolveEffectivePreviewQualityOption } from "@/lib/preview/preview-quality";
 import { getTimelineElementDuration } from "@/lib/timeline";
 import { resolveActiveClipTransitionPreview } from "@/lib/transitions/clip-transition-preview";
 import { JIANYING_TIMELINE_PREFETCH_SECONDS } from "@/lib/transitions/jianying-timeline-preview";
-import { hasMediaEnhancements } from "@/lib/video/video-properties";
 import { getMediaTimelineDuration } from "@/lib/video/video-timing";
-import type { PreviewQualityPreset } from "@/types/playback";
 import {
 	resolveClipTransition,
 	type MediaElement,
@@ -45,13 +44,6 @@ export const PREVIEW_SMOOTH_TIME_NOT_NEEDED: PreviewSmoothTimeNeed = {
 export interface JianyingPrefetchWindow {
 	start: number;
 	end: number;
-}
-
-/** Minimal media info the gate needs to mirror the playback-proxy decision. */
-export interface PreviewSmoothTimeMediaInfo {
-	type: string;
-	width?: number;
-	height?: number;
 }
 
 function need(reason: string): PreviewSmoothTimeNeed {
@@ -230,12 +222,7 @@ export interface ResolvePreviewSmoothTimeNeedParams {
 	fps: number;
 	zoomActive: boolean;
 	cursorOverlayActive: boolean;
-	previewQuality: PreviewQualityPreset;
-	runtimePreviewQuality: PreviewQualityPreset | null;
-	canvasWidth: number;
-	canvasHeight: number;
 	hasElementEffects: (elementId: string) => boolean;
-	getMediaInfo: (mediaId: string) => PreviewSmoothTimeMediaInfo | undefined;
 	jianyingPrefetchWindows: readonly JianyingPrefetchWindow[];
 }
 
@@ -251,12 +238,7 @@ export function resolvePreviewSmoothTimeNeed({
 	fps,
 	zoomActive,
 	cursorOverlayActive,
-	previewQuality,
-	runtimePreviewQuality,
-	canvasWidth,
-	canvasHeight,
 	hasElementEffects,
-	getMediaInfo,
 	jianyingPrefetchWindows,
 }: ResolvePreviewSmoothTimeNeedParams): PreviewSmoothTimeNeed {
 	if (zoomActive) return need("zoom-region");
@@ -279,25 +261,6 @@ export function resolvePreviewSmoothTimeNeed({
 			if (hasElementEffects(element.id)) return need("element-effects");
 			if (timelineElementNeedsSmoothTime({ element })) {
 				return need(`animated-element:${element.type}`);
-			}
-			if (element.type === "media") {
-				const mediaInfo = getMediaInfo(element.mediaId);
-				if (mediaInfo?.type === "video") {
-					const hasEnhancements = element.enhancements
-						? hasMediaEnhancements({ enhancements: element.enhancements })
-						: false;
-					// Enhanced or proxy-forced playback streams from a chunked
-					// proxy whose window advances with the rendered time.
-					if (hasEnhancements) return need("video-enhancements");
-					const qualityOption = resolveEffectivePreviewQualityOption({
-						quality: previewQuality,
-						runtimeQuality: runtimePreviewQuality,
-						sourceWidth: mediaInfo.width ?? canvasWidth,
-						sourceHeight: mediaInfo.height ?? canvasHeight,
-						hasEnhancements,
-					});
-					if (qualityOption.forceProxy) return need("playback-proxy");
-				}
 			}
 		}
 	}

--- a/qcut/apps/web/src/lib/preview/preview-smooth-time.ts
+++ b/qcut/apps/web/src/lib/preview/preview-smooth-time.ts
@@ -81,8 +81,9 @@ function mediaElementNeedsSmoothTime(element: MediaElement): boolean {
 		if (mask.enabled === false) continue;
 		if (hasAnyKeyframes(mask.keyframes) || mask.tracking) return true;
 	}
-	// Custom cutouts are frame-indexed; their style depends on the playhead.
-	if (element.customCutout) return true;
+	// Enabled custom cutouts are frame-indexed; their style depends on the
+	// playhead. Elements carry a disabled default object — ignore it.
+	if (element.customCutout?.enabled) return true;
 	if (
 		element.chromaKey?.enabled &&
 		hasAnyKeyframes(element.chromaKey.keyframes)

--- a/qcut/apps/web/src/lib/transitions/jianying-timeline-preview.ts
+++ b/qcut/apps/web/src/lib/transitions/jianying-timeline-preview.ts
@@ -14,7 +14,10 @@ import {
 } from "@/lib/video/video-timing";
 
 const LOCAL_PACKAGE_HASH_PATTERN = /^[a-f0-9]{32,64}$/;
-const DEFAULT_PREFETCH_SECONDS = 4;
+/** Seconds before a jianying-local transition window in which the preview
+ * proxy prefetch must run; also consumed by preview smooth-time gating. */
+export const JIANYING_TIMELINE_PREFETCH_SECONDS = 4;
+const DEFAULT_PREFETCH_SECONDS = JIANYING_TIMELINE_PREFETCH_SECONDS;
 const MAX_PROXY_DIMENSION = 960;
 const MAX_PROXY_FPS = 30;
 

--- a/qcut/apps/web/src/stores/editor/playback-store.ts
+++ b/qcut/apps/web/src/stores/editor/playback-store.ts
@@ -89,8 +89,17 @@ const startTimer = (store: () => PlaybackStore) => {
 	const storeDuration = store().duration;
 	const actualContentDuration =
 		timelineStore?.getState()?.getTotalDuration() ?? storeDuration;
-	const effectiveDuration =
+	let effectiveDuration =
 		actualContentDuration > 0 ? actualContentDuration : storeDuration;
+	const refreshEffectiveDuration = () => {
+		// Guard against a stale cache: play() can race project hydration and
+		// capture a partial timeline's duration, which would end playback
+		// mid-timeline. Re-check only when the end appears reached.
+		const fresh = timelineStore?.getState()?.getTotalDuration();
+		if (typeof fresh === "number" && fresh > effectiveDuration) {
+			effectiveDuration = fresh;
+		}
+	};
 
 	// Reuse event detail object to reduce GC pressure
 	const eventDetail = { time: 0 };
@@ -98,6 +107,7 @@ const startTimer = (store: () => PlaybackStore) => {
 	let lastUpdate = performance.now();
 	const updateTime = () => {
 		const state = store();
+		if (_mutableCurrentTime >= effectiveDuration) refreshEffectiveDuration();
 		if (!state.isPlaying || _mutableCurrentTime >= effectiveDuration) {
 			return;
 		}
@@ -108,6 +118,7 @@ const startTimer = (store: () => PlaybackStore) => {
 
 		const newTime = _mutableCurrentTime + delta * state.speed;
 
+		if (newTime >= effectiveDuration) refreshEffectiveDuration();
 		if (newTime >= effectiveDuration) {
 			const stopTime = Math.max(0, effectiveDuration - frameOffset);
 			_mutableCurrentTime = stopTime;

--- a/qcut/electron/app-protocol-handler.ts
+++ b/qcut/electron/app-protocol-handler.ts
@@ -29,6 +29,11 @@ import {
 	JIANYING_TEXT_PREVIEW_PROTOCOL_PATH,
 	resolveJianyingTextPreviewFilename,
 } from "./jianying-text-runtime/cache-path.js";
+import {
+	LOCAL_MEDIA_PROTOCOL_PATH,
+	localMediaContentType,
+	resolveLocalMediaFilename,
+} from "./local-media-protocol.js";
 
 export interface RegisterAppProtocolOptions {
 	/** Override the logger — defaults to console. */
@@ -125,6 +130,22 @@ export function registerAppProtocol(
 				return createVideoPreviewProxyResponse({
 					request,
 					filePath: previewPath,
+				});
+			}
+
+			if (pathSegments[0] === LOCAL_MEDIA_PROTOCOL_PATH) {
+				const token = pathSegments[1];
+				if (pathSegments.length !== 2 || !token) {
+					return new Response("Not Found", { status: 404 });
+				}
+				const mediaPath = resolveLocalMediaFilename({ token });
+				if (!mediaPath) {
+					return new Response("Not Found", { status: 404 });
+				}
+				return createVideoPreviewProxyResponse({
+					request,
+					filePath: mediaPath,
+					contentType: localMediaContentType({ filePath: mediaPath }),
 				});
 			}
 

--- a/qcut/electron/claude/http/claude-http-playback-routes.ts
+++ b/qcut/electron/claude/http/claude-http-playback-routes.ts
@@ -15,7 +15,11 @@ export function registerPlaybackDiagnosticsRoutes(
 ): void {
 	router.get("/api/claude/playback/diagnostics", async () => {
 		const snapshot = await options.pullSnapshot();
-		if (!snapshot || typeof snapshot !== "object") {
+		if (
+			!snapshot ||
+			typeof snapshot !== "object" ||
+			(snapshot as { installed?: boolean }).installed !== true
+		) {
 			throw new HttpError(
 				503,
 				"Playback diagnostics collector is not installed (editor not open?)"
@@ -25,7 +29,17 @@ export function registerPlaybackDiagnosticsRoutes(
 	});
 
 	router.post("/api/claude/playback/diagnostics/reset", async () => {
-		await options.resetCollector();
+		const result = await options.resetCollector();
+		if (
+			!result ||
+			typeof result !== "object" ||
+			(result as { installed?: boolean }).installed !== true
+		) {
+			throw new HttpError(
+				503,
+				"Playback diagnostics collector is not installed (editor not open?)"
+			);
+		}
 		return { reset: true };
 	});
 }

--- a/qcut/electron/claude/http/claude-http-playback-routes.ts
+++ b/qcut/electron/claude/http/claude-http-playback-routes.ts
@@ -1,0 +1,60 @@
+import type { Router } from "../utils/http-router.js";
+import { HttpError } from "../utils/http-router.js";
+
+/**
+ * Real-time playback diagnostics pulled from the renderer's
+ * window.__qcutPlaybackDiagnostics collector (installed by the preview
+ * panel). Consumed by scripts/playback-diagnose.ts.
+ */
+export function registerPlaybackDiagnosticsRoutes(
+	router: Router,
+	options: {
+		pullSnapshot: () => Promise<unknown>;
+		resetCollector: () => Promise<unknown>;
+	}
+): void {
+	router.get("/api/claude/playback/diagnostics", async () => {
+		const snapshot = await options.pullSnapshot();
+		if (!snapshot || typeof snapshot !== "object") {
+			throw new HttpError(
+				503,
+				"Playback diagnostics collector is not installed (editor not open?)"
+			);
+		}
+		return snapshot;
+	});
+
+	router.post("/api/claude/playback/diagnostics/reset", async () => {
+		await options.resetCollector();
+		return { reset: true };
+	});
+}
+
+const SNAPSHOT_SCRIPT = `(() => {
+	const collector = window.__qcutPlaybackDiagnostics;
+	if (!collector) return { installed: false };
+	try {
+		return collector.snapshot();
+	} catch (error) {
+		return { installed: false, error: String(error) };
+	}
+})()`;
+
+const RESET_SCRIPT = `(() => {
+	const collector = window.__qcutPlaybackDiagnostics;
+	if (!collector) return { installed: false };
+	collector.reset();
+	return { installed: true };
+})()`;
+
+export async function pullPlaybackDiagnosticsFromRenderer(win: {
+	webContents: { executeJavaScript: (script: string) => Promise<unknown> };
+}): Promise<unknown> {
+	return await win.webContents.executeJavaScript(SNAPSHOT_SCRIPT);
+}
+
+export async function resetPlaybackDiagnosticsInRenderer(win: {
+	webContents: { executeJavaScript: (script: string) => Promise<unknown> };
+}): Promise<unknown> {
+	return await win.webContents.executeJavaScript(RESET_SCRIPT);
+}

--- a/qcut/electron/claude/http/claude-http-server.ts
+++ b/qcut/electron/claude/http/claude-http-server.ts
@@ -75,6 +75,11 @@ import {
 } from "./claude-http-jianying-project-export-routes.js";
 import { requestQCutJianyingProjectExportFromRenderer } from "../handlers/qcut-jianying-project-export-handler.js";
 import { registerSnapshotRoutes } from "./claude-http-snapshot-routes.js";
+import {
+	pullPlaybackDiagnosticsFromRenderer,
+	registerPlaybackDiagnosticsRoutes,
+	resetPlaybackDiagnosticsInRenderer,
+} from "./claude-http-playback-routes.js";
 import { registerAgentPointerRoutes } from "./claude-http-pointer-routes.js";
 import {
 	checkEditorSnapshotRef,
@@ -298,6 +303,10 @@ export function startClaudeHTTPServer(
 		selectSnapshotRef: (request) =>
 			selectEditorSnapshotRef(getWindow(), request),
 		checkSnapshotRef: (request) => checkEditorSnapshotRef(getWindow(), request),
+	});
+	registerPlaybackDiagnosticsRoutes(router, {
+		pullSnapshot: () => pullPlaybackDiagnosticsFromRenderer(getWindow()),
+		resetCollector: () => resetPlaybackDiagnosticsInRenderer(getWindow()),
 	});
 	registerAgentPointerRoutes(router, {
 		getState: async () => pointerController().getState(),

--- a/qcut/electron/local-media-protocol.ts
+++ b/qcut/electron/local-media-protocol.ts
@@ -1,0 +1,93 @@
+/**
+ * Local media streaming over the `app://` protocol.
+ *
+ * `app://local-media/<base64url(absolute path)>` streams a media file from
+ * disk with Range support, so the renderer can play project media without
+ * routing the whole file through IPC into a blob. Paths are only served when
+ * their realpath lives under an allowed root (the qcut-videos temp
+ * extraction dir or the app's userData tree), which keeps the route from
+ * becoming an arbitrary-file read.
+ *
+ * @module electron/local-media-protocol
+ */
+
+import { app } from "electron";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export const LOCAL_MEDIA_PROTOCOL_PATH = "local-media";
+
+const CONTENT_TYPES: Record<string, string> = {
+	".mp4": "video/mp4",
+	".m4v": "video/mp4",
+	".mov": "video/quicktime",
+	".webm": "video/webm",
+	".mkv": "video/x-matroska",
+	".avi": "video/x-msvideo",
+	".mp3": "audio/mpeg",
+	".wav": "audio/wav",
+	".m4a": "audio/mp4",
+	".aac": "audio/aac",
+	".ogg": "audio/ogg",
+	".flac": "audio/flac",
+};
+
+export function localMediaContentType({
+	filePath,
+}: {
+	filePath: string;
+}): string {
+	return (
+		CONTENT_TYPES[path.extname(filePath).toLowerCase()] ??
+		"application/octet-stream"
+	);
+}
+
+function allowedRoots(): string[] {
+	// Media directories only — never the userData root itself, which holds
+	// cookies, auth caches and API-key stores the renderer must not read.
+	return [
+		path.join(app.getPath("temp"), "qcut-videos"),
+		path.join(app.getPath("documents"), "QCut", "Projects"),
+		path.join(app.getPath("userData"), "projects"),
+	];
+}
+
+function isUnderRoot({ real, root }: { real: string; root: string }): boolean {
+	let realRoot: string;
+	try {
+		realRoot = fs.realpathSync(root);
+	} catch {
+		return false;
+	}
+	return real === realRoot || real.startsWith(realRoot + path.sep);
+}
+
+/**
+ * Decodes a protocol token back to a served file path, or null when the
+ * token is malformed, the file is missing, or its realpath escapes every
+ * allowed root (symlinks resolved on both sides).
+ */
+export function resolveLocalMediaFilename({
+	token,
+}: {
+	token: string;
+}): string | null {
+	let decoded: string;
+	try {
+		decoded = Buffer.from(token, "base64url").toString("utf8");
+	} catch {
+		return null;
+	}
+	if (!decoded || !path.isAbsolute(decoded)) return null;
+	let real: string;
+	try {
+		real = fs.realpathSync(decoded);
+	} catch {
+		return null;
+	}
+	if (!fs.statSync(real).isFile()) return null;
+	return allowedRoots().some((root) => isUnderRoot({ real, root }))
+		? real
+		: null;
+}

--- a/qcut/electron/utility/utility-bridge.ts
+++ b/qcut/electron/utility/utility-bridge.ts
@@ -66,6 +66,10 @@ import {
 	resolveEditorSnapshotRef,
 	selectEditorSnapshotRef,
 } from "../claude/handlers/claude-snapshot-handler.js";
+import {
+	pullPlaybackDiagnosticsFromRenderer,
+	resetPlaybackDiagnosticsInRenderer,
+} from "../claude/http/claude-http-playback-routes.js";
 import { getAgentPointerController } from "../claude/handlers/agent-pointer-controller.js";
 import type {
 	AgentKeyboardPressRequest,
@@ -535,6 +539,14 @@ async function handleMainRequest(
 		case "snapshot:check": {
 			const req = data as { request: EditorSnapshotCheckRequest };
 			return checkEditorSnapshotRef(win, req.request);
+		}
+
+		case "playback-diagnostics:snapshot": {
+			return pullPlaybackDiagnosticsFromRenderer(win);
+		}
+
+		case "playback-diagnostics:reset": {
+			return resetPlaybackDiagnosticsInRenderer(win);
 		}
 
 		case "pointer:state": {

--- a/qcut/electron/utility/utility-http-server.ts
+++ b/qcut/electron/utility/utility-http-server.ts
@@ -31,6 +31,7 @@ import {
 	registerQCutJianyingProjectExportRoutes,
 } from "../claude/http/claude-http-jianying-project-export-routes.js";
 import { registerSnapshotRoutes } from "../claude/http/claude-http-snapshot-routes.js";
+import { registerPlaybackDiagnosticsRoutes } from "../claude/http/claude-http-playback-routes.js";
 import { registerAgentPointerRoutes } from "../claude/http/claude-http-pointer-routes.js";
 import {
 	handleClaudeEventsStreamRequest,
@@ -496,6 +497,10 @@ export function startUtilityHttpServer(config: UtilityHttpConfig): void {
 				request,
 			})) as EditorSnapshotActionResult,
 		timeoutMs: 10_000,
+	});
+	registerPlaybackDiagnosticsRoutes(router, {
+		pullSnapshot: () => requestFromMain("playback-diagnostics:snapshot", {}),
+		resetCollector: () => requestFromMain("playback-diagnostics:reset", {}),
 	});
 	registerAgentPointerRoutes(router, {
 		getState: async () =>

--- a/qcut/scripts/playback-diagnose.ts
+++ b/qcut/scripts/playback-diagnose.ts
@@ -10,7 +10,6 @@
  *
  * Usage:
  *   bun scripts/playback-diagnose.ts --project <id> [--from 0] [--seconds 12]
- *   bun scripts/playback-diagnose.ts --seconds 10          # keeps current playhead project
  *
  * Auth: pass --token or set QCUT_API_TOKEN when the app was launched with one.
  */
@@ -85,6 +84,7 @@ interface Snapshot {
 	clockIntervalsMs: number[];
 	longTasks: { at: number; durationMs: number }[];
 	longTaskTotalCount: number;
+	longTaskTotalDurationMs: number;
 	mediaEvents: { at: number; type: string; videoId: string; src: string }[];
 	previewRenderTimestamps: number[];
 	previewRenderTotalCount: number;
@@ -204,10 +204,9 @@ async function main(): Promise<void> {
 	if (snapshot.longTasks.length === 0) {
 		console.log("  无长任务 ✓");
 	} else {
-		const total = snapshot.longTasks.reduce(
-			(sum, task) => sum + task.durationMs,
-			0
-		);
+		const total =
+			snapshot.longTaskTotalDurationMs ??
+			snapshot.longTasks.reduce((sum, task) => sum + task.durationMs, 0);
 		console.log(
 			`  ${snapshot.longTaskTotalCount} 个, 合计 ${ms(total)} (占播放时长 ${((total / runWallMs) * 100).toFixed(1)}%)`
 		);
@@ -221,7 +220,7 @@ async function main(): Promise<void> {
 
 	console.log("\n━━━ 预览 React 重渲 ━━━");
 	console.log(
-		`  本次运行: ${snapshot.previewRenderTimestamps.length} 次 | smooth-time reason: ${snapshot.smoothTimeReason ?? "n/a"}`
+		`  本次运行: ${snapshot.previewRenderTotalCount} 次 | smooth-time reason: ${snapshot.smoothTimeReason ?? "n/a"}`
 	);
 
 	console.log("\n━━━ 媒体元素事件 (seek/停顿/重载) ━━━");
@@ -290,18 +289,17 @@ async function main(): Promise<void> {
 			`主时钟 p95=${ms(clockP95)} ≥50ms → 主线程 JS 阻塞是首要原因`
 		);
 	}
-	const longTaskTotal = snapshot.longTasks.reduce(
-		(sum, task) => sum + task.durationMs,
-		0
-	);
+	const longTaskTotal =
+		snapshot.longTaskTotalDurationMs ??
+		snapshot.longTasks.reduce((sum, task) => sum + task.durationMs, 0);
 	if (longTaskTotal / runWallMs > 0.1) {
 		verdicts.push(
 			`长任务占播放时长 ${((longTaskTotal / runWallMs) * 100).toFixed(0)}% → 找出长任务来源`
 		);
 	}
-	if (snapshot.previewRenderTimestamps.length > args.seconds * 5) {
+	if (snapshot.previewRenderTotalCount > args.seconds * 5) {
 		verdicts.push(
-			`预览重渲 ${snapshot.previewRenderTimestamps.length} 次 (reason=${snapshot.smoothTimeReason}) → 每帧重渲仍在发生`
+			`预览重渲 ${snapshot.previewRenderTotalCount} 次 (reason=${snapshot.smoothTimeReason}) → 每帧重渲仍在发生`
 		);
 	}
 	const reloadCount = interesting.filter(

--- a/qcut/scripts/playback-diagnose.ts
+++ b/qcut/scripts/playback-diagnose.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env bun
+/**
+ * Playback diagnostics CLI.
+ *
+ * Drives the running QCut editor through the Claude HTTP API, samples the
+ * renderer's playback diagnostics collector while a clip plays, and prints
+ * a stutter report: master-clock health, main-thread long tasks, media
+ * element churn (seeks / stalls / source reloads), dropped frames, and
+ * preview re-render counts.
+ *
+ * Usage:
+ *   bun scripts/playback-diagnose.ts --project <id> [--from 0] [--seconds 12]
+ *   bun scripts/playback-diagnose.ts --seconds 10          # keeps current playhead project
+ *
+ * Auth: pass --token or set QCUT_API_TOKEN when the app was launched with one.
+ */
+
+const BASE_URL = process.env.QCUT_API_URL ?? "http://127.0.0.1:8765";
+
+interface CliArgs {
+	project: string | null;
+	from: number;
+	seconds: number;
+	token: string | null;
+	json: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	const args: CliArgs = {
+		project: null,
+		from: 0,
+		seconds: 12,
+		token: process.env.QCUT_API_TOKEN ?? null,
+		json: false,
+	};
+	for (let index = 0; index < argv.length; index++) {
+		const value = argv[index];
+		if (value === "--project") args.project = argv[++index] ?? null;
+		else if (value === "--from") args.from = Number(argv[++index] ?? 0);
+		else if (value === "--seconds") args.seconds = Number(argv[++index] ?? 12);
+		else if (value === "--token") args.token = argv[++index] ?? null;
+		else if (value === "--json") args.json = true;
+	}
+	return args;
+}
+
+async function api(
+	path: string,
+	init: RequestInit = {},
+	token: string | null = null
+): Promise<any> {
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+		...(init.headers as Record<string, string> | undefined),
+	};
+	if (token) headers.Authorization = `Bearer ${token}`;
+	const response = await fetch(`${BASE_URL}${path}`, { ...init, headers });
+	const body = (await response.json()) as {
+		success: boolean;
+		data?: unknown;
+		error?: string;
+	};
+	if (!body.success) {
+		throw new Error(`${path} failed: ${body.error ?? response.status}`);
+	}
+	return body.data;
+}
+
+function percentile(sorted: number[], p: number): number {
+	if (sorted.length === 0) return 0;
+	const index = Math.min(
+		sorted.length - 1,
+		Math.max(0, Math.ceil((p / 100) * sorted.length) - 1)
+	);
+	return sorted[index];
+}
+
+function ms(value: number): string {
+	return `${value.toFixed(1)}ms`;
+}
+
+interface Snapshot {
+	installed: boolean;
+	now: number;
+	clockIntervalsMs: number[];
+	longTasks: { at: number; durationMs: number }[];
+	longTaskTotalCount: number;
+	mediaEvents: { at: number; type: string; videoId: string; src: string }[];
+	previewRenderTimestamps: number[];
+	previewRenderTotalCount: number;
+	presentedFrames: { at: number; videoId: string; intervalMs: number | null }[];
+	videos: {
+		videoId: string;
+		srcKind: string;
+		readyState: number;
+		paused: boolean;
+		currentTime: number;
+		droppedVideoFrames: number | null;
+		totalVideoFrames: number | null;
+	}[];
+	smoothTimeReason: string | null;
+	playbackStore: {
+		isPlaying: boolean;
+		currentTime: number;
+		previewQuality: string;
+		runtimePreviewQuality: string | null;
+		runtimeDiagnosticReason: string | null;
+	} | null;
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+
+	const health = await api("/api/claude/health", {}, args.token);
+	console.log(
+		`■ App ${health.appVersion} healthy (uptime ${Math.round(health.uptime)}s)`
+	);
+
+	const projectId =
+		args.project ??
+		(() => {
+			throw new Error(
+				"Pass --project <id> (see the editor URL or /api/claude/navigator/projects)"
+			);
+		})();
+
+	// Baseline video stats before the run (dropped/total are cumulative).
+	const before = (await api(
+		"/api/claude/playback/diagnostics",
+		{},
+		args.token
+	)) as Snapshot;
+	if (!before.installed) {
+		throw new Error(
+			"Diagnostics collector not installed — is the editor open on a project?"
+		);
+	}
+	const beforeVideoStats = new Map(
+		before.videos.map((video) => [`${video.videoId}:${video.srcKind}`, video])
+	);
+
+	await api(
+		"/api/claude/playback/diagnostics/reset",
+		{ method: "POST", body: "{}" },
+		args.token
+	);
+	await api(
+		`/api/claude/timeline/${projectId}/playback`,
+		{
+			method: "POST",
+			body: JSON.stringify({ action: "seek", time: args.from }),
+		},
+		args.token
+	);
+	await new Promise((resolve) => setTimeout(resolve, 800));
+	const playStartedAt = Date.now();
+	await api(
+		`/api/claude/timeline/${projectId}/playback`,
+		{ method: "POST", body: JSON.stringify({ action: "play" }) },
+		args.token
+	);
+	console.log(
+		`■ Playing project ${projectId} from ${args.from}s for ${args.seconds}s…`
+	);
+	await new Promise((resolve) => setTimeout(resolve, args.seconds * 1000));
+
+	const snapshot = (await api(
+		"/api/claude/playback/diagnostics",
+		{},
+		args.token
+	)) as Snapshot;
+
+	await api(
+		`/api/claude/timeline/${projectId}/playback`,
+		{ method: "POST", body: JSON.stringify({ action: "pause" }) },
+		args.token
+	);
+
+	if (args.json) {
+		console.log(JSON.stringify(snapshot, null, 1));
+		return;
+	}
+
+	const runWallMs = Date.now() - playStartedAt;
+	const runStartPerfTime = snapshot.now - runWallMs;
+	const rel = (at: number) => `${((at - runStartPerfTime) / 1000).toFixed(2)}s`;
+
+	console.log("\n━━━ 主时钟 (playback-update 间隔) ━━━");
+	const clock = [...snapshot.clockIntervalsMs].sort((a, b) => a - b);
+	if (clock.length === 0) {
+		console.log("  没有采到时钟节拍 — 播放没有启动？");
+	} else {
+		const mean = clock.reduce((sum, value) => sum + value, 0) / clock.length;
+		const over50 = clock.filter((value) => value >= 50);
+		console.log(
+			`  ticks=${clock.length} mean=${ms(mean)} p50=${ms(percentile(clock, 50))} p95=${ms(percentile(clock, 95))} p99=${ms(percentile(clock, 99))} max=${ms(clock[clock.length - 1])}`
+		);
+		console.log(
+			`  ≥50ms 停顿: ${over50.length} 次 ${over50.length > 0 ? "← 主线程被阻塞的帧" : "(无)"}`
+		);
+	}
+
+	console.log("\n━━━ 主线程长任务 (>50ms longtask) ━━━");
+	if (snapshot.longTasks.length === 0) {
+		console.log("  无长任务 ✓");
+	} else {
+		const total = snapshot.longTasks.reduce(
+			(sum, task) => sum + task.durationMs,
+			0
+		);
+		console.log(
+			`  ${snapshot.longTaskTotalCount} 个, 合计 ${ms(total)} (占播放时长 ${((total / runWallMs) * 100).toFixed(1)}%)`
+		);
+		const top = [...snapshot.longTasks]
+			.sort((a, b) => b.durationMs - a.durationMs)
+			.slice(0, 8);
+		for (const task of top) {
+			console.log(`    ${rel(task.at)}  ${ms(task.durationMs)}`);
+		}
+	}
+
+	console.log("\n━━━ 预览 React 重渲 ━━━");
+	console.log(
+		`  本次运行: ${snapshot.previewRenderTimestamps.length} 次 | smooth-time reason: ${snapshot.smoothTimeReason ?? "n/a"}`
+	);
+
+	console.log("\n━━━ 媒体元素事件 (seek/停顿/重载) ━━━");
+	const interesting = snapshot.mediaEvents.filter((event) =>
+		["seeking", "waiting", "stalled", "loadstart", "error", "ended"].includes(
+			event.type
+		)
+	);
+	if (interesting.length === 0) {
+		console.log("  无 seek/停顿/重载事件 ✓");
+	} else {
+		for (const event of interesting.slice(-30)) {
+			console.log(
+				`    ${rel(event.at)}  ${event.type.padEnd(9)} ${event.videoId.slice(0, 20)} (${event.src})`
+			);
+		}
+	}
+
+	console.log("\n━━━ 视频元素状态 (运行结束时) ━━━");
+	for (const video of snapshot.videos) {
+		const key = `${video.videoId}:${video.srcKind}`;
+		const baseline = beforeVideoStats.get(key);
+		const droppedDelta =
+			video.droppedVideoFrames !== null && baseline?.droppedVideoFrames != null
+				? video.droppedVideoFrames - baseline.droppedVideoFrames
+				: video.droppedVideoFrames;
+		const totalDelta =
+			video.totalVideoFrames !== null && baseline?.totalVideoFrames != null
+				? video.totalVideoFrames - baseline.totalVideoFrames
+				: video.totalVideoFrames;
+		console.log(
+			`  ${video.videoId.slice(0, 24).padEnd(24)} src=${video.srcKind.padEnd(5)} ready=${video.readyState} ${video.paused ? "paused" : "PLAYING"} t=${video.currentTime.toFixed(2)}s dropped=${droppedDelta ?? "?"}/${totalDelta ?? "?"}`
+		);
+	}
+
+	console.log("\n━━━ 呈现帧间隔 (rVFC) ━━━");
+	const presented = snapshot.presentedFrames
+		.map((frame) => frame.intervalMs)
+		.filter((value): value is number => typeof value === "number" && value > 0)
+		.sort((a, b) => a - b);
+	if (presented.length === 0) {
+		console.log("  无呈现帧样本");
+	} else {
+		console.log(
+			`  n=${presented.length} p50=${ms(percentile(presented, 50))} p95=${ms(percentile(presented, 95))} max=${ms(presented[presented.length - 1])} (24fps 素材理想 ≈41.7ms)`
+		);
+		const stalls = presented.filter((value) => value >= 80);
+		console.log(
+			`  ≥80ms 卡帧: ${stalls.length} 次 ${stalls.length > 0 ? "← 观感卡顿的直接证据" : "(无)"}`
+		);
+	}
+
+	const store = snapshot.playbackStore;
+	if (store) {
+		console.log("\n━━━ 播放存储 ━━━");
+		console.log(
+			`  quality=${store.previewQuality} runtime=${store.runtimePreviewQuality ?? "-"} diagnostic=${store.runtimeDiagnosticReason ?? "-"}`
+		);
+	}
+
+	console.log("\n━━━ 判定 ━━━");
+	const verdicts: string[] = [];
+	const clockP95 = percentile(clock, 95);
+	if (clockP95 >= 50) {
+		verdicts.push(
+			`主时钟 p95=${ms(clockP95)} ≥50ms → 主线程 JS 阻塞是首要原因`
+		);
+	}
+	const longTaskTotal = snapshot.longTasks.reduce(
+		(sum, task) => sum + task.durationMs,
+		0
+	);
+	if (longTaskTotal / runWallMs > 0.1) {
+		verdicts.push(
+			`长任务占播放时长 ${((longTaskTotal / runWallMs) * 100).toFixed(0)}% → 找出长任务来源`
+		);
+	}
+	if (snapshot.previewRenderTimestamps.length > args.seconds * 5) {
+		verdicts.push(
+			`预览重渲 ${snapshot.previewRenderTimestamps.length} 次 (reason=${snapshot.smoothTimeReason}) → 每帧重渲仍在发生`
+		);
+	}
+	const reloadCount = interesting.filter(
+		(event) => event.type === "loadstart"
+	).length;
+	if (reloadCount > 0) {
+		verdicts.push(`播放中发生 ${reloadCount} 次视频源重载 → 每次都是一顿`);
+	}
+	const seekCount = interesting.filter(
+		(event) => event.type === "seeking"
+	).length;
+	if (seekCount > 2) {
+		verdicts.push(`播放中发生 ${seekCount} 次 video seek → 纠偏/重载导致跳帧`);
+	}
+	const presentedStalls = presented.filter((value) => value >= 80).length;
+	if (presentedStalls > 2 && verdicts.length === 0) {
+		verdicts.push("呈现帧卡顿但主线程健康 → 怀疑解码/合成侧");
+	}
+	if (verdicts.length === 0) {
+		verdicts.push("各项指标健康 — 若观感仍卡, 采样窗口可能没覆盖到问题片段");
+	}
+	for (const verdict of verdicts) {
+		console.log(`  • ${verdict}`);
+	}
+}
+
+main().catch((error) => {
+	console.error(`✗ ${error instanceof Error ? error.message : error}`);
+	process.exit(1);
+});


### PR DESCRIPTION
## Problem

Video playback in the preview panel stuttered badly — with plain 1440p clips it degraded to a ~2fps slideshow.

## Root causes (found via the new diagnostics CLI)

1. **Per-frame React re-renders**: `useScreenRecordingPreview` called `setSmoothTime` on every `playback-update` (~60/s), re-rendering the entire preview tree every animation frame — defeating the playback-store design where video/audio elements sync via window events.
2. **Chunked playback-proxy coupling**: the enhancement-proxy chunk window advanced via rendered time (`getVideoEnhancementProxyWindow(currentTime)`), so any ≥1440px source in auto quality forced per-frame renders back on.
3. **Paused-video seek storm (the 2fps slideshow)**: after a mid-playback `<video>` src reload (proxy chunk switch flaps app↔blob), nothing re-called `play()` — and `play()` rejections were silently swallowed. The 0.5s drift corrector then hard-seeked the paused element every 500ms, advancing the picture at 2fps with zero `playing` events.
4. **Gate false positive**: every media element carries a disabled default `customCutout` object; gating on presence (not `.enabled`) kept 60fps renders on for plain clips.

## Fixes

- **Smooth-time gating** (`lib/preview/preview-smooth-time.ts`, `use-smooth-playback-time.ts`): per-frame updates are now opt-in. Only content that animates through React (keyframes, transitions, captions, remotion/hyperframes/effects, screen-recording zoom/cursor, enabled custom cutouts, jianying prefetch windows with 4s lead) subscribes; static clips play with **zero** preview re-renders. Diagnosable via `data-smooth-time-reason` on the capture surface.
- **Event-driven proxy windows** (`useVideoEnhancementProxyWindow`): chunk windows advance from `playback-update` events, state changes only at chunk transitions (~every 10s), so high-res/enhanced clips also hit the zero-re-render path.
- **Video self-heal** (`video-player.tsx`): each sync tick resumes a paused-but-should-be-playing element and keeps `timelineTimeRef` fresh; `play()` failures now log a warning instead of vanishing.
- **Gate correctness**: `customCutout` triggers only when `.enabled`.

## Diagnostics tooling (new)

`bun scripts/playback-diagnose.ts --project <id> [--seconds 12] [--json]` drives the running editor over the HTTP API and reports master-clock tick percentiles, main-thread long tasks, preview render counts + gate reason, per-video seek/stall/reload event timelines, dropped/presented frame stats, and a verdict. Backed by an always-on renderer ring-buffer collector (`lib/debug/playback-diagnostics.ts`) exposed via `GET /api/claude/playback/diagnostics` (registered in both the legacy and utility HTTP servers).

## Verified (same 2560×1440@24fps clips, same machine)

| Metric | Before | After |
|---|---|---|
| Presented-frame interval p50 | 500ms (2fps) | **33.4ms** |
| Presented stalls ≥80ms / 13s | 23 | **0** |
| Preview React renders / 13s | 785 | **5** |
| Corrective video seeks / 13s | 34 | 4 (start + chunk switches) |
| Renderer CPU (steady) | 50–95% | ~10% (source path) |
| Runtime quality downgrade | low (video-frame) | none |

Unit tests: 18 new (gating predicates, prefetch windows, event-driven proxy window hook); `tsc` and biome clean.

## Known remaining blip

Proxy chunk switches (~every 10s) still do an app→blob→app double reload with one visible micro-hitch; keeping the previous chunk URL while the next generates would remove it (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smoother preview playback for animations, effects, transitions, zoom, cursor overlays, and audio.
  * Upcoming video segments and enhancement previews preload to reduce delays at cuts.
  * Added playback diagnostics with JSON and human-readable reports.
  * Improved GPU color processing for masks and spatial effects.
  * Added faster local media streaming in the desktop app.

* **Bug Fixes**
  * Improved seeking, synchronization, playback recovery, and automatic quality adaptation.

* **Tests**
  * Added coverage for playback smoothness, media preloading, and color processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->