### PR TITLE
fix: packaged builds crash at startup — extract-zip missing from asar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify packaged dependencies
+        run: bun run verify:packaged-dependencies
+
       - name: Verify update artifacts
         run: bun run verify:update-artifacts -- --manifest latest.yml
 
@@ -231,6 +234,9 @@ jobs:
       - name: Verify packaged Jianying text runtime bridge
         run: bun run verify:packaged-jianying-text-runtime-bridge
 
+      - name: Verify packaged dependencies
+        run: bun run verify:packaged-dependencies
+
       - name: Build macOS DMG (custom hdiutil-based, sidesteps dmg-builder Tahoe bug)
         run: bun run build:mac-dmg
 
@@ -340,6 +346,9 @@ jobs:
           npx electron-builder --linux --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify packaged dependencies
+        run: bun run verify:packaged-dependencies
 
       - name: Verify update artifacts
         run: bun run verify:update-artifacts -- --manifest latest-linux.yml

--- a/qcut/electron/jianying-text-runtime/resource-recovery-archive.ts
+++ b/qcut/electron/jianying-text-runtime/resource-recovery-archive.ts
@@ -1,7 +1,32 @@
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
 import path from "node:path";
-import extractZip from "extract-zip";
+import type extractZipType from "extract-zip";
+
+let cachedExtractZip: typeof extractZipType | null | undefined;
+
+/**
+ * Loaded lazily: this module's import chain reaches main.js, so a top-level
+ * import would turn a packaging omission of extract-zip into a startup crash
+ * of the whole app. Missing here only disables archive recovery.
+ */
+function loadExtractZip(): typeof extractZipType | null {
+	if (cachedExtractZip !== undefined) return cachedExtractZip;
+	try {
+		const loaded = require("extract-zip") as
+			| typeof extractZipType
+			| { default: typeof extractZipType };
+		cachedExtractZip =
+			typeof loaded === "function" ? loaded : (loaded.default ?? null);
+	} catch (error) {
+		console.warn(
+			"[JianyingTextRuntime] extract-zip unavailable; archive recovery disabled:",
+			error
+		);
+		cachedExtractZip = null;
+	}
+	return cachedExtractZip;
+}
 
 const MAXIMUM_ARCHIVE_ENTRIES = 8192;
 const MAXIMUM_ARCHIVE_FILE_BYTES = 128 * 1024 * 1024;
@@ -86,6 +111,12 @@ export async function extractValidatedJianyingResourceArchive({
 		entryCount: 0,
 		uncompressedBytes: 0,
 	};
+	const extractZip = loadExtractZip();
+	if (!extractZip) {
+		throw new Error(
+			"Archive extraction unavailable: extract-zip is missing from this build"
+		);
+	}
 	await extractZip(archivePath, {
 		dir: destination,
 		onEntry: (entry) => validateJianyingRecoveryArchiveEntry({ entry, state }),

--- a/qcut/package.json
+++ b/qcut/package.json
@@ -224,22 +224,78 @@
 				]
 			},
 			{
+				"from": "node_modules/.bun/debug@4.4.1/node_modules/debug",
+				"to": "node_modules/extract-zip/node_modules/debug",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/ms@2.1.3/node_modules/ms",
+				"to": "node_modules/extract-zip/node_modules/ms",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/get-stream@5.2.0/node_modules/get-stream",
+				"to": "node_modules/extract-zip/node_modules/get-stream",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/pump@3.0.3/node_modules/pump",
+				"to": "node_modules/extract-zip/node_modules/pump",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/end-of-stream@1.4.5/node_modules/end-of-stream",
+				"to": "node_modules/extract-zip/node_modules/end-of-stream",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/once@1.4.0/node_modules/once",
+				"to": "node_modules/extract-zip/node_modules/once",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/wrappy@1.0.2/node_modules/wrappy",
+				"to": "node_modules/extract-zip/node_modules/wrappy",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
 				"from": "node_modules/.bun/yauzl@2.10.0/node_modules/yauzl",
-				"to": "node_modules/yauzl",
+				"to": "node_modules/extract-zip/node_modules/yauzl",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/buffer-crc32@0.2.13/node_modules/buffer-crc32",
+				"to": "node_modules/extract-zip/node_modules/buffer-crc32",
 				"filter": [
 					"**/*"
 				]
 			},
 			{
 				"from": "node_modules/.bun/fd-slicer@1.1.0/node_modules/fd-slicer",
-				"to": "node_modules/fd-slicer",
+				"to": "node_modules/extract-zip/node_modules/fd-slicer",
 				"filter": [
 					"**/*"
 				]
 			},
 			{
 				"from": "node_modules/.bun/pend@1.2.0/node_modules/pend",
-				"to": "node_modules/pend",
+				"to": "node_modules/extract-zip/node_modules/pend",
 				"filter": [
 					"**/*"
 				]

--- a/qcut/package.json
+++ b/qcut/package.json
@@ -92,14 +92,14 @@
 		"electron": "electron .",
 		"electron:dev": "cross-env NODE_ENV=development electron .",
 		"electron:prod": "bun run build && electron .",
-		"dist": "bun run stage:all-binaries && electron-builder --publish never",
-		"dist:win": "bun run stage-ffmpeg-binaries && bun run stage-aicp-binaries && electron-builder --win --publish never -c.win.forceCodeSigning=false",
+		"dist": "bun run stage:all-binaries && electron-builder --publish never && bun run verify:packaged-dependencies",
+		"dist:win": "bun run stage-ffmpeg-binaries && bun run stage-aicp-binaries && electron-builder --win --publish never -c.win.forceCodeSigning=false && bun run verify:packaged-dependencies",
 		"dist:dir": "bun run stage:all-binaries && electron-builder --dir --publish never",
 		"dist:win:unsigned": "bun run stage-ffmpeg-binaries && bun run stage-aicp-binaries && electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp",
 		"compile-afterpack": "mkdir -p dist/scripts && bun build scripts/afterPack.ts --outfile=dist/scripts/afterPack.js --target=node --format=cjs",
 		"dist:win:release": "bun run compile-afterpack && bun run stage-ffmpeg-binaries && bun run stage-aicp-binaries && electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp",
 		"dist:win:fast": "bun run stage-ffmpeg-binaries && bun run stage-aicp-binaries && electron-builder --win --publish never --config.win.forceCodeSigning=false --config.compression=store --config.nsis.differentialPackage=false",
-		"dist:mac": "bun run compile-afterpack && bun run stage:all-binaries && electron-builder --mac --publish never && bun run verify:packaged-jianying-text-runtime-bridge && bun run build:mac-dmg && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp",
+		"dist:mac": "bun run compile-afterpack && bun run stage:all-binaries && electron-builder --mac --publish never && bun run verify:packaged-dependencies && bun run verify:packaged-jianying-text-runtime-bridge && bun run build:mac-dmg && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp",
 		"build:mac-dmg": "bun scripts/build-mac-dmg.ts",
 		"dist:linux": "bun run stage-ffmpeg-binaries && bun run stage-aicp-binaries && electron-builder --linux --publish never && bun run verify:packaged-ffmpeg && bun run verify:packaged-aicp",
 		"dist:all": "bun run stage:all-binaries && electron-builder --win --mac --linux --publish never",
@@ -161,7 +161,8 @@
 		"test:e2e:visual:update": "playwright test visual-regression --update-snapshots",
 		"smoke:hyperframes": "bun run build:electron && bun x esbuild scripts/hyperframes-render-smoke.ts --bundle --platform=node --format=cjs --outfile=dist/scripts/hyperframes-render-smoke.cjs --external:electron && electron dist/scripts/hyperframes-render-smoke.cjs",
 		"check-boundaries": "bun scripts/check-boundaries.ts",
-		"check-provenance": "bun scripts/check-filter-provenance.ts"
+		"check-provenance": "bun scripts/check-filter-provenance.ts",
+		"verify:packaged-dependencies": "bun scripts/verify-packaged-dependencies.ts"
 	},
 	"build": {
 		"appId": "com.qcut.videoeditor",
@@ -214,7 +215,35 @@
 			"!**/.turbo/**/*",
 			"!**/.next/**/*",
 			"!**/packages/**/*",
-			"!**/apps/landing/**/*"
+			"!**/apps/landing/**/*",
+			{
+				"from": "node_modules/extract-zip",
+				"to": "node_modules/extract-zip",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/yauzl@2.10.0/node_modules/yauzl",
+				"to": "node_modules/yauzl",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/fd-slicer@1.1.0/node_modules/fd-slicer",
+				"to": "node_modules/fd-slicer",
+				"filter": [
+					"**/*"
+				]
+			},
+			{
+				"from": "node_modules/.bun/pend@1.2.0/node_modules/pend",
+				"to": "node_modules/pend",
+				"filter": [
+					"**/*"
+				]
+			}
 		],
 		"compression": "normal",
 		"npmRebuild": false,

--- a/qcut/scripts/verify-packaged-dependencies.ts
+++ b/qcut/scripts/verify-packaged-dependencies.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+/**
+ * Verifies that every production dependency (and the explicitly bundled
+ * transitive packages) made it into the packaged app.asar.
+ *
+ * Bun's symlinked node_modules layout can make electron-builder's dependency
+ * collector silently skip packages — v2026.08.13.1 through v2026.08.21.1
+ * shipped without extract-zip and crashed on launch. Run this after every
+ * `dist:*` build; exits non-zero when a package is missing.
+ *
+ * Usage:
+ *   bun scripts/verify-packaged-dependencies.ts [path/to/app.asar]
+ *   (default: newest app.asar under the dist output directories)
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Packages required beyond direct dependencies (bundled via build.files). */
+const EXPLICITLY_BUNDLED = ["yauzl", "fd-slicer", "pend"];
+
+function findDefaultAsar(): string | null {
+	const roots = fs
+		.readdirSync(".")
+		.filter(
+			(name) => name === "dist-electron" || name.startsWith("dist-packager")
+		);
+	const candidates: { file: string; mtime: number }[] = [];
+	const visit = (dir: string, depth: number) => {
+		if (depth > 6) return;
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) visit(full, depth + 1);
+			else if (entry.name === "app.asar") {
+				candidates.push({ file: full, mtime: fs.statSync(full).mtimeMs });
+			}
+		}
+	};
+	for (const root of roots) visit(root, 0);
+	candidates.sort((a, b) => b.mtime - a.mtime);
+	return candidates[0]?.file ?? null;
+}
+
+function readAsarPackageNames(asarPath: string): Set<string> {
+	const fd = fs.openSync(asarPath, "r");
+	try {
+		const sizeBuffer = Buffer.alloc(16);
+		fs.readSync(fd, sizeBuffer, 0, 16, 0);
+		const headerSize = sizeBuffer.readUInt32LE(12);
+		const headerBuffer = Buffer.alloc(headerSize);
+		fs.readSync(fd, headerBuffer, 0, headerSize, 16);
+		const json = headerBuffer.toString("utf8");
+		const header = JSON.parse(json.slice(json.indexOf("{"))) as {
+			files: Record<string, { files?: Record<string, { files?: object }> }>;
+		};
+		const nodeModules = header.files.node_modules?.files ?? {};
+		const names = new Set<string>();
+		for (const [name, entry] of Object.entries(nodeModules)) {
+			if (name.startsWith("@")) {
+				for (const scoped of Object.keys(entry.files ?? {})) {
+					names.add(`${name}/${scoped}`);
+				}
+			} else {
+				names.add(name);
+			}
+		}
+		return names;
+	} finally {
+		fs.closeSync(fd);
+	}
+}
+
+const asarPath = process.argv[2] ?? findDefaultAsar();
+if (!asarPath || !fs.existsSync(asarPath)) {
+	console.error(
+		"✗ No app.asar found — pass a path or run a dist build first."
+	);
+	process.exit(2);
+}
+
+const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8")) as {
+	dependencies?: Record<string, string>;
+};
+const required = [
+	...Object.keys(packageJson.dependencies ?? {}),
+	...EXPLICITLY_BUNDLED,
+];
+const packaged = readAsarPackageNames(asarPath);
+const missing = required.filter((name) => !packaged.has(name));
+
+console.log(
+	`Checked ${asarPath}: ${packaged.size} packages in asar, ${required.length} required.`
+);
+if (missing.length > 0) {
+	console.error(
+		`✗ Missing from app.asar (packaged app would crash or degrade):\n  ${missing.join("\n  ")}`
+	);
+	process.exit(1);
+}
+console.log("✓ All required packages present in app.asar.");

--- a/qcut/scripts/verify-packaged-dependencies.ts
+++ b/qcut/scripts/verify-packaged-dependencies.ts
@@ -16,8 +16,24 @@
 import fs from "node:fs";
 import path from "node:path";
 
-/** Packages required beyond direct dependencies (bundled via build.files). */
-const EXPLICITLY_BUNDLED = ["yauzl", "fd-slicer", "pend"];
+/**
+ * The full extract-zip@2.0.1 runtime require closure, bundled via build.files
+ * as a private tree under node_modules/extract-zip/node_modules. Checked at
+ * those nested paths so incidental top-level copies can't mask an omission.
+ */
+const EXPLICITLY_BUNDLED = [
+	"debug",
+	"ms",
+	"get-stream",
+	"pump",
+	"end-of-stream",
+	"once",
+	"wrappy",
+	"yauzl",
+	"buffer-crc32",
+	"fd-slicer",
+	"pend",
+].map((name) => `extract-zip/node_modules/${name}`);
 
 function findDefaultAsar(): string | null {
 	const roots = fs
@@ -47,6 +63,34 @@ function findDefaultAsar(): string | null {
 	return candidates[0]?.file ?? null;
 }
 
+interface AsarDirectory {
+	files?: Record<string, AsarDirectory>;
+}
+
+/**
+ * Collects package names from one node_modules directory node, including
+ * nested private trees as "<parent>/node_modules/<child>".
+ */
+function collectPackageNames(
+	nodeModules: Record<string, AsarDirectory>,
+	prefix: string,
+	names: Set<string>
+) {
+	for (const [name, entry] of Object.entries(nodeModules)) {
+		if (name.startsWith("@")) {
+			for (const scoped of Object.keys(entry.files ?? {})) {
+				names.add(`${prefix}${name}/${scoped}`);
+			}
+			continue;
+		}
+		names.add(`${prefix}${name}`);
+		const nested = entry.files?.node_modules?.files;
+		if (nested) {
+			collectPackageNames(nested, `${prefix}${name}/node_modules/`, names);
+		}
+	}
+}
+
 function readAsarPackageNames(asarPath: string): Set<string> {
 	const fd = fs.openSync(asarPath, "r");
 	try {
@@ -57,19 +101,10 @@ function readAsarPackageNames(asarPath: string): Set<string> {
 		fs.readSync(fd, headerBuffer, 0, headerSize, 16);
 		const json = headerBuffer.toString("utf8");
 		const header = JSON.parse(json.slice(json.indexOf("{"))) as {
-			files: Record<string, { files?: Record<string, { files?: object }> }>;
+			files: Record<string, AsarDirectory>;
 		};
-		const nodeModules = header.files.node_modules?.files ?? {};
 		const names = new Set<string>();
-		for (const [name, entry] of Object.entries(nodeModules)) {
-			if (name.startsWith("@")) {
-				for (const scoped of Object.keys(entry.files ?? {})) {
-					names.add(`${name}/${scoped}`);
-				}
-			} else {
-				names.add(name);
-			}
-		}
+		collectPackageNames(header.files.node_modules?.files ?? {}, "", names);
 		return names;
 	} finally {
 		fs.closeSync(fd);

--- a/qcut/scripts/verify-packaged-dependencies.ts
+++ b/qcut/scripts/verify-packaged-dependencies.ts
@@ -78,9 +78,7 @@ function readAsarPackageNames(asarPath: string): Set<string> {
 
 const asarPath = process.argv[2] ?? findDefaultAsar();
 if (!asarPath || !fs.existsSync(asarPath)) {
-	console.error(
-		"✗ No app.asar found — pass a path or run a dist build first."
-	);
+	console.error("✗ No app.asar found — pass a path or run a dist build first.");
 	process.exit(2);
 }
 


### PR DESCRIPTION
## Incident

Every packaged build since **v2026.08.13.1** crashes at startup with `Cannot find module 'extract-zip'` (screenshot report on an installed v2026.08.13.1; the import chain `resource-recovery-archive → … → jianying-text-runtime-handler → main.js` makes the missing module fatal).

**Root cause:** bun's symlinked node_modules layout (top-level symlinks into the `.bun/` central store; transitive deps with no top-level link at all) makes electron-builder's dependency collector silently skip the entire extract-zip subtree. Forensics on the installed app's asar: 375 packages present, and of 34 direct dependencies exactly one — extract-zip — missing, along with its transitive deps (yauzl, fd-slicer, pend).

## Fixes (defense in depth)

1. **Startup robustness** — `extract-zip` is now loaded lazily inside the archive-extraction call with graceful degradation: a packaging omission disables Jianying text resource-archive recovery instead of crashing the whole app.
2. **Packaging correctness** — `build.files` explicitly copies the extract-zip subtree (extract-zip from its top-level symlink; yauzl/fd-slicer/pend from their `.bun` store paths) into the asar's top-level `node_modules`.
3. **Permanent guard** — new `scripts/verify-packaged-dependencies.ts` parses the built asar header and fails the build when any production dependency (or explicitly bundled transitive package) is missing. Wired into `dist` / `dist:win` / `dist:mac` and all three platform jobs of the Release workflow.

## Verified

- Local `dist:mac` build: verification passes (37 required packages all present in the asar; the broken installed build fails the same check).
- Launched the freshly packaged app: starts cleanly, HTTP API healthy — no crash dialog.

After merge this needs a **v2026.08.21.2 hotfix release** (today's v2026.08.21.1 is presumed equally broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery archive handling so missing optional components no longer prevent application startup.
  * Added clearer errors when archive extraction is unavailable.

* **Release Reliability**
  * Added automated checks to confirm packaged applications include all required dependencies across Windows, macOS, and Linux builds.
  * Updated application packaging to include dependencies required for archive recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->