### PR TITLE
feat: expand text style lab and filter navigation

### DIFF
--- a/qcut/apps/web/src/components/editor/media-panel/views/__tests__/adjustments.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/__tests__/adjustments.test.tsx
@@ -8,6 +8,7 @@ import type {
 	JianyingFilterLabFilterSummary,
 	JianyingFilterLabLoadResult,
 	JianyingFilterLabLutSummary,
+	JianyingFilterLocalRuntimeStatus,
 } from "@/types/electron";
 import type { TimelineStore } from "@/stores/timeline/types";
 import type { TimelineTrack } from "@/types/timeline";
@@ -153,6 +154,16 @@ const localFilterSummary: JianyingFilterLabFilterSummary = {
 	luts: [localLutSummary],
 };
 
+const localRuntimeStatus: JianyingFilterLocalRuntimeStatus = {
+	state: "ready",
+	message: "QCut private runtime ready",
+	provider: "jianying-local-effect-v1",
+	platform: "darwin",
+	bridgeReady: true,
+	runtimeReady: true,
+	modelReady: true,
+};
+
 function installFilterLabApi({
 	available = true,
 }: {
@@ -168,16 +179,19 @@ function installFilterLabApi({
 	const load = vi.fn(async () => loadedLocalLut);
 	const thumbnail = vi.fn();
 	const onCatalogChanged = vi.fn(() => vi.fn());
+	// The lab mounts JianyingFilterRuntimeStatus, which inspects the runtime on
+	// mount; the mock has to carry that method or the effect never runs.
+	const inspectLocalRuntime = vi.fn(async () => localRuntimeStatus);
 	Object.defineProperty(window, "electronAPI", {
 		configurable: true,
 		value: {
 			...(window.electronAPI ?? {}),
 			jianyingFilterLab: available
-				? { list, load, thumbnail, onCatalogChanged }
+				? { list, load, thumbnail, onCatalogChanged, inspectLocalRuntime }
 				: undefined,
 		},
 	});
-	return { list, load, thumbnail, onCatalogChanged };
+	return { list, load, thumbnail, onCatalogChanged, inspectLocalRuntime };
 }
 
 describe("AdjustmentsView", () => {

--- a/qcut/apps/web/src/components/editor/media-panel/views/__tests__/text-library-nav.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/__tests__/text-library-nav.test.tsx
@@ -32,7 +32,6 @@ const RESULT: JianyingTextStyleLabListResult = {
 
 function renderNav({ styleLabOpen }: { styleLabOpen: boolean }) {
 	const onSelectStyleLabView = vi.fn();
-	const onToggleStyleLabGroup = vi.fn();
 	render(
 		<TextLibraryNav
 			activeCategoryId={DEFAULT_TEXT_TEMPLATE_CATEGORY_ID}
@@ -41,14 +40,12 @@ function renderNav({ styleLabOpen }: { styleLabOpen: boolean }) {
 			onSelectGroup={vi.fn()}
 			onOpenStyleLab={vi.fn()}
 			onSelectStyleLabView={onSelectStyleLabView}
-			onToggleStyleLabGroup={onToggleStyleLabGroup}
-			styleLabExpandedGroups={{ charts: true }}
 			styleLabOpen={styleLabOpen}
 			styleLabResult={RESULT}
 			styleLabView="trial"
 		/>
 	);
-	return { onSelectStyleLabView, onToggleStyleLabGroup };
+	return { onSelectStyleLabView };
 }
 
 describe("TextLibraryNav", () => {
@@ -61,17 +58,14 @@ describe("TextLibraryNav", () => {
 		expect(screen.queryByRole("button", { name: /热门/ })).toBeNull();
 	});
 
-	it("nests the lab categories under the lab entry once it opens", () => {
-		const { onSelectStyleLabView, onToggleStyleLabGroup } = renderNav({
+	it("shows every lab category directly under the lab entry", () => {
+		const { onSelectStyleLabView } = renderNav({
 			styleLabOpen: true,
 		});
 		const labEntry = screen.getByRole("button", { name: "花字实验室" });
 		const category = screen.getByRole("button", {
 			name: "热门，7 个本地花字",
 		});
-		expect(screen.getByRole("button", { name: /榜单/ })).toHaveTextContent(
-			"11"
-		);
 		// The categories belong to the lab, so they must follow its rail entry
 		// rather than sitting beside the template groups above it.
 		expect(
@@ -82,9 +76,13 @@ describe("TextLibraryNav", () => {
 		fireEvent.click(category);
 		expect(onSelectStyleLabView).toHaveBeenCalledWith("popular");
 
-		// 颜色 is folded by default, so 紫色 only exists after the group opens.
-		expect(screen.queryByRole("button", { name: /紫色/ })).toBeNull();
-		fireEvent.click(screen.getByRole("button", { name: /颜色/ }));
-		expect(onToggleStyleLabGroup).toHaveBeenCalledWith("colors");
+		const purple = screen.getByRole("button", {
+			name: "紫色，1 个本地花字",
+		});
+		expect(
+			category.compareDocumentPosition(purple) &
+				Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+		expect(screen.queryByRole("button", { name: /榜单/ })).toBeNull();
 	});
 });

--- a/qcut/apps/web/src/components/editor/media-panel/views/adjustments/jianying-filter-lab-shelf.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/adjustments/jianying-filter-lab-shelf.tsx
@@ -9,7 +9,11 @@ import { useAdjustmentLut } from "./use-adjustment-lut";
  * writes an adjustment layer — this shelf owns that binding so the host
  * panel does not have to know about adjustment semantics.
  */
-export function JianyingFilterLabShelf() {
+export function JianyingFilterLabShelf({
+	sidebarHost,
+}: {
+	sidebarHost?: HTMLElement | null;
+}) {
 	const {
 		activeLut,
 		activeMultiPass,
@@ -77,6 +81,7 @@ export function JianyingFilterLabShelf() {
 		<JianyingFilterLab
 			targetName={target?.element.name}
 			activeEffect={activeMultiPass ?? activeLut}
+			sidebarHost={sidebarHost}
 			onApply={applyJianyingLut}
 			onApplyMultiPass={({ settings }) => applyMultiPass({ settings })}
 			onEffectEnabledChange={setActiveEffectEnabled}

--- a/qcut/apps/web/src/components/editor/media-panel/views/adjustments/jianying-filter-lab-sidebar.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/adjustments/jianying-filter-lab-sidebar.tsx
@@ -92,15 +92,20 @@ function SidebarGroup({
  */
 export function JianyingFilterLabSidebar({
 	groups,
+	nested = false,
 }: {
 	groups: FilterLabSidebarGroup[];
+	nested?: boolean;
 }) {
 	const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(
 		() => new Set()
 	);
 	return (
 		<div
-			className="sticky top-0 flex w-[82px] shrink-0 flex-col gap-1.5 self-start"
+			className={cn(
+				"flex shrink-0 flex-col gap-1.5 self-start",
+				nested ? "w-full" : "sticky top-0 w-[82px]"
+			)}
 			data-testid="jianying-filter-lab-categories"
 		>
 			{groups.map((group) => (

--- a/qcut/apps/web/src/components/editor/media-panel/views/adjustments/jianying-filter-lab.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/adjustments/jianying-filter-lab.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { assetManifestIdentity } from "@qcut/editor-core";
 import { FlaskConical, RefreshCw, Search } from "lucide-react";
 import { toast } from "sonner";
@@ -112,6 +113,7 @@ function filterMatchesCatalogView({
 export function JianyingFilterLab({
 	targetName,
 	activeEffect,
+	sidebarHost,
 	onApply,
 	onApplyMultiPass,
 	onEffectEnabledChange,
@@ -123,6 +125,7 @@ export function JianyingFilterLab({
 		| ColorLutSettings
 		| Pick<ColorMultiPassSettings, "enabled" | "name" | "intensity">
 		| null;
+	sidebarHost?: HTMLElement | null;
 	onApply: ({
 		name,
 		cube,
@@ -363,6 +366,10 @@ export function JianyingFilterLab({
 			setLoadingResourceId("");
 		}
 	};
+	const externalSidebar = sidebarHost !== undefined;
+	const sidebar = (
+		<JianyingFilterLabSidebar groups={sidebarGroups} nested={externalSidebar} />
+	);
 
 	return (
 		<div className="space-y-2.5" data-testid="jianying-filter-lab">
@@ -449,7 +456,11 @@ export function JianyingFilterLab({
 			) : null}
 
 			<div className="flex min-w-0 gap-2">
-				<JianyingFilterLabSidebar groups={sidebarGroups} />
+				{externalSidebar
+					? sidebarHost
+						? createPortal(sidebar, sidebarHost)
+						: null
+					: sidebar}
 
 				<div className="min-w-0 flex-1 space-y-2">
 					{!checking && !error && matchingFilters.length === 0 ? (

--- a/qcut/apps/web/src/components/editor/media-panel/views/adjustments/jianying-filter-runtime-status.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/adjustments/jianying-filter-runtime-status.tsx
@@ -40,7 +40,9 @@ export function JianyingFilterRuntimeStatus() {
 	useEffect(() => {
 		let active = true;
 		const api = window.electronAPI?.jianyingFilterLab;
-		if (!api) {
+		// A bridge without this method must not throw out of the effect and take
+		// the panel down with it — same guard the lab view uses before calling it.
+		if (typeof api?.inspectLocalRuntime !== "function") {
 			setChecking(false);
 			return;
 		}

--- a/qcut/apps/web/src/components/editor/media-panel/views/filters/__tests__/filters-view.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/filters/__tests__/filters-view.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -186,6 +186,62 @@ describe("FiltersView", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: "Filter library" }));
 		expect(screen.getByLabelText("Search filters")).toBeInTheDocument();
+	});
+
+	it("uses one collapsible sidebar for library, favorites, and filter lab", async () => {
+		render(<FiltersView />);
+
+		const sidebar = screen.getByTestId("filter-sidebar");
+		const libraryButton = within(sidebar).getByRole("button", {
+			name: "Filter library",
+		});
+		const favoritesButton = within(sidebar).getByRole("button", {
+			name: "Favorites",
+		});
+		const labButton = within(sidebar).getByRole("button", {
+			name: "滤镜实验室",
+		});
+
+		expect(libraryButton).toHaveAttribute("aria-expanded", "true");
+		expect(favoritesButton).toHaveAttribute("aria-expanded", "false");
+		expect(labButton).toHaveAttribute("aria-expanded", "false");
+
+		fireEvent.click(libraryButton);
+		expect(libraryButton).toHaveAttribute("aria-expanded", "false");
+		expect(
+			within(sidebar).queryByTestId("filter-category-summer")
+		).not.toBeInTheDocument();
+		expect(screen.getByTestId("filter-card-vivid")).toBeInTheDocument();
+
+		fireEvent.click(favoritesButton);
+		expect(favoritesButton).toHaveAttribute("aria-expanded", "true");
+		expect(libraryButton).toHaveAttribute("aria-expanded", "false");
+		expect(
+			within(sidebar).queryByTestId("filter-category-mine")
+		).not.toBeInTheDocument();
+
+		fireEvent.click(labButton);
+		expect(labButton).toHaveAttribute("aria-expanded", "true");
+		expect(favoritesButton).toHaveAttribute("aria-expanded", "false");
+		const labCategories = await within(sidebar).findByTestId(
+			"jianying-filter-lab-categories"
+		);
+		const libraryGroup = within(labCategories).getByRole("button", {
+			name: "滤镜库",
+		});
+		expect(libraryGroup).toHaveAttribute("aria-expanded", "true");
+
+		fireEvent.click(libraryGroup);
+		expect(libraryGroup).toHaveAttribute("aria-expanded", "false");
+		expect(
+			within(labCategories).queryByRole("tablist", { name: "滤镜库" })
+		).not.toBeInTheDocument();
+
+		fireEvent.click(labButton);
+		expect(labButton).toHaveAttribute("aria-expanded", "false");
+		expect(
+			within(sidebar).queryByTestId("jianying-filter-lab-categories")
+		).not.toBeInTheDocument();
 	});
 
 	it("renders the library with the None card and full result count", () => {

--- a/qcut/apps/web/src/components/editor/media-panel/views/filters/filter-sidebar.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/filters/filter-sidebar.tsx
@@ -1,0 +1,178 @@
+import {
+	ChevronDown,
+	FlaskConical,
+	Library,
+	Star,
+	type LucideIcon,
+} from "lucide-react";
+import { useState, type RefCallback } from "react";
+import { cn } from "@/lib/utils";
+import {
+	FILTER_CATEGORIES,
+	type FilterCategoryId,
+	type FilterCategoryOption,
+} from "./filter-categories";
+
+export type FilterLibraryMode = "library" | "favorites" | "lab";
+
+interface FilterSidebarProps {
+	category: FilterCategoryId;
+	labSidebarRef: RefCallback<HTMLDivElement>;
+	mode: FilterLibraryMode;
+	onSelectCategory: ({
+		category,
+		mode,
+	}: {
+		category: FilterCategoryId;
+		mode: Exclude<FilterLibraryMode, "lab">;
+	}) => void;
+	onSelectMode: ({ mode }: { mode: FilterLibraryMode }) => void;
+}
+
+const MODE_OPTIONS: Array<{
+	id: FilterLibraryMode;
+	icon: LucideIcon;
+	label: string;
+}> = [
+	{ id: "library", icon: Library, label: "Filter library" },
+	{ id: "favorites", icon: Star, label: "Favorites" },
+	{ id: "lab", icon: FlaskConical, label: "滤镜实验室" },
+];
+
+function navigationButtonClass({ active }: { active: boolean }) {
+	return cn(
+		"flex h-8 w-full items-center gap-2 rounded px-2 text-left text-[11px] transition-colors",
+		active
+			? "bg-primary/15 font-medium text-primary"
+			: "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+	);
+}
+
+function CategoryButton({
+	category,
+	mode,
+	selectedCategory,
+	onSelectCategory,
+}: {
+	category: FilterCategoryOption;
+	mode: Exclude<FilterLibraryMode, "lab">;
+	selectedCategory: FilterCategoryId;
+	onSelectCategory: FilterSidebarProps["onSelectCategory"];
+}) {
+	const Icon = category.icon;
+	const active = selectedCategory === category.id;
+	return (
+		<button
+			type="button"
+			className={navigationButtonClass({ active })}
+			aria-pressed={active}
+			aria-label={`${category.label} / ${category.localizedLabel}`}
+			title={category.label}
+			data-testid={`filter-category-${category.id}`}
+			onClick={() => onSelectCategory({ category: category.id, mode })}
+			onKeyDown={(event) => {
+				if (event.key !== "Enter" && event.key !== " ") return;
+				event.preventDefault();
+				event.currentTarget.click();
+			}}
+		>
+			<Icon className="size-3.5 shrink-0" aria-hidden="true" />
+			<span className="min-w-0 truncate whitespace-nowrap">
+				{category.localizedLabel}
+			</span>
+		</button>
+	);
+}
+
+export function FilterSidebar({
+	category,
+	labSidebarRef,
+	mode,
+	onSelectCategory,
+	onSelectMode,
+}: FilterSidebarProps) {
+	const [expandedMode, setExpandedMode] = useState<FilterLibraryMode | null>(
+		"library"
+	);
+
+	return (
+		<aside
+			className="flex w-36 shrink-0 flex-col overflow-hidden border-r border-border/50 px-1.5 py-2"
+			data-testid="filter-sidebar"
+		>
+			{MODE_OPTIONS.map(({ id, icon: Icon, label }, index) => {
+				const active = mode === id;
+				const expanded = active && expandedMode === id;
+				const categories = FILTER_CATEGORIES.filter(
+					(item) => id === "library" || item.id !== "mine"
+				);
+				return (
+					<div
+						key={id}
+						className={cn(
+							"flex flex-col py-1.5",
+							expanded ? "min-h-0 flex-1" : "shrink-0",
+							index > 0 && "border-t border-border/50"
+						)}
+					>
+						<button
+							type="button"
+							className={cn(
+								navigationButtonClass({ active: false }),
+								active && "font-semibold text-primary"
+							)}
+							aria-expanded={expanded}
+							aria-label={label}
+							aria-pressed={active}
+							data-testid={`filter-mode-${id}`}
+							onClick={() => {
+								if (!active) {
+									onSelectMode({ mode: id });
+									setExpandedMode(id);
+									return;
+								}
+								setExpandedMode((current) => (current === id ? null : id));
+							}}
+							onKeyDown={(event) => {
+								if (event.key !== "Enter" && event.key !== " ") return;
+								event.preventDefault();
+								event.currentTarget.click();
+							}}
+						>
+							<Icon className="size-3.5 shrink-0" aria-hidden="true" />
+							<span className="min-w-0 flex-1 truncate whitespace-nowrap">
+								{label}
+							</span>
+							<ChevronDown
+								className={cn(
+									"size-3 shrink-0 transition-transform",
+									!expanded && "-rotate-90"
+								)}
+								aria-hidden="true"
+							/>
+						</button>
+						{expanded && id !== "lab" ? (
+							<div className="mt-0.5 min-h-0 flex-1 space-y-0.5 overflow-y-auto">
+								{categories.map((item) => (
+									<CategoryButton
+										key={item.id}
+										category={item}
+										mode={id}
+										selectedCategory={category}
+										onSelectCategory={onSelectCategory}
+									/>
+								))}
+							</div>
+						) : null}
+						{expanded && id === "lab" ? (
+							<div
+								ref={labSidebarRef}
+								className="mt-1 min-h-0 min-w-0 flex-1 overflow-y-auto pl-1"
+							/>
+						) : null}
+					</div>
+				);
+			})}
+		</aside>
+	);
+}

--- a/qcut/apps/web/src/components/editor/media-panel/views/filters/index.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/filters/index.tsx
@@ -1,4 +1,4 @@
-import { FlaskConical, Search, Star } from "lucide-react";
+import { Search } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { assetManifestIdentity } from "@qcut/editor-core";
 import { toast } from "sonner";
@@ -20,7 +20,6 @@ import {
 } from "@/lib/filters/filter-registry";
 import type { FilterPreset } from "@/lib/filters/filter-types";
 import { DEFAULT_COLOR_FILTER_APPLICATION } from "@/lib/filters/filter-resolver";
-import { cn } from "@/lib/utils";
 import { useAssetLibraryStore } from "@/stores/asset-library-store";
 import { useTimelineStore } from "@/stores/timeline/timeline-store";
 import {
@@ -32,8 +31,7 @@ import { JianyingFilterLabShelf } from "../adjustments/jianying-filter-lab-shelf
 import { updateSelectedMediaColors } from "./filter-application";
 import { FilterCard } from "./filter-card";
 import { getSelectedMediaTargets } from "./filter-selection";
-
-type LibraryMode = "library" | "favorites" | "lab";
+import { FilterSidebar, type FilterLibraryMode } from "./filter-sidebar";
 
 function matchesQuery({
 	preset,
@@ -63,9 +61,12 @@ function savedPresetMatchesQuery({
 }
 
 export function FiltersView() {
-	const [mode, setMode] = useState<LibraryMode>("library");
+	const [mode, setMode] = useState<FilterLibraryMode>("library");
 	const [category, setCategory] = useState<FilterCategoryId>("all");
 	const [query, setQuery] = useState("");
+	const [labSidebarHost, setLabSidebarHost] = useState<HTMLDivElement | null>(
+		null
+	);
 	const [savedPresets, setSavedPresets] = useState(loadColorPresets);
 	const [selectedSavedPresetId, setSelectedSavedPresetId] = useState<string>();
 	const favorites = useAssetLibraryStore((state) => state.favorites);
@@ -189,6 +190,22 @@ export function FiltersView() {
 	const toggleFavorite = ({ presetId }: { presetId: string }) => {
 		toggleAssetFavorite({ kind: "filter", id: presetId });
 	};
+	const selectMode = ({ mode: nextMode }: { mode: FilterLibraryMode }) => {
+		setMode(nextMode);
+		if (nextMode === "favorites" && category === "mine") {
+			setCategory("all");
+		}
+	};
+	const selectSidebarCategory = ({
+		category: nextCategory,
+		mode: nextMode,
+	}: {
+		category: FilterCategoryId;
+		mode: Exclude<FilterLibraryMode, "lab">;
+	}) => {
+		setMode(nextMode);
+		setCategory(nextCategory);
+	};
 
 	const showNoneCard =
 		mode === "library" && category === "all" && query.trim().length === 0;
@@ -199,99 +216,35 @@ export function FiltersView() {
 			className="flex h-full min-h-0 flex-col bg-panel text-foreground"
 			data-testid="filters-view"
 		>
-			<div className="border-b border-border/50 p-3">
-				<div className="grid grid-cols-3 rounded-md bg-foreground/5 p-0.5">
-					{(["library", "favorites", "lab"] as const).map((item) => (
-						<button
-							key={item}
-							type="button"
-							className={cn(
-								"flex h-7 items-center justify-center gap-1.5 rounded text-[11px] font-medium transition-colors",
-								mode === item
-									? "bg-background text-foreground shadow-sm"
-									: "text-muted-foreground hover:text-foreground"
-							)}
-							onClick={() => {
-								setMode(item);
-								if (item === "favorites" && category === "mine")
-									setCategory("all");
-							}}
-							onKeyDown={(event) => {
-								if (event.key === "Enter" || event.key === " ") {
-									event.currentTarget.click();
-								}
-							}}
-							aria-pressed={mode === item}
-						>
-							{item === "favorites" && <Star className="size-3" />}
-							{item === "lab" && <FlaskConical className="size-3" />}
-							{item === "library"
-								? "Filter library"
-								: item === "favorites"
-									? "Favorites"
-									: "滤镜实验室"}
-						</button>
-					))}
-				</div>
-				{mode !== "lab" ? (
-					<div className="relative mt-2">
-						<Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-						<Input
-							value={query}
-							onChange={(event) => setQuery(event.target.value)}
-							placeholder="Search filters / 搜索滤镜"
-							className="h-8 pl-8 text-xs"
-							aria-label="Search filters"
-						/>
+			<div className="flex min-h-0 flex-1">
+				<FilterSidebar
+					category={category}
+					labSidebarRef={setLabSidebarHost}
+					mode={mode}
+					onSelectCategory={selectSidebarCategory}
+					onSelectMode={selectMode}
+				/>
+
+				{mode === "lab" ? (
+					<div className="min-h-0 min-w-0 flex-1 overflow-y-auto p-3">
+						<JianyingFilterLabShelf sidebarHost={labSidebarHost} />
 					</div>
-				) : null}
-			</div>
-
-			{mode === "lab" ? (
-				<div className="min-h-0 flex-1 overflow-y-auto p-3">
-					<JianyingFilterLabShelf />
-				</div>
-			) : (
-				<>
-					<div className="flex min-h-0 flex-1">
-						<aside className="w-[120px] shrink-0 overflow-y-auto border-r border-border/50 p-2">
-							<div className="space-y-0.5">
-								{FILTER_CATEGORIES.filter(
-									(item) => mode === "library" || item.id !== "mine"
-								).map((item) => {
-									const Icon = item.icon;
-									return (
-										<button
-											key={item.id}
-											type="button"
-											className={cn(
-												"flex h-8 w-full items-center gap-2 rounded px-2 text-left text-[10px] transition-colors",
-												category === item.id
-													? "bg-primary/15 text-primary"
-													: "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
-											)}
-											aria-pressed={category === item.id}
-											aria-label={`${item.label} / ${item.localizedLabel}`}
-											title={item.label}
-											data-testid={`filter-category-${item.id}`}
-											onClick={() => setCategory(item.id)}
-											onKeyDown={(event) => {
-												if (event.key === "Enter" || event.key === " ") {
-													event.currentTarget.click();
-												}
-											}}
-										>
-											<Icon className="size-3.5 shrink-0" />
-											<span className="whitespace-nowrap">
-												{item.localizedLabel}
-											</span>
-										</button>
-									);
-								})}
+				) : (
+					<div className="flex min-h-0 min-w-0 flex-1 flex-col">
+						<div className="shrink-0 border-b border-border/50 p-3">
+							<div className="relative">
+								<Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+								<Input
+									value={query}
+									onChange={(event) => setQuery(event.target.value)}
+									placeholder="Search filters / 搜索滤镜"
+									className="h-8 pl-8 text-xs"
+									aria-label="Search filters"
+								/>
 							</div>
-						</aside>
+						</div>
 
-						<section className="flex min-w-0 flex-1 flex-col">
+						<section className="flex min-h-0 min-w-0 flex-1 flex-col">
 							<div className="flex h-9 shrink-0 items-center justify-between border-b border-border/40 px-3 text-[10px] text-muted-foreground">
 								<div className="flex min-w-0 items-center gap-2">
 									<span className="truncate font-medium text-foreground">
@@ -363,51 +316,51 @@ export function FiltersView() {
 								)}
 							</div>
 						</section>
-					</div>
 
-					<div className="h-[68px] shrink-0 border-t border-border/50 px-3 py-2">
-						{activePreset ? (
-							<div className="flex h-full items-center gap-3">
-								<div className="w-[112px] min-w-0">
-									<div className="truncate text-xs font-medium">
-										{activePreset.name}
+						<div className="h-[68px] shrink-0 border-t border-border/50 px-3 py-2">
+							{activePreset ? (
+								<div className="flex h-full items-center gap-3">
+									<div className="w-[112px] min-w-0">
+										<div className="truncate text-xs font-medium">
+											{activePreset.name}
+										</div>
+										<div className="truncate text-[10px] text-muted-foreground">
+											{activePreset.localizedName}
+										</div>
 									</div>
-									<div className="truncate text-[10px] text-muted-foreground">
-										{activePreset.localizedName}
+									<div className="min-w-0 flex-1">
+										<div className="mb-1 flex items-center justify-between text-[10px] text-muted-foreground">
+											<span>Intensity</span>
+											<span className="tabular-nums">
+												{Math.round(activeFilter.intensity)}%
+											</span>
+										</div>
+										<Slider
+											value={[activeFilter.intensity]}
+											min={0}
+											max={100}
+											step={1}
+											disabled={!hasSelection}
+											aria-label="Filter intensity"
+											data-testid="filter-intensity-slider"
+											onValueChange={([value]) => updateIntensity({ value })}
+											onValueCommit={() => {
+												intensityInteractionActive.current = false;
+											}}
+										/>
 									</div>
 								</div>
-								<div className="min-w-0 flex-1">
-									<div className="mb-1 flex items-center justify-between text-[10px] text-muted-foreground">
-										<span>Intensity</span>
-										<span className="tabular-nums">
-											{Math.round(activeFilter.intensity)}%
-										</span>
-									</div>
-									<Slider
-										value={[activeFilter.intensity]}
-										min={0}
-										max={100}
-										step={1}
-										disabled={!hasSelection}
-										aria-label="Filter intensity"
-										data-testid="filter-intensity-slider"
-										onValueChange={([value]) => updateIntensity({ value })}
-										onValueCommit={() => {
-											intensityInteractionActive.current = false;
-										}}
-									/>
+							) : (
+								<div className="flex h-full items-center text-[11px] text-muted-foreground">
+									{hasSelection
+										? "Choose a filter to adjust its intensity."
+										: "Select one or more image or video clips to apply a filter."}
 								</div>
-							</div>
-						) : (
-							<div className="flex h-full items-center text-[11px] text-muted-foreground">
-								{hasSelection
-									? "Choose a filter to adjust its intensity."
-									: "Select one or more image or video clips to apply a filter."}
-							</div>
-						)}
+							)}
+						</div>
 					</div>
-				</>
-			)}
+				)}
+			</div>
 		</div>
 	);
 }

--- a/qcut/apps/web/src/components/editor/media-panel/views/text-style-lab/__tests__/jianying-text-style-lab.test.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/text-style-lab/__tests__/jianying-text-style-lab.test.tsx
@@ -31,22 +31,12 @@ function LabHarness({
 }) {
 	const lab = useJianyingTextStyleLab({ enabled: true });
 	const [view, setView] = useState<LabView>("trial");
-	const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>(
-		() => ({ charts: true, styles: false, effects: false, colors: false })
-	);
 	return (
 		<>
 			<JianyingTextStyleLabCategoryNav
-				expandedGroups={expandedGroups}
 				result={lab.result}
 				view={view}
 				onSelect={setView}
-				onToggleGroup={(groupId) =>
-					setExpandedGroups((current) => ({
-						...current,
-						[groupId]: !(current[groupId] ?? false),
-					}))
-				}
 			/>
 			<JianyingTextStyleLabPanel
 				lab={lab}
@@ -270,6 +260,11 @@ describe("JianyingTextStyleLabPanel", () => {
 		);
 		const cards = await screen.findAllByTestId("jianying-text-style-lab-card");
 		expect(cards).toHaveLength(5);
+		expect(cards[0]).toHaveAttribute("data-layout", "compact");
+		expect(screen.getByTestId("jianying-text-style-lab-grid")).toHaveClass(
+			"grid-cols-[repeat(auto-fill,minmax(82px,1fr))]"
+		);
+		expect(screen.queryByText("测试花字 1")).toBeNull();
 		await waitFor(() => expect(api.cover).toHaveBeenCalledTimes(5));
 
 		fireEvent.click(cards[0]);
@@ -289,7 +284,7 @@ describe("JianyingTextStyleLabPanel", () => {
 			await screen.findAllByTestId("jianying-text-style-lab-card")
 		).toHaveLength(5);
 
-		fireEvent.click(screen.getByRole("button", { name: "全部 8" }));
+		fireEvent.click(screen.getByRole("button", { name: "全部，8 个本地花字" }));
 		await waitFor(() =>
 			expect(
 				screen.getAllByTestId("jianying-text-style-lab-card")
@@ -300,8 +295,8 @@ describe("JianyingTextStyleLabPanel", () => {
 		).toBeDisabled();
 	});
 
-	it("pages beyond the first 24 cached flowers instead of truncating a category", async () => {
-		const styles = Array.from({ length: 30 }, (_, index) =>
+	it("pages beyond the first 40 cached flowers instead of truncating a category", async () => {
+		const styles = Array.from({ length: 50 }, (_, index) =>
 			createStyle({ index: index + 1 })
 		);
 		window.electronAPI = {
@@ -327,17 +322,19 @@ describe("JianyingTextStyleLabPanel", () => {
 		} as never;
 		render(<LabHarness onApply={vi.fn()} onClose={vi.fn()} />);
 
-		fireEvent.click(await screen.findByRole("button", { name: "全部 30" }));
+		fireEvent.click(
+			await screen.findByRole("button", { name: "全部，50 个本地花字" })
+		);
 		await waitFor(() =>
 			expect(
 				screen.getAllByTestId("jianying-text-style-lab-card")
-			).toHaveLength(24)
+			).toHaveLength(40)
 		);
 		fireEvent.click(screen.getByRole("button", { name: "加载更多" }));
 		await waitFor(() =>
 			expect(
 				screen.getAllByTestId("jianying-text-style-lab-card")
-			).toHaveLength(30)
+			).toHaveLength(50)
 		);
 		expect(screen.queryByRole("button", { name: "加载更多" })).toBeNull();
 	});
@@ -367,7 +364,9 @@ describe("JianyingTextStyleLabPanel", () => {
 		const onApply = vi.fn();
 		render(<LabHarness onApply={onApply} onClose={vi.fn()} />);
 
-		fireEvent.click(await screen.findByRole("button", { name: "全部 1" }));
+		fireEvent.click(
+			await screen.findByRole("button", { name: "全部，1 个本地花字" })
+		);
 		const card = await screen.findByRole("button", {
 			name: "应用花字 动态脚本花字",
 		});
@@ -501,12 +500,7 @@ describe("JianyingTextStyleLabPanel", () => {
 			7
 		);
 
-		// 颜色 starts folded, so its members are not in the tree until it opens —
-		// which is the collapse behaviour itself.
-		expect(
-			screen.queryByRole("button", { name: "紫色，1 个本地花字" })
-		).toBeNull();
-		fireEvent.click(screen.getByRole("button", { name: /颜色/ }));
+		// Jianying keeps every category in one scan-friendly list.
 		fireEvent.click(screen.getByRole("button", { name: "紫色，1 个本地花字" }));
 		expect(screen.getAllByTestId("jianying-text-style-lab-card")).toHaveLength(
 			1

--- a/qcut/apps/web/src/components/editor/media-panel/views/text-style-lab/jianying-text-style-lab-category-nav.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/text-style-lab/jianying-text-style-lab-category-nav.tsx
@@ -1,206 +1,79 @@
-import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type {
 	JianyingTextStyleCategoryId,
-	JianyingTextStyleLabCategoryGroupSummary,
 	JianyingTextStyleLabListResult,
 } from "@/types/electron";
 import { selectTrialStyles } from "./text-style-lab-selection";
 
 export type LabView = "trial" | "all" | JianyingTextStyleCategoryId;
 
-export const CATEGORY_GROUPS = [
-	{ id: "charts", label: "榜单", members: ["popular", "latest"] },
-	{ id: "styles", label: "风格", members: ["summer", "variety", "guofeng"] },
-	{ id: "effects", label: "效果", members: ["glow", "gradient", "texture"] },
-	{
-		id: "colors",
-		label: "颜色",
-		members: [
-			"red",
-			"yellow",
-			"black-white",
-			"blue",
-			"pink",
-			"green",
-			"purple",
-		],
-	},
-] as const;
-
-function resolvedCategoryGroups({
-	result,
-}: {
-	result: JianyingTextStyleLabListResult;
-}): JianyingTextStyleLabCategoryGroupSummary[] {
-	if (result.categoryGroups && result.categoryGroups.length > 0) {
-		return result.categoryGroups;
-	}
-	const groups = CATEGORY_GROUPS.map(({ id, label, members }) => {
-		const categoryIds = members.filter((member) =>
-			result.categories.some(({ id: categoryId }) => categoryId === member)
-		) as JianyingTextStyleCategoryId[];
-		return {
-			id,
-			label,
-			categoryIds,
-			count: result.styles.filter(({ categoryIds: styleCategoryIds }) =>
-				categoryIds.some((categoryId) => styleCategoryIds.includes(categoryId))
-			).length,
-		};
-	}).filter(({ categoryIds }) => categoryIds.length > 0);
-	const groupedIds = new Set(groups.flatMap(({ categoryIds }) => categoryIds));
-	const ungroupedIds = result.categories
-		.map(({ id }) => id)
-		.filter((id) => !groupedIds.has(id));
-	if (ungroupedIds.length === 0) return groups;
-	return [
-		...groups,
-		{
-			id: "other",
-			label: "其他",
-			categoryIds: ungroupedIds,
-			count: result.styles.filter(({ categoryIds }) =>
-				ungroupedIds.some((categoryId) => categoryIds.includes(categoryId))
-			).length,
-		},
-	];
-}
-
-function CategoryGroup({
-	group,
-	categories,
+function CategoryButton({
+	count,
+	label,
+	selected,
 	view,
-	expanded,
-	onToggle,
 	onSelect,
 }: {
-	group: JianyingTextStyleLabCategoryGroupSummary;
-	categories: { id: string; label: string; count: number }[];
+	count: number;
+	label: string;
+	selected: boolean;
 	view: LabView;
-	expanded: boolean;
-	onToggle: () => void;
 	onSelect: (id: LabView) => void;
 }) {
-	const members = group.categoryIds
-		.map((id) => categories.find((category) => category.id === id))
-		.filter((category): category is NonNullable<typeof category> =>
-			Boolean(category)
-		);
-	if (members.length === 0) return null;
-	const holdsActive = members.some((category) => category.id === view);
 	return (
-		<div className="mb-1">
-			<button
-				type="button"
-				aria-expanded={expanded}
-				className={cn(
-					"flex h-6 w-full items-center gap-1 rounded-sm px-1.5 text-[10px] uppercase tracking-wide",
-					holdsActive && !expanded
-						? "text-cyan-200"
-						: "text-muted-foreground hover:bg-white/[0.06]"
-				)}
-				onClick={onToggle}
-				onKeyDown={(event) => {
-					if (event.key === "Enter" || event.key === " ") {
-						event.preventDefault();
-						onToggle();
-					}
-				}}
-			>
-				<ChevronRight
-					className={cn(
-						"size-3 shrink-0 transition-transform",
-						expanded && "rotate-90"
-					)}
-				>
-					<title>{expanded ? "收起" : "展开"}</title>
-				</ChevronRight>
-				<span className="truncate">{group.label}</span>
-				<span className="ml-auto text-[10px]">{group.count}</span>
-			</button>
-			{expanded
-				? members.map((category) => (
-						<button
-							key={category.id}
-							type="button"
-							aria-label={`${category.label}，${category.count} 个本地花字`}
-							aria-pressed={view === category.id}
-							className={cn(
-								"mb-0.5 flex h-7 w-full items-center justify-between rounded-sm pl-4 pr-2 text-[11px]",
-								view === category.id
-									? "bg-cyan-400/10 text-cyan-200"
-									: "text-muted-foreground hover:bg-white/[0.06]"
-							)}
-							onClick={() => onSelect(category.id as LabView)}
-							onKeyDown={(event) => {
-								if (event.key === "Enter" || event.key === " ") {
-									event.preventDefault();
-									onSelect(category.id as LabView);
-								}
-							}}
-						>
-							<span className="truncate">{category.label}</span>
-							<span className="text-[10px] text-muted-foreground">
-								{category.count}
-							</span>
-						</button>
-					))
-				: null}
-		</div>
+		<button
+			type="button"
+			aria-label={`${label}，${count} 个本地花字`}
+			aria-pressed={selected}
+			className={cn(
+				"mb-0.5 flex h-7 w-full items-center rounded-sm px-2 text-left text-[11px] transition-colors",
+				selected
+					? "bg-white/10 text-cyan-300"
+					: "text-muted-foreground hover:bg-white/[0.06] hover:text-foreground"
+			)}
+			onClick={() => onSelect(view)}
+			onKeyDown={(event) => {
+				if (event.key === "Escape") event.currentTarget.blur();
+			}}
+		>
+			<span className="truncate">{label}</span>
+		</button>
 	);
 }
 
 export function JianyingTextStyleLabCategoryNav({
-	expandedGroups,
 	result,
 	view,
 	onSelect,
-	onToggleGroup,
 }: {
-	expandedGroups: Record<string, boolean>;
 	result: JianyingTextStyleLabListResult;
 	view: LabView;
 	onSelect: (id: LabView) => void;
-	onToggleGroup: (groupId: string) => void;
 }) {
 	const trialCount = selectTrialStyles({ styles: result.styles }).length;
-	const groups = resolvedCategoryGroups({ result });
 	return (
-		<div className="pl-2">
-			{(["trial", "all"] as const).map((option) => (
-				<button
-					key={option}
-					type="button"
-					aria-pressed={view === option}
-					className={cn(
-						"mb-1 flex h-7 w-full items-center justify-between rounded-sm px-2 text-[11px]",
-						view === option
-							? "bg-white/10 text-foreground"
-							: "text-muted-foreground hover:bg-white/[0.06]"
-					)}
-					onClick={() => onSelect(option)}
-					onKeyDown={(event) => {
-						if (event.key === "Enter" || event.key === " ") {
-							event.preventDefault();
-							onSelect(option);
-						}
-					}}
-				>
-					<span>{option === "trial" ? "五款预览" : "全部"}</span>
-					<span className="text-[10px] text-muted-foreground">
-						{option === "trial" ? trialCount : result.count}
-					</span>
-				</button>
-			))}
-			{groups.map((group) => (
-				<CategoryGroup
-					key={group.id}
-					group={group}
-					categories={result.categories}
-					view={view}
-					expanded={expandedGroups[group.id] ?? false}
-					onToggle={() => onToggleGroup(group.id)}
+		<div className="pl-2 pt-0.5">
+			<CategoryButton
+				count={trialCount}
+				label="五款预览"
+				selected={view === "trial"}
+				view="trial"
+				onSelect={onSelect}
+			/>
+			<CategoryButton
+				count={result.count}
+				label="全部"
+				selected={view === "all"}
+				view="all"
+				onSelect={onSelect}
+			/>
+			{result.categories.map((category) => (
+				<CategoryButton
+					key={category.id}
+					count={category.count}
+					label={category.label}
+					selected={view === category.id}
+					view={category.id}
 					onSelect={onSelect}
 				/>
 			))}

--- a/qcut/apps/web/src/components/editor/media-panel/views/text-style-lab/jianying-text-style-lab.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/text-style-lab/jianying-text-style-lab.tsx
@@ -31,8 +31,8 @@ export {
 	type LabView,
 } from "./jianying-text-style-lab-category-nav";
 
-const INITIAL_STYLE_BATCH = 24;
-const STYLE_BATCH_SIZE = 24;
+const INITIAL_STYLE_BATCH = 40;
+const STYLE_BATCH_SIZE = 40;
 type CoverState = "loading" | "ready" | "error" | "missing";
 
 function compatibilityLabel({
@@ -46,23 +46,17 @@ function compatibilityLabel({
 	return "仅参考预览";
 }
 
-function fillKindLabel({ style }: { style: JianyingTextStyleLabStyleSummary }) {
-	if (style.packageKind !== "TextStyle") return "运行时";
-	if (style.fillKind === "solid") return "纯色";
-	if (style.fillKind === "gradient") return "渐变";
-	if (style.fillKind === "texture") return "纹理";
-	return "未知";
-}
-
 function packageKindLabel({
 	style,
 }: {
 	style: JianyingTextStyleLabStyleSummary;
 }) {
-	if (style.packageKind === "TextStyle") return fillKindLabel({ style });
 	if (style.packageKind === "InfoSticker") return "动态组件";
 	if (style.packageKind === "ScriptInfoSticker") return "脚本组件";
 	if (style.packageKind === "AmazingFeature") return "引擎组件";
+	if (style.fillKind === "solid") return "纯色";
+	if (style.fillKind === "gradient") return "渐变";
+	if (style.fillKind === "texture") return "纹理";
 	return "运行时";
 }
 
@@ -127,24 +121,26 @@ function TextStyleLabCard({
 			aria-label={canApply ? `应用花字 ${title}` : `${title} 仅供预览`}
 			aria-pressed={selected}
 			className={cn(
-				"group min-w-0 rounded-md border bg-[#292929] p-1.5 text-left transition-colors",
+				"group relative aspect-square min-w-0 overflow-hidden rounded-md border bg-[#303030] p-0 text-left transition-colors",
 				selected
 					? "border-cyan-400 bg-cyan-400/10"
-					: "border-white/5 hover:border-white/20 hover:bg-[#303030]",
+					: "border-transparent hover:border-white/25 hover:bg-[#383838]",
 				!canApply && "cursor-not-allowed opacity-65"
 			)}
 			disabled={!canApply}
+			data-layout="compact"
 			data-testid="jianying-text-style-lab-card"
+			title={`${title} · ${compatibilityLabel({ style })}`}
 			onClick={() => onApply({ style })}
 			onKeyDown={(event) => {
 				if (event.key === "Escape") event.currentTarget.blur();
 			}}
 		>
-			<div className="relative aspect-square overflow-hidden rounded-sm bg-[#202020]">
+			<div className="relative h-full w-full overflow-hidden bg-[#262626]">
 				{cover.state === "ready" ? (
 					<img
 						alt=""
-						className="h-full w-full object-cover"
+						className="h-full w-full object-contain"
 						draggable={false}
 						src={cover.url}
 					/>
@@ -162,7 +158,7 @@ function TextStyleLabCard({
 				<div className="absolute left-1 top-1 flex items-center gap-1">
 					<span
 						className={cn(
-							"flex size-4 items-center justify-center rounded-sm bg-black/70",
+							"flex size-4 items-center justify-center rounded-full bg-black/75 shadow-sm",
 							style.compatibility === "flat-compatible"
 								? "text-emerald-300"
 								: style.compatibility === "approximated"
@@ -183,25 +179,10 @@ function TextStyleLabCard({
 					</span>
 				</div>
 				{selected ? (
-					<span className="absolute right-1 top-1 flex size-5 items-center justify-center rounded-sm bg-cyan-400 text-black">
-						<Check className="size-3.5" />
+					<span className="absolute right-1 top-1 flex size-4 items-center justify-center rounded-full bg-cyan-400 text-black shadow-sm">
+						<Check className="size-3" />
 					</span>
 				) : null}
-			</div>
-			<div className="mt-1.5 truncate text-xs text-foreground" title={title}>
-				{title}
-			</div>
-			<div className="mt-0.5 flex min-w-0 items-center justify-between gap-1 text-[10px] text-muted-foreground">
-				<span className="truncate">{packageKindLabel({ style })}</span>
-				{style.packageKind === "TextStyle" ? (
-					<span className="shrink-0">
-						{style.strokeCount} 描边 · {style.shadowCount} 阴影
-					</span>
-				) : style.runtimeReference ? (
-					<span className="shrink-0">本机原版</span>
-				) : (
-					<span className="shrink-0">仅预览</span>
-				)}
 			</div>
 		</button>
 	);
@@ -395,8 +376,7 @@ export function JianyingTextStyleLabPanel({
 								(view === "trial" ? "五款预览" : "全部花字")}
 						</span>
 						<span className="text-[10px] text-muted-foreground">
-							{visibleStyles.length} / {filteredStyles.length} QCut 备份 ·{" "}
-							{result.packageCount} 包
+							{filteredStyles.length} 款
 						</span>
 					</div>
 					{error ? (
@@ -413,8 +393,9 @@ export function JianyingTextStyleLabPanel({
 					) : null}
 					{!error && (!checking || result.count > 0) ? (
 						<div
+							data-testid="jianying-text-style-lab-grid"
 							className={cn(
-								"mt-2 grid auto-rows-max content-start grid-cols-2 gap-2 overflow-y-auto pr-1",
+								"mt-2 grid auto-rows-max content-start grid-cols-[repeat(auto-fill,minmax(82px,1fr))] gap-2 overflow-y-auto pr-1",
 								animationPickerVisible ? "max-h-[16rem]" : "flex-1"
 							)}
 						>
@@ -429,7 +410,7 @@ export function JianyingTextStyleLabPanel({
 							{hasMore ? (
 								<div
 									ref={loadMoreRef}
-									className="col-span-2 flex h-10 items-center justify-center"
+									className="col-span-full flex h-10 items-center justify-center"
 								>
 									<Button
 										type="button"

--- a/qcut/apps/web/src/components/editor/media-panel/views/text.tsx
+++ b/qcut/apps/web/src/components/editor/media-panel/views/text.tsx
@@ -1660,9 +1660,7 @@ export function TextLibraryNav({
 	onOpenStyleLab,
 	styleLabView = "trial",
 	styleLabResult = EMPTY_TEXT_STYLE_LAB_RESULT,
-	styleLabExpandedGroups = {},
 	onSelectStyleLabView,
-	onToggleStyleLabGroup,
 }: {
 	activeCategoryId: TextTemplateCategoryId;
 	className?: string;
@@ -1678,9 +1676,7 @@ export function TextLibraryNav({
 	 */
 	styleLabView?: StyleLabView;
 	styleLabResult?: JianyingTextStyleLabListResult;
-	styleLabExpandedGroups?: Record<string, boolean>;
 	onSelectStyleLabView?: (view: StyleLabView) => void;
-	onToggleStyleLabGroup?: (groupId: string) => void;
 }) {
 	const { locale, t } = useTranslation();
 	return (
@@ -1802,11 +1798,9 @@ export function TextLibraryNav({
 			</button>
 			{styleLabOpen && (
 				<JianyingTextStyleLabCategoryNav
-					expandedGroups={styleLabExpandedGroups}
 					result={styleLabResult}
 					view={styleLabView}
 					onSelect={(next) => onSelectStyleLabView?.(next)}
-					onToggleGroup={(groupId) => onToggleStyleLabGroup?.(groupId)}
 				/>
 			)}
 		</nav>
@@ -2229,9 +2223,6 @@ export function TextView() {
 	// not the lab — owns the selection and the data.
 	const [styleLabOpen, setStyleLabOpen] = useState(false);
 	const [styleLabView, setStyleLabView] = useState<StyleLabView>("trial");
-	const [styleLabExpandedGroups, setStyleLabExpandedGroups] = useState<
-		Record<string, boolean>
-	>(() => ({ charts: true, styles: false, effects: false, colors: false }));
 	const styleLab = useJianyingTextStyleLab({ enabled: styleLabOpen });
 	const { locale, t } = useTranslation();
 	const tracks = useTimelineStore((state) => state.tracks);
@@ -2762,14 +2753,7 @@ export function TextView() {
 						onOpenStyleLab={() => setStyleLabOpen(true)}
 						styleLabView={styleLabView}
 						styleLabResult={styleLab.result}
-						styleLabExpandedGroups={styleLabExpandedGroups}
 						onSelectStyleLabView={setStyleLabView}
-						onToggleStyleLabGroup={(groupId) =>
-							setStyleLabExpandedGroups((current) => ({
-								...current,
-								[groupId]: !(current[groupId] ?? false),
-							}))
-						}
 					/>
 				</ResizablePanel>
 				<ResizableHandle />

--- a/qcut/apps/web/src/lib/audio/local-sound-effects-lab-config.ts
+++ b/qcut/apps/web/src/lib/audio/local-sound-effects-lab-config.ts
@@ -2,6 +2,14 @@ export type LocalSoundEffectsLabSource =
 	| { kind: "manifest"; manifestPath: string }
 	| { kind: "private-manifest" };
 
+export function isSoundEffectsLabEnabled({
+	configuredValue,
+}: {
+	configuredValue?: string;
+}): boolean {
+	return configuredValue?.trim().toLowerCase() !== "false";
+}
+
 export function buildLocalSoundEffectsLabSource({
 	isEnabled,
 	manifestPath,
@@ -19,7 +27,9 @@ export function buildLocalSoundEffectsLabSource({
 
 export function getLocalSoundEffectsLabSource(): LocalSoundEffectsLabSource | null {
 	return buildLocalSoundEffectsLabSource({
-		isEnabled: import.meta.env.VITE_QCUT_ENABLE_SOUND_EFFECTS_LAB === "true",
+		isEnabled: isSoundEffectsLabEnabled({
+			configuredValue: import.meta.env.VITE_QCUT_ENABLE_SOUND_EFFECTS_LAB,
+		}),
 		manifestPath: import.meta.env.VITE_QCUT_SOUND_EFFECTS_LAB_MANIFEST_PATH,
 	});
 }

--- a/qcut/apps/web/src/test/e2e/filter-library.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/filter-library.e2e.ts
@@ -90,6 +90,12 @@ test.describe("Filter library", () => {
 		await openFilters({ page });
 
 		const filters = page.getByTestId("filters-view");
+		const sidebar = filters.getByTestId("filter-sidebar");
+		const libraryMode = sidebar.getByRole("button", {
+			name: "Filter library",
+		});
+		await expect(sidebar).toBeVisible();
+		await expect(libraryMode).toHaveAttribute("aria-expanded", "true");
 		await expect(filters.locator('[data-testid^="filter-card-"]')).toHaveCount(
 			allCardCount
 		);
@@ -106,10 +112,37 @@ test.describe("Filter library", () => {
 					)
 			)
 			.toBe(true);
+
+		await libraryMode.click();
+		await expect(libraryMode).toHaveAttribute("aria-expanded", "false");
+		await expect(sidebar.getByTestId("filter-category-all")).toHaveCount(0);
+		await expect(filters.locator('[data-testid^="filter-card-"]')).toHaveCount(
+			allCardCount
+		);
+		await filters.screenshot({
+			path: path.join(outputDirectory, "00-library-collapsed.png"),
+			animations: "disabled",
+		});
+		await libraryMode.click();
+		await expect(sidebar.getByTestId("filter-category-all")).toBeVisible();
 		await filters.screenshot({
 			path: path.join(outputDirectory, "00-library.png"),
 			animations: "disabled",
 		});
+
+		const labMode = sidebar.getByRole("button", { name: "滤镜实验室" });
+		await labMode.click();
+		await expect(labMode).toHaveAttribute("aria-expanded", "true");
+		await expect(
+			sidebar.getByTestId("jianying-filter-lab-categories")
+		).toBeVisible();
+		await filters.screenshot({
+			path: path.join(outputDirectory, "00-filter-lab.png"),
+			animations: "disabled",
+		});
+		await libraryMode.click();
+		await expect(filters.getByLabel("Search filters")).toBeVisible();
+
 		for (const categoryCase of categoryCases) {
 			await filters.getByTestId(`filter-category-${categoryCase.id}`).click();
 			const categoryCards = filters.locator('[data-testid^="filter-card-"]');

--- a/qcut/electron/__tests__/jianying-filter-thumbnail-cache.test.ts
+++ b/qcut/electron/__tests__/jianying-filter-thumbnail-cache.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -93,5 +93,39 @@ describe("Jianying filter thumbnail cache", () => {
 				fetcher,
 			})
 		).rejects.toThrow("格式不受支持");
+	});
+
+	it("falls back to the remote source when the local file is unusable", async () => {
+		for (const localContent of [Buffer.alloc(0), Buffer.from("not an image")]) {
+			const cacheRoot = await createCacheRoot();
+			const sourcePath = join(cacheRoot, "stale-thumbnail.png");
+			await writeFile(sourcePath, localContent);
+			const fetcher = vi.fn(
+				async () =>
+					new Response(PNG_BYTES, {
+						status: 200,
+						headers: {
+							"content-length": String(PNG_BYTES.length),
+							"content-type": "image/png",
+						},
+					})
+			) as unknown as typeof fetch;
+
+			const thumbnail = await readJianyingFilterThumbnail({
+				source: {
+					resourceId: "filter-1",
+					sourcePath,
+					sourceUrl: "https://p3-heycan-jy-sign.byteimg.com/filter.png",
+				},
+				cacheRoot,
+				fetcher,
+			});
+
+			expect(thumbnail).toMatchObject({
+				mimeType: "image/png",
+				fromCache: false,
+			});
+			expect(fetcher).toHaveBeenCalledOnce();
+		}
 	});
 });

--- a/qcut/electron/__tests__/jianying-text-render-cache-lock.test.ts
+++ b/qcut/electron/__tests__/jianying-text-render-cache-lock.test.ts
@@ -61,28 +61,43 @@ describe("Jianying text render cache lock", () => {
 		const cacheRoot = await createCacheRoot();
 		const events: string[] = [];
 		let releaseFirst: (() => void) | undefined;
+		let firstStarted: (() => void) | undefined;
 		const firstMayFinish = new Promise<void>((resolve) => {
 			releaseFirst = resolve;
+		});
+		const firstIsRunning = new Promise<void>((resolve) => {
+			firstStarted = resolve;
 		});
 		const first = runLocked({
 			cacheRoot,
 			task: async () => {
 				events.push("first:start");
+				firstStarted?.();
 				await firstMayFinish;
 				events.push("first:end");
 			},
 		});
-		await delay(20);
-		const second = runLocked({
-			cacheRoot,
-			task: async () => {
-				events.push("second:start");
-			},
-		});
-		await delay(20);
-		expect(events).toEqual(["first:start"]);
-		releaseFirst?.();
-		await Promise.all([first, second]);
+		let second: Promise<void> | undefined;
+		try {
+			// Wait for the real critical-section entry rather than guessing with a
+			// wall clock: acquiring does open + write + fsync + fstat, which costs
+			// a few milliseconds here but roughly ten times that on Windows CI.
+			await firstIsRunning;
+			second = runLocked({
+				cacheRoot,
+				task: async () => {
+					events.push("second:start");
+				},
+			});
+			await delay(20);
+			expect(events).toEqual(["first:start"]);
+		} finally {
+			// Settle both writers before afterEach removes cacheRoot; otherwise a
+			// failed assertion leaves the second writer retrying open() against a
+			// deleted directory, which surfaces as an unrelated ENOENT.
+			releaseFirst?.();
+			await Promise.allSettled([first, second]);
+		}
 		expect(events).toEqual(["first:start", "first:end", "second:start"]);
 	});
 

--- a/qcut/electron/__tests__/jianying-text-render-cache-lock.test.ts
+++ b/qcut/electron/__tests__/jianying-text-render-cache-lock.test.ts
@@ -82,7 +82,9 @@ describe("Jianying text render cache lock", () => {
 			// Wait for the real critical-section entry rather than guessing with a
 			// wall clock: acquiring does open + write + fsync + fstat, which costs
 			// a few milliseconds here but roughly ten times that on Windows CI.
-			await firstIsRunning;
+			// Racing `first` means a failed acquisition reports its own error
+			// instead of hanging this barrier until the test times out.
+			await Promise.race([firstIsRunning, first]);
 			second = runLocked({
 				cacheRoot,
 				task: async () => {

--- a/qcut/electron/__tests__/jianying-text-style-cover-cache.test.ts
+++ b/qcut/electron/__tests__/jianying-text-style-cover-cache.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readJianyingTextStyleCoverImage } from "../jianying-text-style-cover-cache.js";
+
+const PNG_BYTES = Buffer.from(
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+	"base64"
+);
+const temporaryRoots: string[] = [];
+
+async function createCacheRoot() {
+	const root = await mkdtemp(join(tmpdir(), "qcut-text-cover-cache-"));
+	temporaryRoots.push(root);
+	return root;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryRoots
+			.splice(0)
+			.map((root) => rm(root, { recursive: true, force: true }))
+	);
+});
+
+describe("Jianying text style cover cache", () => {
+	it("keeps a cover across signed URL changes", async () => {
+		const cacheRoot = await createCacheRoot();
+		const fetcher = vi.fn(
+			async () =>
+				new Response(PNG_BYTES, {
+					status: 200,
+					headers: { "content-type": "image/png" },
+				})
+		) as unknown as typeof fetch;
+		const styleId = `7212166583127379258/${"a".repeat(32)}`;
+
+		const first = await readJianyingTextStyleCoverImage({
+			cacheRoot,
+			fetcher,
+			sourceUrl: "https://p3-heycan-jy-sign.byteimg.com/cover.png?token=old",
+			styleId,
+		});
+		const second = await readJianyingTextStyleCoverImage({
+			cacheRoot,
+			fetcher,
+			sourceUrl: "https://p3-heycan-jy-sign.byteimg.com/cover.png?token=new",
+			styleId,
+		});
+
+		expect(first).toMatchObject({ mimeType: "image/png", fromCache: false });
+		expect(second).toMatchObject({ mimeType: "image/png", fromCache: true });
+		expect(fetcher).toHaveBeenCalledOnce();
+		expect(await readdir(cacheRoot)).toHaveLength(1);
+	});
+
+	it("rejects an untrusted cover host", async () => {
+		const fetcher = vi.fn() as unknown as typeof fetch;
+		await expect(
+			readJianyingTextStyleCoverImage({
+				cacheRoot: await createCacheRoot(),
+				fetcher,
+				sourceUrl: "https://example.com/cover.png",
+				styleId: `7212166583127379258/${"a".repeat(32)}`,
+			})
+		).rejects.toThrow("不受信任");
+		expect(fetcher).not.toHaveBeenCalled();
+	});
+
+	it("caches a local fallback when the remote cover fails", async () => {
+		const cacheRoot = await createCacheRoot();
+		const fetcher = vi.fn(async () => {
+			throw new Error("network unavailable");
+		}) as unknown as typeof fetch;
+		const produceFallback = vi.fn(async () => PNG_BYTES);
+		const request = {
+			cacheRoot,
+			fetcher,
+			produceFallback,
+			sourceUrl: "https://p3-heycan-jy-sign.byteimg.com/cover.png",
+			styleId: `7212166583127379258/${"b".repeat(32)}`,
+		};
+
+		const first = await readJianyingTextStyleCoverImage(request);
+		const second = await readJianyingTextStyleCoverImage(request);
+
+		expect(first).toMatchObject({ mimeType: "image/png", fromCache: false });
+		expect(second).toMatchObject({ mimeType: "image/png", fromCache: true });
+		expect(fetcher).toHaveBeenCalledOnce();
+		expect(produceFallback).toHaveBeenCalledOnce();
+	});
+});

--- a/qcut/electron/__tests__/jianying-text-style-cover-metadata.test.ts
+++ b/qcut/electron/__tests__/jianying-text-style-cover-metadata.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import type { JianyingTextStyleCatalogEntry } from "../jianying-text-style-lab-catalog.js";
+import {
+	attachJianyingTextStyleCoverUrls,
+	resolveJianyingTextStyleCoverUrls,
+} from "../jianying-text-style-cover-metadata.js";
+
+const temporaryDirectories: string[] = [];
+
+async function createDatabaseRoot() {
+	const root = await mkdtemp(join(tmpdir(), "qcut-text-cover-metadata-"));
+	temporaryDirectories.push(root);
+	const accountDirectory = join(root, "account-one");
+	await mkdir(accountDirectory, { recursive: true });
+	const database = new DatabaseSync(join(accountDirectory, "rp.db"));
+	database.exec(`
+		CREATE TABLE http_cache (
+			url TEXT NOT NULL,
+			response_body TEXT NOT NULL,
+			timestamp INTEGER NOT NULL
+		)
+	`);
+	return { database, root };
+}
+
+function catalogEntry({
+	resourceId,
+	version,
+}: {
+	resourceId: string;
+	version: string;
+}) {
+	return {
+		styleId: `${resourceId}/${version}`,
+		resourceId,
+		version,
+		hasCover: false,
+	} as JianyingTextStyleCatalogEntry;
+}
+
+function catalogResponse({
+	coverUrl,
+	resourceId,
+	version,
+}: {
+	coverUrl: string;
+	resourceId: string;
+	version: string;
+}) {
+	return JSON.stringify({
+		data: {
+			items: [
+				{
+					common_attr: {
+						id: resourceId,
+						md5: version,
+						cover_url: { static_img: coverUrl },
+					},
+				},
+			],
+		},
+	});
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { recursive: true, force: true }))
+	);
+});
+
+describe("Jianying text style cover metadata", () => {
+	it("resolves the newest trusted static cover for an exact package", async () => {
+		const { database, root } = await createDatabaseRoot();
+		const resourceId = "7212166583127379258";
+		const version = "a".repeat(32);
+		const insert = database.prepare(
+			"INSERT INTO http_cache (url, response_body, timestamp) VALUES (?, ?, ?)"
+		);
+		insert.run(
+			"https://example.test/text-template",
+			catalogResponse({
+				coverUrl: "https://p3-heycan-jy-sign.byteimg.com/new.png?token=2",
+				resourceId,
+				version,
+			}),
+			2
+		);
+		insert.run(
+			"https://example.test/text-template",
+			catalogResponse({
+				coverUrl: "https://p3-heycan-jy-sign.byteimg.com/old.png?token=1",
+				resourceId,
+				version,
+			}),
+			1
+		);
+		insert.run(
+			"https://example.test/text-template",
+			catalogResponse({
+				coverUrl: "https://example.com/untrusted.png",
+				resourceId: "7212166583127379259",
+				version: "b".repeat(32),
+			}),
+			3
+		);
+		database.close();
+
+		const covers = await resolveJianyingTextStyleCoverUrls({
+			databaseRoot: root,
+			references: [
+				catalogEntry({ resourceId, version }),
+				catalogEntry({
+					resourceId: "7212166583127379259",
+					version: "b".repeat(32),
+				}),
+			],
+		});
+
+		expect([...covers]).toEqual([
+			[
+				`${resourceId}/${version}`,
+				"https://p3-heycan-jy-sign.byteimg.com/new.png?token=2",
+			],
+		]);
+	});
+
+	it("attaches covers without replacing titles or categories", () => {
+		const styleId = `7212166583127379258/${"a".repeat(32)}`;
+		const metadata = attachJianyingTextStyleCoverUrls({
+			coverUrls: new Map([
+				[styleId, "https://p3-heycan-jy-sign.byteimg.com/cover.png"],
+			]),
+			metadata: new Map([
+				[
+					styleId,
+					{ title: "脚本模板", categoryIds: ["source-qcut-script-template"] },
+				],
+			]),
+		});
+
+		expect(metadata.get(styleId)).toEqual({
+			title: "脚本模板",
+			categoryIds: ["source-qcut-script-template"],
+			coverUrl: "https://p3-heycan-jy-sign.byteimg.com/cover.png",
+		});
+	});
+});

--- a/qcut/electron/__tests__/jianying-text-style-generated-cover.test.ts
+++ b/qcut/electron/__tests__/jianying-text-style-generated-cover.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCanvas } from "@napi-rs/canvas";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEmptyJianyingTextEffectCapabilities } from "../jianying-text-effect-capabilities.js";
+import type { JianyingTextStyleCatalogEntry } from "../jianying-text-style-lab-catalog.js";
+import { readJianyingTextStyleGeneratedCover } from "../jianying-text-style-generated-cover.js";
+import type { renderJianyingText } from "../jianying-text-runtime/render.js";
+
+const temporaryRoots: string[] = [];
+
+function createFrameBytes({ tiny = false }: { tiny?: boolean } = {}) {
+	const canvas = createCanvas(256, 256);
+	const context = canvas.getContext("2d");
+	context.fillStyle = "#00ddff";
+	context.fillRect(
+		tiny ? 126 : 48,
+		tiny ? 126 : 88,
+		tiny ? 4 : 160,
+		tiny ? 4 : 80
+	);
+	return canvas.toBuffer("image/png");
+}
+
+async function createWorkspace({
+	frameBytes = createFrameBytes(),
+}: {
+	frameBytes?: Buffer;
+} = {}) {
+	const root = await mkdtemp(join(tmpdir(), "qcut-generated-text-cover-"));
+	temporaryRoots.push(root);
+	const frames = join(root, "frames");
+	await mkdir(frames, { recursive: true });
+	await writeFile(join(frames, "frame-000001.png"), frameBytes);
+	return { cacheRoot: join(root, "cache"), frames };
+}
+
+function runtimeEntry(): JianyingTextStyleCatalogEntry {
+	const resourceId = "7328639616670649634";
+	const version = "b".repeat(32);
+	return {
+		styleId: `${resourceId}/${version}`,
+		resourceId,
+		version,
+		packageKind: "ScriptInfoSticker",
+		packageVersion: "runtime",
+		fillKind: "unknown",
+		strokeCount: 0,
+		innerShadowCount: 0,
+		shadowCount: 0,
+		textureLayerCount: 0,
+		capabilities: createEmptyJianyingTextEffectCapabilities(),
+		diagnostics: [],
+		hasCover: false,
+		compatibility: "native-runtime",
+		runtimeReference: {
+			schemaVersion: 1,
+			source: "jianying-cache",
+			packageKind: "ScriptInfoSticker",
+			resourceId,
+			packageHash: version,
+			editMode: "runtime-with-preload-fallback",
+			slotMapping: "line-to-widget",
+			timeMapping: "stretch",
+			templateDuration: 3,
+		},
+	};
+}
+
+function createRender({
+	entry,
+	frames,
+}: {
+	entry: JianyingTextStyleCatalogEntry;
+	frames: string;
+}) {
+	return vi.fn(async ({ request }) => ({
+		requestId: request.requestId,
+		resourceId: entry.resourceId,
+		packageHash: entry.version,
+		templateDuration: 3,
+		frameCount: 3,
+		strategy: "runtime-parameters" as const,
+		cacheHit: false,
+		x: 0,
+		y: 0,
+		width: 256,
+		height: 256,
+		source: {
+			kind: "image-sequence" as const,
+			path: join(frames, "frame-%06d.png"),
+			frameRate: 1,
+		},
+	})) as unknown as typeof renderJianyingText;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryRoots
+			.splice(0)
+			.map((root) => rm(root, { recursive: true, force: true }))
+	);
+});
+
+describe("Jianying generated text style covers", () => {
+	it("renders a middle frame once and reuses the local cover", async () => {
+		const { cacheRoot, frames } = await createWorkspace();
+		const entry = runtimeEntry();
+		const render = createRender({ entry, frames });
+
+		const first = await readJianyingTextStyleGeneratedCover({
+			cacheRoot,
+			entry,
+			render,
+		});
+		const second = await readJianyingTextStyleGeneratedCover({
+			cacheRoot,
+			entry,
+			render,
+		});
+
+		expect(first).toMatchObject({ mimeType: "image/png", fromCache: false });
+		expect(second).toMatchObject({ mimeType: "image/png", fromCache: true });
+		expect(render).toHaveBeenCalledOnce();
+		expect(render).toHaveBeenCalledWith({
+			request: expect.objectContaining({
+				content: "花字",
+				frameCount: 3,
+				fps: 1,
+			}),
+		});
+	});
+
+	it("creates a cached QCut cover when the native runtime is unavailable", async () => {
+		const { cacheRoot } = await createWorkspace();
+		const entry = runtimeEntry();
+		const render = vi.fn(async () => {
+			throw new Error("unsupported text ABI");
+		}) as unknown as typeof renderJianyingText;
+
+		const first = await readJianyingTextStyleGeneratedCover({
+			cacheRoot,
+			entry,
+			render,
+		});
+		const second = await readJianyingTextStyleGeneratedCover({
+			cacheRoot,
+			entry,
+			render,
+		});
+
+		expect(first).toMatchObject({ mimeType: "image/png", fromCache: false });
+		expect(first.bytes.length).toBeGreaterThan(1000);
+		expect(first.bytes.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
+		expect(second).toMatchObject({ mimeType: "image/png", fromCache: true });
+		expect(render).toHaveBeenCalledOnce();
+	});
+
+	it("replaces a nearly empty runtime frame with a QCut cover", async () => {
+		const { cacheRoot, frames } = await createWorkspace({
+			frameBytes: createFrameBytes({ tiny: true }),
+		});
+		const entry = runtimeEntry();
+		const render = createRender({ entry, frames });
+
+		const cover = await readJianyingTextStyleGeneratedCover({
+			cacheRoot,
+			entry,
+			render,
+		});
+
+		expect(cover.mimeType).toBe("image/png");
+		expect(cover.bytes.length).toBeGreaterThan(1000);
+		expect(cover.bytes).not.toEqual(createFrameBytes({ tiny: true }));
+	});
+});

--- a/qcut/electron/__tests__/jianying-text-style-lab-handler.test.ts
+++ b/qcut/electron/__tests__/jianying-text-style-lab-handler.test.ts
@@ -310,6 +310,119 @@ describe("Jianying text style lab IPC", () => {
 		);
 	});
 
+	it("serves a database cover through the QCut private cache", async () => {
+		const context = createWindowContext();
+		const entry = createRuntimeEntry();
+		const sourceUrl = "https://p3-heycan-jy-sign.byteimg.com/cover.png";
+		const readCachedCover = vi.fn(async () => ({
+			bytes: Buffer.from("cached-cover"),
+			mimeType: "image/png" as const,
+			fromCache: true,
+		}));
+		setupJianyingTextStyleLabIPC({
+			getMainWindow: () => context.mainWindow,
+			buildCatalog: async () => ({
+				entries: [entry],
+				packageCount: 1,
+				invalidPackageCount: 0,
+			}),
+			resolveMetadata: async () => new Map(),
+			resolveOwnership: async () => new Map(),
+			resolveCoverUrls: async () => new Map([[entry.styleId, sourceUrl]]),
+			readCachedCover,
+		});
+
+		const listed = (await getHandler({
+			channel: JIANYING_TEXT_STYLE_LAB_LIST_CHANNEL,
+		})(context.event)) as JianyingTextStyleLabListResult;
+		expect(listed.styles[0]).toMatchObject({
+			styleId: entry.styleId,
+			hasCover: true,
+		});
+		expect(JSON.stringify(listed)).not.toContain(sourceUrl);
+
+		const cover = (await getHandler({
+			channel: JIANYING_TEXT_STYLE_LAB_COVER_CHANNEL,
+		})(context.event, {
+			styleId: entry.styleId,
+		})) as JianyingTextStyleLabCoverResult;
+		expect(readCachedCover).toHaveBeenCalledWith({ entry, sourceUrl });
+		expect(Array.from(cover.bytes)).toEqual(
+			Array.from(Buffer.from("cached-cover"))
+		);
+	});
+
+	it("generates a cover when the catalog has no image", async () => {
+		const context = createWindowContext();
+		const entry = createRuntimeEntry();
+		const readGeneratedCover = vi.fn(async () => ({
+			bytes: Buffer.from("generated-cover"),
+			mimeType: "image/png" as const,
+			fromCache: false,
+		}));
+		setupJianyingTextStyleLabIPC({
+			getMainWindow: () => context.mainWindow,
+			buildCatalog: async () => ({
+				entries: [entry],
+				packageCount: 1,
+				invalidPackageCount: 0,
+			}),
+			resolveMetadata: async () => new Map(),
+			resolveOwnership: async () => new Map(),
+			resolveCoverUrls: async () => new Map(),
+			readGeneratedCover,
+		});
+
+		const listed = (await getHandler({
+			channel: JIANYING_TEXT_STYLE_LAB_LIST_CHANNEL,
+		})(context.event)) as JianyingTextStyleLabListResult;
+		expect(listed.styles[0]?.hasCover).toBe(true);
+
+		await getHandler({
+			channel: JIANYING_TEXT_STYLE_LAB_COVER_CHANNEL,
+		})(context.event, { styleId: entry.styleId });
+		expect(readGeneratedCover).toHaveBeenCalledWith({ entry });
+	});
+
+	it("generates a cover when the database cover cannot be cached", async () => {
+		const context = createWindowContext();
+		const entry = createRuntimeEntry();
+		const sourceUrl = "https://p3-heycan-jy-sign.byteimg.com/cover.png";
+		const readCachedCover = vi.fn(async () => {
+			throw new Error("remote cover timed out");
+		});
+		const readGeneratedCover = vi.fn(async () => ({
+			bytes: Buffer.from("generated-cover"),
+			mimeType: "image/png" as const,
+			fromCache: false,
+		}));
+		setupJianyingTextStyleLabIPC({
+			getMainWindow: () => context.mainWindow,
+			buildCatalog: async () => ({
+				entries: [entry],
+				packageCount: 1,
+				invalidPackageCount: 0,
+			}),
+			resolveMetadata: async () => new Map(),
+			resolveOwnership: async () => new Map(),
+			resolveCoverUrls: async () => new Map([[entry.styleId, sourceUrl]]),
+			readCachedCover,
+			readGeneratedCover,
+		});
+
+		const cover = (await getHandler({
+			channel: JIANYING_TEXT_STYLE_LAB_COVER_CHANNEL,
+		})(context.event, {
+			styleId: entry.styleId,
+		})) as JianyingTextStyleLabCoverResult;
+
+		expect(readCachedCover).toHaveBeenCalledWith({ entry, sourceUrl });
+		expect(readGeneratedCover).toHaveBeenCalledWith({ entry });
+		expect(Array.from(cover.bytes)).toEqual(
+			Array.from(Buffer.from("generated-cover"))
+		);
+	});
+
 	it("rejects iframe callers, malformed IDs, and unknown styles", async () => {
 		const context = createWindowContext();
 		setupJianyingTextStyleLabIPC({
@@ -414,8 +527,12 @@ describe("Jianying text style lab IPC", () => {
 		expect(listed.styles[1]).toMatchObject({
 			resourceId: runtimeEntry.resourceId,
 			packageKind: "ScriptInfoSticker",
-			categoryIds: [],
+			categoryIds: ["source-qcut-script-template"],
 			compatibility: "native-runtime",
+		});
+		expect(listed.categoryGroups?.at(-1)).toMatchObject({
+			id: "qcut-local",
+			count: 1,
 		});
 	});
 
@@ -503,6 +620,10 @@ describe("Jianying text style lab IPC", () => {
 			resourceId: "7000000000000000014",
 			version: "4".repeat(32),
 		});
+		const componentEntry = createInfoStickerEntry({
+			resourceId: "7000000000000000015",
+			version: "5".repeat(32),
+		});
 		const resolveOwnership = vi.fn(
 			async () =>
 				new Map([
@@ -531,13 +652,27 @@ describe("Jianying text style lab IPC", () => {
 							catalogFamilies: [],
 						},
 					],
+					[
+						componentEntry.styleId,
+						{
+							kind: "component" as const,
+							match: "catalog-dependency" as const,
+							catalogFamilies: ["flower" as const],
+						},
+					],
 				])
 		);
 		setupJianyingTextStyleLabIPC({
 			getMainWindow: () => context.mainWindow,
 			buildCatalog: async () => ({
-				entries: [catalogEntry, flowerEntry, filterEntry, unclassifiedEntry],
-				packageCount: 4,
+				entries: [
+					catalogEntry,
+					flowerEntry,
+					filterEntry,
+					unclassifiedEntry,
+					componentEntry,
+				],
+				packageCount: 5,
 				invalidPackageCount: 0,
 			}),
 			resolveMetadata: async () =>
@@ -563,7 +698,7 @@ describe("Jianying text style lab IPC", () => {
 				?.title
 		).toBe("项目恢复花字");
 		expect(resolveOwnership).toHaveBeenCalledWith({
-			references: [flowerEntry, filterEntry, unclassifiedEntry],
+			references: [flowerEntry, filterEntry, unclassifiedEntry, componentEntry],
 		});
 	});
 

--- a/qcut/electron/__tests__/jianying-text-style-lab-handler.test.ts
+++ b/qcut/electron/__tests__/jianying-text-style-lab-handler.test.ts
@@ -26,6 +26,17 @@ vi.mock("electron", () => ({
 	ipcMain: { handle: mockHandle, removeHandler: mockRemoveHandler },
 }));
 
+// The private archive only exists on an authorized developer machine. Failing
+// here keeps these tests hermetic: every dependency that would reach it must be
+// injected, so the suite behaves the same on CI as it does locally.
+vi.mock("../jianying-text-private-archive.js", () => ({
+	ensureQCutJianyingTextPrivateArchive: vi.fn(async () => {
+		throw new Error(
+			"QCut 尚未建立花字私有备份，且没有找到可导入的剪映花字缓存。"
+		);
+	}),
+}));
+
 import { setupJianyingTextStyleLabIPC } from "../jianying-text-style-lab-handler.js";
 
 const STYLE_ID = `7405879107424111910/${"a".repeat(32)}`;
@@ -514,6 +525,8 @@ describe("Jianying text style lab IPC", () => {
 						{ title: "黄色花字", categoryIds: ["yellow" as const] },
 					],
 				]),
+			resolveOwnership: async () => new Map(),
+			resolveCoverUrls: async () => new Map(),
 		});
 
 		const listed = (await getHandler({
@@ -683,6 +696,7 @@ describe("Jianying text style lab IPC", () => {
 					],
 				]),
 			resolveOwnership,
+			resolveCoverUrls: async () => new Map(),
 		});
 
 		const listed = (await getHandler({

--- a/qcut/electron/__tests__/jianying-text-style-local-categories.test.ts
+++ b/qcut/electron/__tests__/jianying-text-style-local-categories.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { createEmptyJianyingTextEffectCapabilities } from "../jianying-text-effect-capabilities.js";
+import type { JianyingTextStylePackageKind } from "../jianying-text-style-lab-contract.js";
+import type { JianyingTextStyleCatalogEntry } from "../jianying-text-style-lab-catalog.js";
+import { classifyLocalJianyingTextStyles } from "../jianying-text-style-local-categories.js";
+import type { JianyingTextPackageOwnership } from "../jianying-text-package-ownership.js";
+
+function catalogEntry({
+	packageKind,
+	styleId,
+}: {
+	packageKind: JianyingTextStylePackageKind;
+	styleId: string;
+}): JianyingTextStyleCatalogEntry {
+	const [resourceId, version] = styleId.split("/");
+	return {
+		styleId,
+		resourceId,
+		version,
+		packageKind,
+		packageVersion: "1",
+		fillKind: "unknown",
+		strokeCount: 0,
+		innerShadowCount: 0,
+		shadowCount: 0,
+		textureLayerCount: 0,
+		capabilities: createEmptyJianyingTextEffectCapabilities(),
+		diagnostics: [],
+		hasCover: true,
+		compatibility: "native-runtime",
+	};
+}
+
+function ownership({
+	kind,
+	title,
+}: {
+	kind: JianyingTextPackageOwnership["kind"];
+	title?: string;
+}): JianyingTextPackageOwnership {
+	return {
+		kind,
+		match: kind === "unclassified" ? "none" : "exact",
+		catalogFamilies: [],
+		...(title ? { title } : {}),
+	};
+}
+
+describe("Jianying local text style categories", () => {
+	it("classifies missing flower, script-template, and component metadata", () => {
+		const existing = catalogEntry({
+			styleId: `100/${"a".repeat(32)}`,
+			packageKind: "TextStyle",
+		});
+		const flower = catalogEntry({
+			styleId: `200/${"b".repeat(32)}`,
+			packageKind: "InfoSticker",
+		});
+		const script = catalogEntry({
+			styleId: `300/${"c".repeat(32)}`,
+			packageKind: "ScriptInfoSticker",
+		});
+		const component = catalogEntry({
+			styleId: `400/${"d".repeat(32)}`,
+			packageKind: "TextStyle",
+		});
+		const unknown = catalogEntry({
+			styleId: `500/${"e".repeat(32)}`,
+			packageKind: "TextStyle",
+		});
+		const result = classifyLocalJianyingTextStyles({
+			entries: [existing, flower, script, component, unknown],
+			ownership: new Map([
+				[flower.styleId, ownership({ kind: "flower", title: "本机花字" })],
+				[script.styleId, ownership({ kind: "non-flower", title: "脚本模板" })],
+				[
+					component.styleId,
+					ownership({ kind: "component", title: "样式组件" }),
+				],
+				[unknown.styleId, ownership({ kind: "unclassified" })],
+			]),
+			resolvedMetadata: {
+				metadata: new Map([
+					[
+						existing.styleId,
+						{ title: "已有分类", categoryIds: ["popular" as const] },
+					],
+				]),
+				categories: [
+					{
+						id: "popular",
+						sourceId: "10721",
+						label: "热门",
+						groupId: "charts",
+						order: 0,
+					},
+				],
+				categoryGroups: [
+					{
+						id: "charts",
+						label: "榜单",
+						categoryIds: ["popular"],
+						order: 0,
+					},
+				],
+			},
+		});
+
+		expect(result.metadata.get(existing.styleId)).toEqual({
+			title: "已有分类",
+			categoryIds: ["popular"],
+		});
+		expect(result.metadata.get(flower.styleId)).toEqual({
+			title: "本机花字",
+			categoryIds: ["source-qcut-local-flower"],
+		});
+		expect(result.metadata.get(script.styleId)?.categoryIds).toEqual([
+			"source-qcut-script-template",
+		]);
+		expect(result.metadata.get(component.styleId)?.categoryIds).toEqual([
+			"source-qcut-style-component",
+		]);
+		expect(result.metadata.has(unknown.styleId)).toBe(false);
+		expect(
+			result.categories.slice(-3).map(({ id, label }) => ({ id, label }))
+		).toEqual([
+			{ id: "source-qcut-local-flower", label: "本机花字" },
+			{ id: "source-qcut-script-template", label: "脚本模板" },
+			{ id: "source-qcut-style-component", label: "样式组件" },
+		]);
+		expect(result.categoryGroups.at(-1)).toMatchObject({
+			id: "qcut-local",
+			label: "本机补充",
+			categoryIds: [
+				"source-qcut-local-flower",
+				"source-qcut-script-template",
+				"source-qcut-style-component",
+			],
+		});
+	});
+});

--- a/qcut/electron/jianying-filter-thumbnail-cache.ts
+++ b/qcut/electron/jianying-filter-thumbnail-cache.ts
@@ -1,9 +1,7 @@
-import { createHash } from "node:crypto";
-import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
-
-const MAX_THUMBNAIL_BYTES = 2 * 1024 * 1024;
-const THUMBNAIL_TIMEOUT_MS = 10_000;
+import {
+	readJianyingCachedImage,
+	type JianyingImageMimeType,
+} from "./jianying-image-cache.js";
 
 export interface JianyingFilterThumbnailSource {
 	resourceId: string;
@@ -13,150 +11,9 @@ export interface JianyingFilterThumbnailSource {
 }
 
 export interface JianyingFilterThumbnail {
-	mimeType: "image/jpeg" | "image/png" | "image/webp";
+	mimeType: Exclude<JianyingImageMimeType, "image/gif">;
 	bytes: Buffer;
 	fromCache: boolean;
-}
-
-function detectImageMimeType({
-	bytes,
-}: {
-	bytes: Uint8Array;
-}): JianyingFilterThumbnail["mimeType"] | undefined {
-	if (
-		bytes.length >= 8 &&
-		bytes[0] === 0x89 &&
-		bytes[1] === 0x50 &&
-		bytes[2] === 0x4e &&
-		bytes[3] === 0x47 &&
-		bytes[4] === 0x0d &&
-		bytes[5] === 0x0a &&
-		bytes[6] === 0x1a &&
-		bytes[7] === 0x0a
-	) {
-		return "image/png";
-	}
-	if (
-		bytes.length >= 3 &&
-		bytes[0] === 0xff &&
-		bytes[1] === 0xd8 &&
-		bytes[2] === 0xff
-	) {
-		return "image/jpeg";
-	}
-	if (
-		bytes.length >= 12 &&
-		Buffer.from(bytes.subarray(0, 4)).toString("ascii") === "RIFF" &&
-		Buffer.from(bytes.subarray(8, 12)).toString("ascii") === "WEBP"
-	) {
-		return "image/webp";
-	}
-}
-
-function assertValidThumbnail({ bytes }: { bytes: Buffer }) {
-	if (bytes.length === 0 || bytes.length > MAX_THUMBNAIL_BYTES) {
-		throw new Error("剪映滤镜缩略图大小无效");
-	}
-	const mimeType = detectImageMimeType({ bytes });
-	if (!mimeType) throw new Error("剪映滤镜缩略图格式不受支持");
-	return mimeType;
-}
-
-function assertTrustedThumbnailUrl({ value }: { value: string }) {
-	const parsed = new URL(value);
-	if (
-		parsed.protocol !== "https:" ||
-		!(
-			parsed.hostname === "byteimg.com" ||
-			parsed.hostname.endsWith(".byteimg.com")
-		)
-	) {
-		throw new Error("剪映滤镜缩略图地址不受信任");
-	}
-	return parsed.toString();
-}
-
-function thumbnailCachePath({
-	cacheRoot,
-	source,
-}: {
-	cacheRoot: string;
-	source: JianyingFilterThumbnailSource;
-}) {
-	const fingerprint = createHash("sha256")
-		.update(
-			[
-				source.resourceId,
-				source.version ?? "",
-				source.sourcePath ?? "",
-				source.sourceUrl ?? "",
-			].join("\0")
-		)
-		.digest("hex");
-	return join(cacheRoot, `${fingerprint}.image`);
-}
-
-async function readCachedThumbnail({
-	filePath,
-}: {
-	filePath: string;
-}): Promise<JianyingFilterThumbnail | undefined> {
-	try {
-		const bytes = await readFile(filePath);
-		return {
-			mimeType: assertValidThumbnail({ bytes }),
-			bytes,
-			fromCache: true,
-		};
-	} catch {
-		return undefined;
-	}
-}
-
-async function readLocalThumbnail({ filePath }: { filePath: string }) {
-	const fileStats = await stat(filePath);
-	if (!fileStats.isFile() || fileStats.size > MAX_THUMBNAIL_BYTES) {
-		throw new Error("本机剪映滤镜缩略图大小无效");
-	}
-	return readFile(filePath);
-}
-
-async function fetchRemoteThumbnail({
-	url,
-	fetcher,
-}: {
-	url: string;
-	fetcher: typeof fetch;
-}) {
-	const response = await fetcher(assertTrustedThumbnailUrl({ value: url }), {
-		credentials: "omit",
-		redirect: "follow",
-		signal: AbortSignal.timeout(THUMBNAIL_TIMEOUT_MS),
-	});
-	if (!response.ok) {
-		throw new Error(`剪映滤镜缩略图请求失败 (${response.status})`);
-	}
-	assertTrustedThumbnailUrl({ value: response.url || url });
-	const contentLength = Number(response.headers.get("content-length"));
-	if (Number.isFinite(contentLength) && contentLength > MAX_THUMBNAIL_BYTES) {
-		throw new Error("剪映滤镜缩略图超过大小限制");
-	}
-	const bytes = Buffer.from(await response.arrayBuffer());
-	assertValidThumbnail({ bytes });
-	return bytes;
-}
-
-async function cacheThumbnail({
-	filePath,
-	bytes,
-}: {
-	filePath: string;
-	bytes: Buffer;
-}) {
-	await mkdir(dirname(filePath), { recursive: true });
-	const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
-	await writeFile(temporaryPath, bytes, { flag: "wx" });
-	await rename(temporaryPath, filePath);
 }
 
 export async function readJianyingFilterThumbnail({
@@ -168,17 +25,24 @@ export async function readJianyingFilterThumbnail({
 	cacheRoot: string;
 	fetcher?: typeof fetch;
 }): Promise<JianyingFilterThumbnail> {
-	const cachePath = thumbnailCachePath({ cacheRoot, source });
-	const cached = await readCachedThumbnail({ filePath: cachePath });
-	if (cached) return cached;
-
-	const bytes = source.sourcePath
-		? await readLocalThumbnail({ filePath: source.sourcePath })
-		: source.sourceUrl
-			? await fetchRemoteThumbnail({ url: source.sourceUrl, fetcher })
-			: undefined;
-	if (!bytes) throw new Error("该剪映滤镜没有可用缩略图");
-	const mimeType = assertValidThumbnail({ bytes });
-	await cacheThumbnail({ filePath: cachePath, bytes });
-	return { mimeType, bytes, fromCache: false };
+	const image = await readJianyingCachedImage({
+		cacheRoot,
+		fetcher,
+		label: "剪映滤镜缩略图",
+		source: {
+			cacheKey: [
+				source.resourceId,
+				source.version ?? "",
+				source.sourcePath ?? "",
+				source.sourceUrl ?? "",
+			].join("\0"),
+			...(source.sourcePath ? { sourcePath: source.sourcePath } : {}),
+			...(source.sourceUrl ? { sourceUrl: source.sourceUrl } : {}),
+		},
+	});
+	const { mimeType } = image;
+	if (mimeType === "image/gif") {
+		throw new Error("剪映滤镜缩略图格式不受支持");
+	}
+	return { ...image, mimeType };
 }

--- a/qcut/electron/jianying-flower-resource-metadata.ts
+++ b/qcut/electron/jianying-flower-resource-metadata.ts
@@ -29,6 +29,7 @@ export interface JianyingFlowerResourceReference {
 export interface JianyingFlowerResourceMetadata {
 	title?: string;
 	categoryIds: JianyingTextStyleCategoryId[];
+	coverUrl?: string;
 }
 
 export interface JianyingFlowerCatalogPackageReference {

--- a/qcut/electron/jianying-image-cache.ts
+++ b/qcut/electron/jianying-image-cache.ts
@@ -245,24 +245,31 @@ async function loadJianyingCachedImage({
 	if (cached) return cached;
 	let sourceError: unknown;
 	let bytes: Buffer | undefined;
-	try {
-		bytes = source.sourcePath
-			? await readLocalImage({
-					filePath: source.sourcePath,
-					label,
-					maximumBytes,
-				})
-			: source.sourceUrl
-				? await fetchRemoteImage({
-						fetcher,
-						label,
-						maximumBytes,
-						timeoutMs,
-						url: source.sourceUrl,
-					})
-				: undefined;
-	} catch (error) {
-		sourceError = error;
+	// Try every source the caller supplied, local first: a stale or missing
+	// local path must still fall back to the remote copy instead of failing.
+	if (source.sourcePath) {
+		try {
+			bytes = await readLocalImage({
+				filePath: source.sourcePath,
+				label,
+				maximumBytes,
+			});
+		} catch (error) {
+			sourceError = error;
+		}
+	}
+	if (!bytes && source.sourceUrl) {
+		try {
+			bytes = await fetchRemoteImage({
+				fetcher,
+				label,
+				maximumBytes,
+				timeoutMs,
+				url: source.sourceUrl,
+			});
+		} catch (error) {
+			sourceError = error;
+		}
 	}
 	if (!bytes && source.produce) bytes = await source.produce();
 	if (!bytes && sourceError) throw sourceError;

--- a/qcut/electron/jianying-image-cache.ts
+++ b/qcut/electron/jianying-image-cache.ts
@@ -1,0 +1,308 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export type JianyingImageMimeType =
+	| "image/gif"
+	| "image/jpeg"
+	| "image/png"
+	| "image/webp";
+
+export interface JianyingCachedImage {
+	mimeType: JianyingImageMimeType;
+	bytes: Buffer;
+	fromCache: boolean;
+}
+
+export interface JianyingCachedImageSource {
+	cacheKey: string;
+	produce?: () => Promise<Buffer>;
+	sourcePath?: string;
+	sourceUrl?: string;
+}
+
+const inFlightImages = new Map<string, Promise<JianyingCachedImage>>();
+
+function detectImageMimeType({
+	bytes,
+}: {
+	bytes: Uint8Array;
+}): JianyingImageMimeType | undefined {
+	if (
+		bytes.length >= 8 &&
+		bytes[0] === 0x89 &&
+		bytes[1] === 0x50 &&
+		bytes[2] === 0x4e &&
+		bytes[3] === 0x47 &&
+		bytes[4] === 0x0d &&
+		bytes[5] === 0x0a &&
+		bytes[6] === 0x1a &&
+		bytes[7] === 0x0a
+	) {
+		return "image/png";
+	}
+	if (
+		bytes.length >= 3 &&
+		bytes[0] === 0xff &&
+		bytes[1] === 0xd8 &&
+		bytes[2] === 0xff
+	) {
+		return "image/jpeg";
+	}
+	if (
+		bytes.length >= 6 &&
+		(Buffer.from(bytes.subarray(0, 6)).toString("ascii") === "GIF87a" ||
+			Buffer.from(bytes.subarray(0, 6)).toString("ascii") === "GIF89a")
+	) {
+		return "image/gif";
+	}
+	if (
+		bytes.length >= 12 &&
+		Buffer.from(bytes.subarray(0, 4)).toString("ascii") === "RIFF" &&
+		Buffer.from(bytes.subarray(8, 12)).toString("ascii") === "WEBP"
+	) {
+		return "image/webp";
+	}
+}
+
+function assertValidImage({
+	bytes,
+	label,
+	maximumBytes,
+}: {
+	bytes: Buffer;
+	label: string;
+	maximumBytes: number;
+}) {
+	if (bytes.length === 0 || bytes.length > maximumBytes) {
+		throw new Error(`${label}大小无效`);
+	}
+	const mimeType = detectImageMimeType({ bytes });
+	if (!mimeType) throw new Error(`${label}格式不受支持`);
+	return mimeType;
+}
+
+function assertTrustedImageUrl({ value }: { value: string }) {
+	const parsed = new URL(value);
+	if (
+		parsed.protocol !== "https:" ||
+		!(
+			parsed.hostname === "byteimg.com" ||
+			parsed.hostname.endsWith(".byteimg.com")
+		)
+	) {
+		throw new Error("剪映图片地址不受信任");
+	}
+	return parsed.toString();
+}
+
+function imageCachePath({
+	cacheRoot,
+	cacheKey,
+}: {
+	cacheRoot: string;
+	cacheKey: string;
+}) {
+	if (!cacheKey) throw new Error("剪映图片缓存键不能为空");
+	const fingerprint = createHash("sha256").update(cacheKey).digest("hex");
+	return join(cacheRoot, `${fingerprint}.image`);
+}
+
+async function readCachedImage({
+	filePath,
+	label,
+	maximumBytes,
+}: {
+	filePath: string;
+	label: string;
+	maximumBytes: number;
+}): Promise<JianyingCachedImage | undefined> {
+	try {
+		const bytes = await readFile(filePath);
+		return {
+			mimeType: assertValidImage({ bytes, label, maximumBytes }),
+			bytes,
+			fromCache: true,
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+async function readLocalImage({
+	filePath,
+	label,
+	maximumBytes,
+}: {
+	filePath: string;
+	label: string;
+	maximumBytes: number;
+}) {
+	const fileStats = await stat(filePath);
+	if (!fileStats.isFile() || fileStats.size > maximumBytes) {
+		throw new Error(`本机${label}大小无效`);
+	}
+	return readFile(filePath);
+}
+
+async function readResponseBody({
+	chunks,
+	maximumBytes,
+	reader,
+	receivedBytes,
+}: {
+	chunks: Buffer[];
+	maximumBytes: number;
+	reader: ReadableStreamDefaultReader<Uint8Array>;
+	receivedBytes: number;
+}): Promise<Buffer> {
+	const { done, value } = await reader.read();
+	if (done) return Buffer.concat(chunks, receivedBytes);
+	const nextReceivedBytes = receivedBytes + value.byteLength;
+	if (nextReceivedBytes > maximumBytes) {
+		await reader.cancel();
+		throw new Error("剪映图片超过大小限制");
+	}
+	chunks.push(Buffer.from(value));
+	return readResponseBody({
+		chunks,
+		maximumBytes,
+		reader,
+		receivedBytes: nextReceivedBytes,
+	});
+}
+
+async function fetchRemoteImage({
+	fetcher,
+	label,
+	maximumBytes,
+	timeoutMs,
+	url,
+}: {
+	fetcher: typeof fetch;
+	label: string;
+	maximumBytes: number;
+	timeoutMs: number;
+	url: string;
+}) {
+	const trustedUrl = assertTrustedImageUrl({ value: url });
+	const response = await fetcher(trustedUrl, {
+		credentials: "omit",
+		redirect: "follow",
+		signal: AbortSignal.timeout(timeoutMs),
+	});
+	if (!response.ok) throw new Error(`${label}请求失败 (${response.status})`);
+	assertTrustedImageUrl({ value: response.url || trustedUrl });
+	const contentLength = Number(response.headers.get("content-length"));
+	if (Number.isFinite(contentLength) && contentLength > maximumBytes) {
+		await response.body?.cancel();
+		throw new Error(`${label}超过大小限制`);
+	}
+	if (!response.body) throw new Error(`${label}响应为空`);
+	const bytes = await readResponseBody({
+		chunks: [],
+		maximumBytes,
+		reader: response.body.getReader(),
+		receivedBytes: 0,
+	});
+	assertValidImage({ bytes, label, maximumBytes });
+	return bytes;
+}
+
+async function cacheImage({
+	bytes,
+	filePath,
+}: {
+	bytes: Buffer;
+	filePath: string;
+}) {
+	await mkdir(dirname(filePath), { recursive: true });
+	const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+	await writeFile(temporaryPath, bytes, { flag: "wx" });
+	await rename(temporaryPath, filePath);
+}
+
+async function loadJianyingCachedImage({
+	cachePath,
+	fetcher,
+	label,
+	maximumBytes,
+	source,
+	timeoutMs,
+}: {
+	cachePath: string;
+	fetcher: typeof fetch;
+	label: string;
+	maximumBytes: number;
+	source: JianyingCachedImageSource;
+	timeoutMs: number;
+}) {
+	const cached = await readCachedImage({
+		filePath: cachePath,
+		label,
+		maximumBytes,
+	});
+	if (cached) return cached;
+	let sourceError: unknown;
+	let bytes: Buffer | undefined;
+	try {
+		bytes = source.sourcePath
+			? await readLocalImage({
+					filePath: source.sourcePath,
+					label,
+					maximumBytes,
+				})
+			: source.sourceUrl
+				? await fetchRemoteImage({
+						fetcher,
+						label,
+						maximumBytes,
+						timeoutMs,
+						url: source.sourceUrl,
+					})
+				: undefined;
+	} catch (error) {
+		sourceError = error;
+	}
+	if (!bytes && source.produce) bytes = await source.produce();
+	if (!bytes && sourceError) throw sourceError;
+	if (!bytes) throw new Error(`${label}没有可用来源`);
+	const mimeType = assertValidImage({ bytes, label, maximumBytes });
+	await cacheImage({ filePath: cachePath, bytes });
+	return { mimeType, bytes, fromCache: false } satisfies JianyingCachedImage;
+}
+
+export function readJianyingCachedImage({
+	cacheRoot,
+	fetcher = fetch,
+	label,
+	maximumBytes = 2 * 1024 * 1024,
+	source,
+	timeoutMs = 10_000,
+}: {
+	cacheRoot: string;
+	fetcher?: typeof fetch;
+	label: string;
+	maximumBytes?: number;
+	source: JianyingCachedImageSource;
+	timeoutMs?: number;
+}): Promise<JianyingCachedImage> {
+	const cachePath = imageCachePath({
+		cacheRoot,
+		cacheKey: source.cacheKey,
+	});
+	const pending = inFlightImages.get(cachePath);
+	if (pending) return pending;
+	const task = loadJianyingCachedImage({
+		cachePath,
+		fetcher,
+		label,
+		maximumBytes,
+		source,
+		timeoutMs,
+	}).finally(() => {
+		inFlightImages.delete(cachePath);
+	});
+	inFlightImages.set(cachePath, task);
+	return task;
+}

--- a/qcut/electron/jianying-image-cache.ts
+++ b/qcut/electron/jianying-image-cache.ts
@@ -245,28 +245,34 @@ async function loadJianyingCachedImage({
 	if (cached) return cached;
 	let sourceError: unknown;
 	let bytes: Buffer | undefined;
-	// Try every source the caller supplied, local first: a stale or missing
-	// local path must still fall back to the remote copy instead of failing.
+	// Try every source the caller supplied, local first: a stale, missing or
+	// corrupt local copy must still fall back to the remote one. Each candidate
+	// is validated here rather than only at the end, so an empty or malformed
+	// file fails over to the next source instead of failing the whole read.
 	if (source.sourcePath) {
 		try {
-			bytes = await readLocalImage({
+			const localBytes = await readLocalImage({
 				filePath: source.sourcePath,
 				label,
 				maximumBytes,
 			});
+			assertValidImage({ bytes: localBytes, label, maximumBytes });
+			bytes = localBytes;
 		} catch (error) {
 			sourceError = error;
 		}
 	}
 	if (!bytes && source.sourceUrl) {
 		try {
-			bytes = await fetchRemoteImage({
+			const remoteBytes = await fetchRemoteImage({
 				fetcher,
 				label,
 				maximumBytes,
 				timeoutMs,
 				url: source.sourceUrl,
 			});
+			assertValidImage({ bytes: remoteBytes, label, maximumBytes });
+			bytes = remoteBytes;
 		} catch (error) {
 			sourceError = error;
 		}

--- a/qcut/electron/jianying-text-lab-service.ts
+++ b/qcut/electron/jianying-text-lab-service.ts
@@ -3,6 +3,11 @@ import { resolveJianyingFlowerCatalogMetadata } from "./jianying-flower-resource
 import { ensureQCutJianyingTextPrivateArchive } from "./jianying-text-private-archive.js";
 import { resolveJianyingTextPackageOwnership } from "./jianying-text-package-ownership.js";
 import { isDiscoverableJianyingTextCatalogEntry } from "./jianying-text-style-discovery.js";
+import {
+	attachJianyingTextStyleCoverUrls,
+	resolveJianyingTextStyleCoverUrls,
+} from "./jianying-text-style-cover-metadata.js";
+import { classifyLocalJianyingTextStyles } from "./jianying-text-style-local-categories.js";
 import { buildJianyingTextStyleCatalog } from "./jianying-text-style-lab-catalog.js";
 import type {
 	JianyingTextAnimationLabListResult,
@@ -36,24 +41,40 @@ export async function buildQCutJianyingTextLabCatalog(): Promise<QCutJianyingTex
 			databaseRoot: archive.databaseRoot,
 		}),
 	});
-	const { categories, categoryGroups, metadata } = resolvedMetadata;
 	const ownershipCandidates = catalog.entries.filter(
-		({ packageKind, styleId }) =>
-			!metadata.has(styleId) &&
-			(packageKind === "AmazingFeature" || packageKind === "InfoSticker")
+		({ styleId }) => !resolvedMetadata.metadata.has(styleId)
 	);
-	const ownership =
+	const [ownership, coverUrls] = await Promise.all([
 		ownershipCandidates.length > 0
-			? await resolveJianyingTextPackageOwnership({
+			? resolveJianyingTextPackageOwnership({
 					references: ownershipCandidates,
 					databaseRoot: archive.databaseRoot,
 					packageRoot: archive.packageRoot,
 					projectRoot: archive.projectEvidenceRoot,
 				})
-			: new Map();
+			: Promise.resolve(new Map()),
+		resolveJianyingTextStyleCoverUrls({
+			references: catalog.entries.filter(({ hasCover }) => !hasCover),
+			databaseRoot: archive.databaseRoot,
+		}),
+	]);
 	const entries = catalog.entries.filter((entry) =>
-		isDiscoverableJianyingTextCatalogEntry({ entry, metadata, ownership })
+		isDiscoverableJianyingTextCatalogEntry({
+			entry,
+			metadata: resolvedMetadata.metadata,
+			ownership,
+		})
 	);
+	const classifiedMetadata = classifyLocalJianyingTextStyles({
+		entries,
+		ownership,
+		resolvedMetadata,
+	});
+	const metadata = attachJianyingTextStyleCoverUrls({
+		coverUrls,
+		metadata: classifiedMetadata.metadata,
+	});
+	const { categories, categoryGroups } = classifiedMetadata;
 	const styles = entries
 		.map((entry) => summarizeEntry({ entry, metadata, ownership }))
 		.sort((left, right) => compareStyleSummaries({ left, right }));

--- a/qcut/electron/jianying-text-lab-snapshot-cache.ts
+++ b/qcut/electron/jianying-text-lab-snapshot-cache.ts
@@ -25,7 +25,7 @@ import { jianyingEffectCacheRoot } from "./native-pipeline/filters/filter-lab-lu
  * rp.db is deliberately ignored; the lab's refresh button forces a rebuild.
  * Everything stays on this machine — nothing is uploaded anywhere.
  */
-export const JIANYING_TEXT_LAB_SNAPSHOT_SCHEMA_VERSION = 3;
+export const JIANYING_TEXT_LAB_SNAPSHOT_SCHEMA_VERSION = 5;
 
 export interface JianyingTextLabSnapshot {
 	schemaVersion: typeof JIANYING_TEXT_LAB_SNAPSHOT_SCHEMA_VERSION;

--- a/qcut/electron/jianying-text-style-cover-cache.ts
+++ b/qcut/electron/jianying-text-style-cover-cache.ts
@@ -1,0 +1,31 @@
+import {
+	readJianyingCachedImage,
+	type JianyingCachedImage,
+} from "./jianying-image-cache.js";
+
+const TEXT_STYLE_COVER_CACHE_VERSION = 3;
+
+export function readJianyingTextStyleCoverImage({
+	cacheRoot,
+	fetcher = fetch,
+	produceFallback,
+	sourceUrl,
+	styleId,
+}: {
+	cacheRoot: string;
+	fetcher?: typeof fetch;
+	produceFallback?: () => Promise<Buffer>;
+	sourceUrl: string;
+	styleId: string;
+}): Promise<JianyingCachedImage> {
+	return readJianyingCachedImage({
+		cacheRoot,
+		fetcher,
+		label: "剪映花字封面",
+		source: {
+			cacheKey: `v${TEXT_STYLE_COVER_CACHE_VERSION}:${styleId}`,
+			produce: produceFallback,
+			sourceUrl,
+		},
+	});
+}

--- a/qcut/electron/jianying-text-style-cover-metadata.ts
+++ b/qcut/electron/jianying-text-style-cover-metadata.ts
@@ -1,0 +1,196 @@
+import { DatabaseSync } from "node:sqlite";
+import { listJianyingResourceDatabasePaths } from "./jianying-resource-database.js";
+import type { JianyingFlowerResourceMetadata } from "./jianying-flower-resource-metadata.js";
+import type { JianyingTextStyleCatalogEntry } from "./jianying-text-style-lab-catalog.js";
+import {
+	JIANYING_TEXT_PACKAGE_HASH_PATTERN,
+	JIANYING_TEXT_RESOURCE_ID_PATTERN,
+} from "./jianying-text-package-metadata.js";
+
+const SQLITE_PARAMETER_LIMIT = 900;
+
+interface TextStyleCoverRow {
+	resourceId: string | null;
+	packageHash: string | null;
+	coverUrl: string | null;
+	timestamp: string | null;
+}
+
+function tableExists({
+	database,
+	table,
+}: {
+	database: DatabaseSync;
+	table: string;
+}) {
+	const row = database
+		.prepare(
+			"SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?) AS present"
+		)
+		.get(table) as { present?: number } | undefined;
+	return row?.present === 1;
+}
+
+function chunkResourceIds({ resourceIds }: { resourceIds: string[] }) {
+	const chunks: string[][] = [];
+	for (
+		let index = 0;
+		index < resourceIds.length;
+		index += SQLITE_PARAMETER_LIMIT
+	) {
+		chunks.push(resourceIds.slice(index, index + SQLITE_PARAMETER_LIMIT));
+	}
+	return chunks;
+}
+
+function readCoverRows({
+	database,
+	resourceIds,
+}: {
+	database: DatabaseSync;
+	resourceIds: string[];
+}) {
+	if (!tableExists({ database, table: "http_cache" })) return [];
+	return chunkResourceIds({ resourceIds }).flatMap((ids) => {
+		const placeholders = ids.map(() => "?").join(",");
+		return database
+			.prepare(`
+				SELECT
+					CAST(json_extract(node.value, '$.common_attr.id') AS TEXT)
+						AS resourceId,
+					LOWER(CAST(json_extract(node.value, '$.common_attr.md5') AS TEXT))
+						AS packageHash,
+					CAST(
+						json_extract(node.value, '$.common_attr.cover_url.static_img')
+						AS TEXT
+					) AS coverUrl,
+					CAST(cache.timestamp AS TEXT) AS timestamp
+				FROM http_cache AS cache,
+					json_tree(
+						CASE WHEN json_valid(cache.response_body)
+							THEN cache.response_body ELSE '{}' END
+					) AS node
+				WHERE node.type = 'object'
+					AND CAST(json_extract(node.value, '$.common_attr.id') AS TEXT)
+						IN (${placeholders})
+					AND json_type(
+						node.value,
+						'$.common_attr.cover_url.static_img'
+					) = 'text'
+				ORDER BY cache.timestamp DESC
+			`)
+			.all(...ids) as unknown as TextStyleCoverRow[];
+	});
+}
+
+function collectCoverRows({
+	databasePath,
+	resourceIds,
+}: {
+	databasePath: string;
+	resourceIds: string[];
+}) {
+	const database = new DatabaseSync(databasePath, { readOnly: true });
+	try {
+		return readCoverRows({ database, resourceIds });
+	} finally {
+		database.close();
+	}
+}
+
+function trustedCoverUrl({ value }: { value: string | null }) {
+	if (!value) return null;
+	try {
+		const parsed = new URL(value);
+		if (
+			parsed.protocol !== "https:" ||
+			!(
+				parsed.hostname === "byteimg.com" ||
+				parsed.hostname.endsWith(".byteimg.com")
+			)
+		) {
+			return null;
+		}
+		return parsed.toString();
+	} catch {
+		return null;
+	}
+}
+
+function compareRows({
+	left,
+	right,
+}: {
+	left: TextStyleCoverRow;
+	right: TextStyleCoverRow;
+}) {
+	const numericDelta = Number(right.timestamp) - Number(left.timestamp);
+	if (Number.isFinite(numericDelta) && numericDelta !== 0) return numericDelta;
+	return (right.timestamp ?? "").localeCompare(left.timestamp ?? "");
+}
+
+export async function resolveJianyingTextStyleCoverUrls({
+	databaseRoot,
+	references,
+}: {
+	databaseRoot: string;
+	references: JianyingTextStyleCatalogEntry[];
+}) {
+	const requestedStyleIds = new Set(references.map(({ styleId }) => styleId));
+	const resourceIds = [
+		...new Set(
+			references
+				.map(({ resourceId }) => resourceId)
+				.filter((resourceId) =>
+					JIANYING_TEXT_RESOURCE_ID_PATTERN.test(resourceId)
+				)
+		),
+	];
+	if (resourceIds.length === 0) return new Map<string, string>();
+	const databasePaths = await listJianyingResourceDatabasePaths({
+		databaseRoot,
+	});
+	const rows = databasePaths
+		.flatMap((databasePath) => {
+			try {
+				return collectCoverRows({ databasePath, resourceIds });
+			} catch {
+				return [];
+			}
+		})
+		.sort((left, right) => compareRows({ left, right }));
+	const covers = new Map<string, string>();
+	for (const row of rows) {
+		const resourceId = row.resourceId?.trim() ?? "";
+		const packageHash = row.packageHash?.trim().toLowerCase() ?? "";
+		if (
+			!JIANYING_TEXT_RESOURCE_ID_PATTERN.test(resourceId) ||
+			!JIANYING_TEXT_PACKAGE_HASH_PATTERN.test(packageHash)
+		) {
+			continue;
+		}
+		const styleId = `${resourceId}/${packageHash}`;
+		if (!requestedStyleIds.has(styleId) || covers.has(styleId)) continue;
+		const coverUrl = trustedCoverUrl({ value: row.coverUrl });
+		if (coverUrl) covers.set(styleId, coverUrl);
+	}
+	return covers;
+}
+
+export function attachJianyingTextStyleCoverUrls({
+	coverUrls,
+	metadata,
+}: {
+	coverUrls: ReadonlyMap<string, string>;
+	metadata: ReadonlyMap<string, JianyingFlowerResourceMetadata>;
+}) {
+	const resolved = new Map(metadata);
+	for (const [styleId, coverUrl] of coverUrls) {
+		const current = resolved.get(styleId);
+		resolved.set(styleId, {
+			...(current ?? { categoryIds: [] }),
+			coverUrl,
+		});
+	}
+	return resolved;
+}

--- a/qcut/electron/jianying-text-style-generated-cover.ts
+++ b/qcut/electron/jianying-text-style-generated-cover.ts
@@ -1,0 +1,181 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { createCanvas, loadImage } from "@napi-rs/canvas";
+import {
+	readJianyingCachedImage,
+	type JianyingCachedImage,
+} from "./jianying-image-cache.js";
+import type { JianyingTextStyleCatalogEntry } from "./jianying-text-style-lab-catalog.js";
+import { renderJianyingText } from "./jianying-text-runtime/render.js";
+
+const COVER_SIZE = 256;
+const COVER_FRAME_COUNT = 3;
+const COVER_FPS = 1;
+const GENERATED_COVER_CACHE_VERSION = 3;
+const MINIMUM_CONTENT_AREA_RATIO = 0.002;
+const MINIMUM_CONTENT_BOUND_RATIO = 0.08;
+
+let renderQueue: Promise<void> = Promise.resolve();
+
+function queueRender<T>({ task }: { task: () => Promise<T> }) {
+	const result = renderQueue.then(task, task);
+	renderQueue = result.then(
+		() => undefined,
+		() => undefined
+	);
+	return result;
+}
+
+function middleFramePath({ pattern }: { pattern: string }) {
+	if (!pattern.includes("%06d")) {
+		throw new Error("剪映花字封面帧路径格式无效");
+	}
+	return pattern.replace("%06d", "000001");
+}
+
+async function hasUsefulCoverContent({ bytes }: { bytes: Buffer }) {
+	const image = await loadImage(bytes);
+	if (image.width <= 0 || image.height <= 0) return false;
+	const canvas = createCanvas(image.width, image.height);
+	const context = canvas.getContext("2d");
+	context.drawImage(image, 0, 0);
+	const pixels = context.getImageData(0, 0, image.width, image.height).data;
+	let visiblePixels = 0;
+	let minimumX = image.width;
+	let minimumY = image.height;
+	let maximumX = -1;
+	let maximumY = -1;
+	for (let y = 0; y < image.height; y += 1) {
+		for (let x = 0; x < image.width; x += 1) {
+			if (pixels[(y * image.width + x) * 4 + 3] < 16) continue;
+			visiblePixels += 1;
+			minimumX = Math.min(minimumX, x);
+			minimumY = Math.min(minimumY, y);
+			maximumX = Math.max(maximumX, x);
+			maximumY = Math.max(maximumY, y);
+		}
+	}
+	const minimumDimension = Math.min(image.width, image.height);
+	const contentWidth = maximumX - minimumX + 1;
+	const contentHeight = maximumY - minimumY + 1;
+	return (
+		visiblePixels >= image.width * image.height * MINIMUM_CONTENT_AREA_RATIO &&
+		contentWidth >= minimumDimension * MINIMUM_CONTENT_BOUND_RATIO &&
+		contentHeight >= minimumDimension * MINIMUM_CONTENT_BOUND_RATIO
+	);
+}
+
+async function renderCover({
+	entry,
+	render,
+}: {
+	entry: JianyingTextStyleCatalogEntry;
+	render: typeof renderJianyingText;
+}) {
+	if (!entry.runtimeReference) {
+		throw new Error("该花字没有可生成封面的运行时引用");
+	}
+	const requestHash = createHash("sha256")
+		.update(`cover\0${entry.styleId}`)
+		.digest("hex")
+		.slice(0, 16);
+	const result = await render({
+		request: {
+			requestId: `text-style-cover-${requestHash}`,
+			reference: entry.runtimeReference,
+			content: "花字",
+			fontSize: 48,
+			canvasWidth: COVER_SIZE,
+			canvasHeight: COVER_SIZE,
+			transform: {
+				x: 0,
+				y: 0,
+				width: COVER_SIZE,
+				height: COVER_SIZE,
+				rotation: 0,
+				opacity: 1,
+			},
+			sourceStart: 0,
+			elementDuration: COVER_FRAME_COUNT / COVER_FPS,
+			frameCount: COVER_FRAME_COUNT,
+			fps: COVER_FPS,
+			previewVideo: false,
+		},
+	});
+	if (result.source.kind !== "image-sequence") {
+		throw new Error("剪映花字封面渲染没有返回图片序列");
+	}
+	const bytes = await readFile(
+		middleFramePath({ pattern: result.source.path })
+	);
+	if (!(await hasUsefulCoverContent({ bytes }))) {
+		throw new Error("剪映花字封面有效内容过小");
+	}
+	return bytes;
+}
+
+function renderFallbackCover({
+	entry,
+}: {
+	entry: JianyingTextStyleCatalogEntry;
+}) {
+	const hue =
+		Number.parseInt(
+			createHash("sha256").update(entry.styleId).digest("hex").slice(0, 6),
+			16
+		) % 360;
+	const canvas = createCanvas(COVER_SIZE, COVER_SIZE);
+	const context = canvas.getContext("2d");
+	context.clearRect(0, 0, COVER_SIZE, COVER_SIZE);
+	context.font = "bold 72px sans-serif";
+	context.textAlign = "center";
+	context.textBaseline = "middle";
+	context.lineJoin = "round";
+	context.strokeStyle = "rgba(8, 10, 14, 0.96)";
+	context.lineWidth = 15;
+	context.shadowColor = `hsla(${hue}, 95%, 62%, 0.9)`;
+	context.shadowBlur = 20;
+	context.strokeText("花字", COVER_SIZE / 2, COVER_SIZE / 2);
+	const gradient = context.createLinearGradient(56, 72, 200, 184);
+	gradient.addColorStop(0, `hsl(${hue}, 96%, 76%)`);
+	gradient.addColorStop(1, `hsl(${(hue + 48) % 360}, 92%, 54%)`);
+	context.fillStyle = gradient;
+	context.fillText("花字", COVER_SIZE / 2, COVER_SIZE / 2);
+	return canvas.toBuffer("image/png");
+}
+
+async function generateCover({
+	entry,
+	render,
+}: {
+	entry: JianyingTextStyleCatalogEntry;
+	render: typeof renderJianyingText;
+}) {
+	try {
+		return await renderCover({ entry, render });
+	} catch {
+		return renderFallbackCover({ entry });
+	}
+}
+
+export function readJianyingTextStyleGeneratedCover({
+	cacheRoot,
+	entry,
+	render = renderJianyingText,
+}: {
+	cacheRoot: string;
+	entry: JianyingTextStyleCatalogEntry;
+	render?: typeof renderJianyingText;
+}): Promise<JianyingCachedImage> {
+	return readJianyingCachedImage({
+		cacheRoot: path.join(cacheRoot, "generated"),
+		label: "剪映花字生成封面",
+		maximumBytes: 4 * 1024 * 1024,
+		source: {
+			cacheKey: `v${GENERATED_COVER_CACHE_VERSION}:${entry.styleId}`,
+			produce: () =>
+				queueRender({ task: () => generateCover({ entry, render }) }),
+		},
+	});
+}

--- a/qcut/electron/jianying-text-style-lab-contract.ts
+++ b/qcut/electron/jianying-text-style-lab-contract.ts
@@ -111,7 +111,7 @@ export interface JianyingTextStyleLabCoverRequest {
 
 export interface JianyingTextStyleLabCoverResult {
 	styleId: string;
-	mimeType: "image/png";
+	mimeType: "image/gif" | "image/jpeg" | "image/png" | "image/webp";
 	bytes: Uint8Array;
 }
 

--- a/qcut/electron/jianying-text-style-lab-handler.ts
+++ b/qcut/electron/jianying-text-style-lab-handler.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { BrowserWindow, IpcMainInvokeEvent } from "electron";
 import { ipcMain } from "electron";
 import {
@@ -12,6 +13,7 @@ import {
 	type JianyingTextStyleLabListResult,
 } from "./jianying-text-style-lab-contract.js";
 import { buildJianyingTextAnimationCatalog } from "./jianying-text-animation-lab-catalog.js";
+import type { JianyingCachedImage } from "./jianying-image-cache.js";
 import { ensureQCutJianyingTextPrivateArchive } from "./jianying-text-private-archive.js";
 import {
 	type JianyingFlowerCategoryDefinition,
@@ -34,6 +36,13 @@ import {
 	type JianyingTextPackageOwnership,
 } from "./jianying-text-package-ownership.js";
 import { isDiscoverableJianyingTextCatalogEntry } from "./jianying-text-style-discovery.js";
+import { readJianyingTextStyleCoverImage } from "./jianying-text-style-cover-cache.js";
+import {
+	attachJianyingTextStyleCoverUrls,
+	resolveJianyingTextStyleCoverUrls,
+} from "./jianying-text-style-cover-metadata.js";
+import { readJianyingTextStyleGeneratedCover } from "./jianying-text-style-generated-cover.js";
+import { classifyLocalJianyingTextStyles } from "./jianying-text-style-local-categories.js";
 import {
 	compareStyleSummaries,
 	normalizeResolvedMetadata,
@@ -85,11 +94,28 @@ export interface SetupJianyingTextStyleLabIPCOptions {
 	}: {
 		references: JianyingTextStyleCatalogEntry[];
 	}) => Promise<Map<string, JianyingTextPackageOwnership>>;
+	resolveCoverUrls?: ({
+		references,
+	}: {
+		references: JianyingTextStyleCatalogEntry[];
+	}) => Promise<Map<string, string>>;
 	readCover?: ({
 		entry,
 	}: {
 		entry: JianyingTextStyleCatalogEntry;
 	}) => Promise<Buffer>;
+	readCachedCover?: ({
+		entry,
+		sourceUrl,
+	}: {
+		entry: JianyingTextStyleCatalogEntry;
+		sourceUrl: string;
+	}) => Promise<JianyingCachedImage>;
+	readGeneratedCover?: ({
+		entry,
+	}: {
+		entry: JianyingTextStyleCatalogEntry;
+	}) => Promise<JianyingCachedImage>;
 	/** Enables the on-disk catalog snapshot when set; tests leave it unset. */
 	snapshotCacheFilePath?: string;
 	computeSnapshotFingerprint?: () => Promise<string>;
@@ -184,7 +210,36 @@ export function setupJianyingTextStyleLabIPC({
 			projectRoot: archive.projectEvidenceRoot,
 		});
 	},
+	resolveCoverUrls = async ({ references }) => {
+		const archive = await ensureQCutJianyingTextPrivateArchive();
+		return resolveJianyingTextStyleCoverUrls({
+			references,
+			databaseRoot: archive.databaseRoot,
+		});
+	},
 	readCover = readJianyingTextStyleCover,
+	readCachedCover = async ({ entry, sourceUrl }) => {
+		const archive = await ensureQCutJianyingTextPrivateArchive();
+		return readJianyingTextStyleCoverImage({
+			cacheRoot: path.join(archive.archiveRoot, "Covers"),
+			produceFallback: async () =>
+				(
+					await readJianyingTextStyleGeneratedCover({
+						cacheRoot: path.join(archive.archiveRoot, "Covers"),
+						entry,
+					})
+				).bytes,
+			sourceUrl,
+			styleId: entry.styleId,
+		});
+	},
+	readGeneratedCover = async ({ entry }) => {
+		const archive = await ensureQCutJianyingTextPrivateArchive();
+		return readJianyingTextStyleGeneratedCover({
+			cacheRoot: path.join(archive.archiveRoot, "Covers"),
+			entry,
+		});
+	},
 	snapshotCacheFilePath,
 	computeSnapshotFingerprint = async () => {
 		const archive = await ensureQCutJianyingTextPrivateArchive();
@@ -199,6 +254,20 @@ export function setupJianyingTextStyleLabIPC({
 		null;
 	let snapshotPromise: Promise<JianyingTextLabSnapshot | null> | null = null;
 	let snapshotWriteQueued = false;
+	const readRemoteCoverWithGeneratedFallback = async ({
+		entry,
+		sourceUrl,
+	}: {
+		entry: JianyingTextStyleCatalogEntry;
+		sourceUrl: string;
+	}) => {
+		try {
+			return await readCachedCover({ entry, sourceUrl });
+		} catch (error) {
+			if (!entry.runtimeReference) throw error;
+			return readGeneratedCover({ entry });
+		}
+	};
 	const loadSnapshot = () => {
 		if (!snapshotCacheFilePath) return Promise.resolve(null);
 		if (!snapshotPromise) {
@@ -248,26 +317,38 @@ export function setupJianyingTextStyleLabIPC({
 			const resolvedMetadata = normalizeResolvedMetadata({
 				resolved: await resolveMetadata({ references: catalog.entries }),
 			});
-			const { categories, categoryGroups, metadata } = resolvedMetadata;
 			const ownershipCandidates = catalog.entries.filter(
-				({ packageKind, styleId }) =>
-					!metadata.has(styleId) &&
-					(packageKind === "AmazingFeature" || packageKind === "InfoSticker")
+				({ styleId }) => !resolvedMetadata.metadata.has(styleId)
 			);
-			const ownership =
+			const [ownership, coverUrls] = await Promise.all([
 				ownershipCandidates.length > 0
-					? await resolveOwnership({ references: ownershipCandidates })
-					: new Map<string, JianyingTextPackageOwnership>();
+					? resolveOwnership({ references: ownershipCandidates })
+					: Promise.resolve(new Map<string, JianyingTextPackageOwnership>()),
+				resolveCoverUrls({
+					references: catalog.entries.filter(({ hasCover }) => !hasCover),
+				}),
+			]);
+			const entries = catalog.entries.filter((entry) =>
+				isDiscoverableJianyingTextCatalogEntry({
+					entry,
+					metadata: resolvedMetadata.metadata,
+					ownership,
+				})
+			);
+			const classifiedMetadata = classifyLocalJianyingTextStyles({
+				entries,
+				ownership,
+				resolvedMetadata,
+			});
+			const metadata = attachJianyingTextStyleCoverUrls({
+				coverUrls,
+				metadata: classifiedMetadata.metadata,
+			});
+			const { categories, categoryGroups } = classifiedMetadata;
 			return {
 				catalog: {
 					...catalog,
-					entries: catalog.entries.filter((entry) =>
-						isDiscoverableJianyingTextCatalogEntry({
-							entry,
-							metadata,
-							ownership,
-						})
-					),
+					entries,
 				},
 				metadata,
 				ownership,
@@ -371,13 +452,27 @@ export function setupJianyingTextStyleLabIPC({
 		): Promise<JianyingTextStyleLabCoverResult> => {
 			assertTrustedMainFrame({ event, mainWindow: getMainWindow() });
 			const { styleId } = parseCoverRequest({ request });
-			const { catalog } = await readCatalog({ refresh: false });
+			const { catalog, metadata } = await readCatalog({ refresh: false });
 			const entry = requireCatalogEntry({ catalog, styleId });
-			const bytes = await readCover({ entry });
+			const remoteCoverUrl = metadata.get(styleId)?.coverUrl;
+			const cover = entry.coverPath
+				? {
+						bytes: await readCover({ entry }),
+						mimeType: "image/png" as const,
+					}
+				: remoteCoverUrl
+					? await readRemoteCoverWithGeneratedFallback({
+							entry,
+							sourceUrl: remoteCoverUrl,
+						})
+					: entry.runtimeReference
+						? await readGeneratedCover({ entry })
+						: null;
+			if (!cover) throw new Error("本机花字缓存没有缩略图");
 			return {
 				styleId,
-				mimeType: "image/png",
-				bytes: new Uint8Array(bytes),
+				mimeType: cover.mimeType,
+				bytes: new Uint8Array(cover.bytes),
 			};
 		}
 	);

--- a/qcut/electron/jianying-text-style-lab-handler.ts
+++ b/qcut/electron/jianying-text-style-lab-handler.ts
@@ -320,13 +320,16 @@ export function setupJianyingTextStyleLabIPC({
 			const ownershipCandidates = catalog.entries.filter(
 				({ styleId }) => !resolvedMetadata.metadata.has(styleId)
 			);
+			const coverUrlCandidates = catalog.entries.filter(
+				({ hasCover }) => !hasCover
+			);
 			const [ownership, coverUrls] = await Promise.all([
 				ownershipCandidates.length > 0
 					? resolveOwnership({ references: ownershipCandidates })
 					: Promise.resolve(new Map<string, JianyingTextPackageOwnership>()),
-				resolveCoverUrls({
-					references: catalog.entries.filter(({ hasCover }) => !hasCover),
-				}),
+				coverUrlCandidates.length > 0
+					? resolveCoverUrls({ references: coverUrlCandidates })
+					: Promise.resolve(new Map<string, string>()),
 			]);
 			const entries = catalog.entries.filter((entry) =>
 				isDiscoverableJianyingTextCatalogEntry({

--- a/qcut/electron/jianying-text-style-lab-handler.ts
+++ b/qcut/electron/jianying-text-style-lab-handler.ts
@@ -268,6 +268,28 @@ export function setupJianyingTextStyleLabIPC({
 			return readGeneratedCover({ entry });
 		}
 	};
+	const selectCover = async ({
+		entry,
+		remoteCoverUrl,
+	}: {
+		entry: JianyingTextStyleCatalogEntry;
+		remoteCoverUrl: string | undefined;
+	}) => {
+		if (entry.coverPath) {
+			return {
+				bytes: await readCover({ entry }),
+				mimeType: "image/png" as const,
+			};
+		}
+		if (remoteCoverUrl) {
+			return readRemoteCoverWithGeneratedFallback({
+				entry,
+				sourceUrl: remoteCoverUrl,
+			});
+		}
+		if (entry.runtimeReference) return readGeneratedCover({ entry });
+		return null;
+	};
 	const loadSnapshot = () => {
 		if (!snapshotCacheFilePath) return Promise.resolve(null);
 		if (!snapshotPromise) {
@@ -457,20 +479,10 @@ export function setupJianyingTextStyleLabIPC({
 			const { styleId } = parseCoverRequest({ request });
 			const { catalog, metadata } = await readCatalog({ refresh: false });
 			const entry = requireCatalogEntry({ catalog, styleId });
-			const remoteCoverUrl = metadata.get(styleId)?.coverUrl;
-			const cover = entry.coverPath
-				? {
-						bytes: await readCover({ entry }),
-						mimeType: "image/png" as const,
-					}
-				: remoteCoverUrl
-					? await readRemoteCoverWithGeneratedFallback({
-							entry,
-							sourceUrl: remoteCoverUrl,
-						})
-					: entry.runtimeReference
-						? await readGeneratedCover({ entry })
-						: null;
+			const cover = await selectCover({
+				entry,
+				remoteCoverUrl: metadata.get(styleId)?.coverUrl,
+			});
 			if (!cover) throw new Error("本机花字缓存没有缩略图");
 			return {
 				styleId,

--- a/qcut/electron/jianying-text-style-lab-summary.ts
+++ b/qcut/electron/jianying-text-style-lab-summary.ts
@@ -43,7 +43,10 @@ export function summarizeEntry({
 		textureLayerCount: entry.textureLayerCount,
 		capabilities: entry.capabilities,
 		diagnostics: entry.diagnostics,
-		hasCover: entry.hasCover,
+		hasCover:
+			entry.hasCover ||
+			Boolean(resourceMetadata?.coverUrl) ||
+			Boolean(entry.runtimeReference),
 		compatibility: entry.compatibility,
 		...(entry.approximation ? { approximation: entry.approximation } : {}),
 		...(entry.runtimeReference

--- a/qcut/electron/jianying-text-style-local-categories.ts
+++ b/qcut/electron/jianying-text-style-local-categories.ts
@@ -1,0 +1,141 @@
+import type {
+	JianyingFlowerCatalogMetadata,
+	JianyingFlowerResourceMetadata,
+} from "./jianying-flower-resource-metadata.js";
+import type {
+	JianyingFlowerCategoryDefinition,
+	JianyingFlowerCategoryGroupDefinition,
+} from "./jianying-flower-taxonomy.js";
+import type { JianyingTextStyleCategoryId } from "./jianying-text-style-lab-contract.js";
+import type { JianyingTextStyleCatalogEntry } from "./jianying-text-style-lab-catalog.js";
+import type { JianyingTextPackageOwnership } from "./jianying-text-package-ownership.js";
+
+const LOCAL_CATEGORY_GROUP_ID = "qcut-local";
+const LOCAL_CATEGORY_GROUP_LABEL = "本机补充";
+
+const LOCAL_CATEGORIES = [
+	{
+		id: "source-qcut-local-flower",
+		sourceId: "qcut-local-flower",
+		label: "本机花字",
+	},
+	{
+		id: "source-qcut-script-template",
+		sourceId: "qcut-script-template",
+		label: "脚本模板",
+	},
+	{
+		id: "source-qcut-style-component",
+		sourceId: "qcut-style-component",
+		label: "样式组件",
+	},
+] as const satisfies readonly {
+	id: JianyingTextStyleCategoryId;
+	sourceId: string;
+	label: string;
+}[];
+
+function localCategoryId({
+	entry,
+	ownership,
+}: {
+	entry: JianyingTextStyleCatalogEntry;
+	ownership: JianyingTextPackageOwnership | undefined;
+}): JianyingTextStyleCategoryId | null {
+	if (ownership?.kind === "flower") return "source-qcut-local-flower";
+	if (entry.packageKind === "ScriptInfoSticker") {
+		return "source-qcut-script-template";
+	}
+	if (ownership?.kind === "component") {
+		return "source-qcut-style-component";
+	}
+	return null;
+}
+
+function appendLocalTaxonomy({
+	categories,
+	categoryGroups,
+	usedCategoryIds,
+}: {
+	categories: JianyingFlowerCategoryDefinition[];
+	categoryGroups: JianyingFlowerCategoryGroupDefinition[];
+	usedCategoryIds: ReadonlySet<JianyingTextStyleCategoryId>;
+}) {
+	const localCategories = LOCAL_CATEGORIES.filter(({ id }) =>
+		usedCategoryIds.has(id)
+	).map(
+		({ id, label, sourceId }, index) =>
+			({
+				id,
+				label,
+				sourceId,
+				groupId: LOCAL_CATEGORY_GROUP_ID,
+				order: categories.length + index,
+			}) satisfies JianyingFlowerCategoryDefinition
+	);
+	if (localCategories.length === 0) return { categories, categoryGroups };
+
+	const localCategoryIds = localCategories.map(({ id }) => id);
+	const existingGroup = categoryGroups.find(
+		({ id }) => id === LOCAL_CATEGORY_GROUP_ID
+	);
+	const nextGroups = existingGroup
+		? categoryGroups.map((group) =>
+				group.id === LOCAL_CATEGORY_GROUP_ID
+					? {
+							...group,
+							categoryIds: [
+								...new Set([...group.categoryIds, ...localCategoryIds]),
+							],
+						}
+					: group
+			)
+		: [
+				...categoryGroups,
+				{
+					id: LOCAL_CATEGORY_GROUP_ID,
+					label: LOCAL_CATEGORY_GROUP_LABEL,
+					categoryIds: localCategoryIds,
+					order: categoryGroups.length,
+				} satisfies JianyingFlowerCategoryGroupDefinition,
+			];
+	return {
+		categories: [...categories, ...localCategories],
+		categoryGroups: nextGroups,
+	};
+}
+
+export function classifyLocalJianyingTextStyles({
+	entries,
+	ownership,
+	resolvedMetadata,
+}: {
+	entries: JianyingTextStyleCatalogEntry[];
+	ownership: ReadonlyMap<string, JianyingTextPackageOwnership>;
+	resolvedMetadata: JianyingFlowerCatalogMetadata;
+}): JianyingFlowerCatalogMetadata {
+	const metadata = new Map<string, JianyingFlowerResourceMetadata>(
+		resolvedMetadata.metadata
+	);
+	const usedCategoryIds = new Set<JianyingTextStyleCategoryId>();
+	for (const entry of entries) {
+		if (metadata.has(entry.styleId)) continue;
+		const packageOwnership = ownership.get(entry.styleId);
+		const categoryId = localCategoryId({
+			entry,
+			ownership: packageOwnership,
+		});
+		if (!categoryId) continue;
+		metadata.set(entry.styleId, {
+			...(packageOwnership?.title ? { title: packageOwnership.title } : {}),
+			categoryIds: [categoryId],
+		});
+		usedCategoryIds.add(categoryId);
+	}
+	const taxonomy = appendLocalTaxonomy({
+		categories: resolvedMetadata.categories,
+		categoryGroups: resolvedMetadata.categoryGroups,
+		usedCategoryIds,
+	});
+	return { metadata, ...taxonomy };
+}


### PR DESCRIPTION
## Summary
- classify local Jianying text-style packages and resolve, cache, or generate usable cover artwork
- flatten and compact the text-style library navigation and grid
- move Filter library, Favorites, and 滤镜实验室 into one collapsible sidebar with nested lab categories
- share the local image cache across text-style and filter labs and enable the sound-effects lab by default

## Verification
- `bunx biome check` on all changed filter navigation files
- `bunx vitest run apps/web/src/components/editor/media-panel/views/filters/__tests__/filters-view.test.tsx apps/web/src/components/editor/media-panel/views/adjustments/__tests__/jianying-filter-lab.test.tsx` (30 passed)
- `bunx playwright test apps/web/src/test/e2e/filter-library.e2e.ts --project=electron --reporter=line` (1 passed)
- `bunx vite build`

## Known existing issues
- full web TypeScript check is blocked by existing Claude media API and sticker platform capability type errors outside this PR scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared, collapsible sidebar for filter library, favorites, and Filter Lab modes.
  * Simplified Jianying filter and text-style category navigation into flat lists.
  * Redesigned text-style cards with a compact responsive grid and larger result batches.
  * Added local text-style categories and improved cover availability with cached and generated fallbacks.
  * Enabled the local sound-effects lab by default.

* **Bug Fixes**
  * Improved compatibility when local runtime inspection is unavailable.
  * Improved reliability and caching for filter and text-style preview images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->