### PR TITLE
feat(filter-lab): render cached filters from CLI

### DIFF
--- a/qcut/.gitignore
+++ b/qcut/.gitignore
@@ -19,6 +19,7 @@
 !/build/*.ico
 !/build/icon.png
 !/build/entitlements.mac.plist
+!/build/entitlements.transition-bridge.mac.plist
 !/build/aicp/
 !/build/aicp/aicp.spec
 !/build/aicp/entry.py

--- a/qcut/apps/web/src/components/editor/preview-panel/preview-element-renderer.tsx
+++ b/qcut/apps/web/src/components/editor/preview-panel/preview-element-renderer.tsx
@@ -58,6 +58,7 @@ import {
 	resolveEffectivePreviewQualityOption,
 	resolvePreviewEffectRenderMode,
 } from "@/lib/preview/preview-quality";
+import { usesOriginalAudioFallbackForGeneratedMask } from "@/lib/preview/generated-mask-audio-preview";
 import { resolvePreviewVideoSource } from "@/lib/preview/preview-video-source";
 import type { ClipTransitionPreviewState } from "@/lib/transitions/clip-transition-preview";
 import {
@@ -881,6 +882,18 @@ export function PreviewElementRenderer({
 				const generatedMaskSource = generatedMask?.sourceMediaId
 					? videoSourcesById.get(generatedMask.sourceMediaId)
 					: undefined;
+				const generatedMaskMediaItem = generatedMask?.sourceMediaId
+					? mediaItems.find((item) => item.id === generatedMask.sourceMediaId)
+					: undefined;
+				const usesOriginalMaskAudioFallback =
+					usesOriginalAudioFallbackForGeneratedMask({
+						generatedMaskHasAudio:
+							typeof generatedMaskMediaItem?.metadata?.hasAudio === "boolean"
+								? generatedMaskMediaItem.metadata.hasAudio
+								: undefined,
+						hasDerivedAudio,
+						hasGeneratedMaskSource: Boolean(generatedMaskSource),
+					});
 				const geometricMasks = generatedMaskSource
 					? visual.masks.filter((mask) => !mask.sourceMediaId)
 					: visual.masks;
@@ -1137,7 +1150,7 @@ export function PreviewElementRenderer({
 									</TriangleAlert>
 								</div>
 							) : null}
-							{generatedMaskSource && !hasDerivedAudio ? (
+							{usesOriginalMaskAudioFallback ? (
 								<VideoPlayer
 									videoSource={source}
 									clipStartTime={previewAudioElement.startTime}

--- a/qcut/apps/web/src/components/editor/properties-panel/media-automatic-cutout-properties.tsx
+++ b/qcut/apps/web/src/components/editor/properties-panel/media-automatic-cutout-properties.tsx
@@ -374,7 +374,7 @@ export function MediaAutomaticCutoutProperties({
 	const sourceReady = Boolean(projectId && mediaItem && sourceUrl);
 
 	return (
-		<PropertyGroup title="智能抠像" defaultExpanded>
+		<PropertyGroup title="抠像" defaultExpanded>
 			<Tabs
 				value={mode}
 				onValueChange={(value) => setMode(value as AutomaticCutoutMode)}
@@ -382,11 +382,11 @@ export function MediaAutomaticCutoutProperties({
 				<TabsList className="grid h-8 w-full grid-cols-2 rounded-sm p-0.5">
 					<TabsTrigger value="person" className="gap-1.5 text-xs">
 						<UserRound className="size-3.5" />
-						本地人物
+						人物抠像
 					</TabsTrigger>
 					<TabsTrigger value="object" className="gap-1.5 text-xs">
 						<ScanSearch className="size-3.5" />
-						云端物体
+						物体抠像
 					</TabsTrigger>
 				</TabsList>
 
@@ -395,20 +395,23 @@ export function MediaAutomaticCutoutProperties({
 						<LocalPersonCutoutPanel
 							projectId={projectId}
 							sourceFile={mediaItem.file}
+							sourcePath={
+								mediaItem.localPath ?? mediaItem.importMetadata?.originalPath
+							}
 							sourceUrl={sourceUrl}
 							addMediaItem={addMediaItem}
-							onProgress={({ progress }) =>
+							onProgress={({ progress, source }) =>
 								updateGeneratedMaskTrackingProgress({
 									progress,
-									source: "mediapipe",
+									source,
 								})
 							}
-							onMaskReady={({ sourceMediaId, trackingSamples }) =>
+							onMaskReady={({ source, sourceMediaId, trackingSamples }) =>
 								attachGeneratedMask({
 									sourceMediaId,
 									type: "person",
-									source: "mediapipe",
-									name: "MediaPipe 人物",
+									source,
+									name: "人物抠像",
 									trackingSamples,
 									targetElementId: element.id,
 								})
@@ -464,12 +467,9 @@ export function MediaAutomaticCutoutProperties({
 						onRetry={retryObjectCutout}
 					/>
 					{objectResultUrl ? (
-						<video
-							controls
-							playsInline
-							src={objectResultUrl}
-							className="max-h-56 w-full rounded-sm border bg-black object-contain"
-						/>
+						<p className="rounded-sm border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+							物体抠像结果已生成并应用
+						</p>
 					) : null}
 				</TabsContent>
 			</Tabs>

--- a/qcut/apps/web/src/components/editor/properties-panel/media-chroma-key-properties.tsx
+++ b/qcut/apps/web/src/components/editor/properties-panel/media-chroma-key-properties.tsx
@@ -1,5 +1,5 @@
-import { Pipette } from "lucide-react";
-import { useRef } from "react";
+import { ChevronDown, Pipette } from "lucide-react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { usePlaybackStore } from "@/stores/editor/playback-store";
@@ -59,6 +59,7 @@ export function MediaChromaKeyProperties({
 	const seek = usePlaybackStore((state) => state.seek);
 	const fps = useProjectStore((state) => state.activeProject?.fps ?? 30);
 	const interactionActive = useRef(false);
+	const [advancedOpen, setAdvancedOpen] = useState(false);
 	const settings = normalizeMediaChromaKey(element.chromaKey);
 	const resolved = resolveMediaChromaKeyAtTime({
 		chromaKey: settings,
@@ -167,6 +168,62 @@ export function MediaChromaKeyProperties({
 			},
 		});
 	};
+	const renderControl = ({
+		property,
+		label,
+		withKeyframes,
+	}: {
+		property: MediaChromaKeyKeyframeProperty;
+		label: string;
+		withKeyframes: boolean;
+	}) => {
+		const frames = keyframeFrames({ settings, property });
+		const previousFrame = [...frames]
+			.reverse()
+			.find((frame) => frame < currentFrame);
+		const nextFrame = frames.find((frame) => frame > currentFrame);
+		return (
+			<ColorNumberControl
+				key={property}
+				label={label}
+				value={resolved[property] * 100}
+				min={property === "similarity" ? 1 : 0}
+				max={100}
+				step={1}
+				suffix="%"
+				keyframedHere={withKeyframes && frames.includes(currentFrame)}
+				hasPreviousKeyframe={withKeyframes && previousFrame !== undefined}
+				hasNextKeyframe={withKeyframes && nextFrame !== undefined}
+				onChange={(value) => updateProperty({ property, value: value / 100 })}
+				onToggleKeyframe={
+					withKeyframes ? () => toggleKeyframe({ property }) : undefined
+				}
+				onPreviousKeyframe={
+					withKeyframes
+						? () => {
+								if (previousFrame !== undefined) {
+									seek(element.startTime + previousFrame / fps);
+								}
+							}
+						: undefined
+				}
+				onNextKeyframe={
+					withKeyframes
+						? () => {
+								if (nextFrame !== undefined) {
+									seek(element.startTime + nextFrame / fps);
+								}
+							}
+						: undefined
+				}
+				onInteractionStart={beginInteraction}
+				onInteractionEnd={endInteraction}
+			/>
+		);
+	};
+	const basicProperties = MEDIA_CHROMA_KEY_KEYFRAME_PROPERTIES.filter(
+		({ value }) => value !== "spill"
+	);
 
 	return (
 		<ColorModuleSection
@@ -195,45 +252,37 @@ export function MediaChromaKeyProperties({
 				</ColorIconButton>
 			</div>
 
-			{MEDIA_CHROMA_KEY_KEYFRAME_PROPERTIES.map(
-				({ value: property, label }) => {
-					const frames = keyframeFrames({ settings, property });
-					const previousFrame = [...frames]
-						.reverse()
-						.find((frame) => frame < currentFrame);
-					const nextFrame = frames.find((frame) => frame > currentFrame);
-					return (
-						<ColorNumberControl
-							key={property}
-							label={label}
-							value={resolved[property] * 100}
-							min={property === "similarity" ? 1 : 0}
-							max={100}
-							step={1}
-							suffix="%"
-							keyframedHere={frames.includes(currentFrame)}
-							hasPreviousKeyframe={previousFrame !== undefined}
-							hasNextKeyframe={nextFrame !== undefined}
-							onChange={(value) =>
-								updateProperty({ property, value: value / 100 })
-							}
-							onToggleKeyframe={() => toggleKeyframe({ property })}
-							onPreviousKeyframe={() => {
-								if (previousFrame !== undefined) {
-									seek(element.startTime + previousFrame / fps);
-								}
-							}}
-							onNextKeyframe={() => {
-								if (nextFrame !== undefined) {
-									seek(element.startTime + nextFrame / fps);
-								}
-							}}
-							onInteractionStart={beginInteraction}
-							onInteractionEnd={endInteraction}
-						/>
-					);
-				}
-			)}
+			{advancedOpen
+				? null
+				: basicProperties.map(({ value, label }) =>
+						renderControl({
+							property: value,
+							label,
+							withKeyframes: false,
+						})
+					)}
+			<details
+				open={advancedOpen}
+				onToggle={(event) => setAdvancedOpen(event.currentTarget.open)}
+				className="group rounded-sm border px-3 py-2"
+			>
+				<summary className="flex cursor-pointer list-none items-center justify-between text-xs font-medium">
+					高级
+					<ChevronDown className="size-3.5 transition-transform group-open:rotate-180" />
+				</summary>
+				<div className="mt-3 space-y-3">
+					<p className="text-[11px] text-muted-foreground">
+						可为每项参数添加关键帧，并用溢色抑制清理人物边缘的背景色
+					</p>
+					{MEDIA_CHROMA_KEY_KEYFRAME_PROPERTIES.map(({ value, label }) =>
+						renderControl({
+							property: value,
+							label,
+							withKeyframes: true,
+						})
+					)}
+				</div>
+			</details>
 		</ColorModuleSection>
 	);
 }

--- a/qcut/apps/web/src/components/editor/properties-panel/media-portrait-properties.tsx
+++ b/qcut/apps/web/src/components/editor/properties-panel/media-portrait-properties.tsx
@@ -65,13 +65,18 @@ type FacePanelSection =
 	| "features"
 	| "makeup"
 	| "manual";
-type BodyPanelTab = "automatic" | "manual";
+type BodyPanelSection = "smart" | "manual";
 
 const INITIAL_FACE_SECTION_VISIBILITY: Record<FacePanelSection, boolean> = {
 	skin: false,
 	"face-shape": false,
 	features: false,
 	makeup: false,
+	manual: false,
+};
+
+const INITIAL_BODY_SECTION_VISIBILITY: Record<BodyPanelSection, boolean> = {
+	smart: true,
 	manual: false,
 };
 
@@ -216,7 +221,9 @@ export function MediaPortraitProperties({
 	const [openFaceSections, setOpenFaceSections] = useState(() => ({
 		...INITIAL_FACE_SECTION_VISIBILITY,
 	}));
-	const [activeBodyTab, setActiveBodyTab] = useState<BodyPanelTab>("automatic");
+	const [openBodySections, setOpenBodySections] = useState(() => ({
+		...INITIAL_BODY_SECTION_VISIBILITY,
+	}));
 	const [status, setStatus] = useState<JianyingPortraitAdjustmentStatus | null>(
 		null
 	);
@@ -390,6 +397,14 @@ export function MediaPortraitProperties({
 		makeup: Object.values(scopedAdjustments.makeup ?? {}).some(Boolean),
 		manual: (adjustments.manualRetouch?.strokes.length ?? 0) > 0,
 	};
+	const bodySectionActivity: Record<BodyPanelSection, boolean> = {
+		smart: (controlsBySection.get("body") ?? []).some(
+			({ key }) => (adjustments.values[key] ?? 0) !== 0
+		),
+		manual: Object.values(adjustments.manualBody ?? {}).some(
+			(value) => (value?.intensity ?? 0) !== 0
+		),
+	};
 	const setFaceSectionOpen = ({
 		open,
 		section,
@@ -401,6 +416,15 @@ export function MediaPortraitProperties({
 		if (section === "manual" && open && !detection && !detecting) {
 			void detectFaces();
 		}
+	};
+	const setBodySectionOpen = ({
+		open,
+		section,
+	}: {
+		open: boolean;
+		section: BodyPanelSection;
+	}) => {
+		setOpenBodySections((current) => ({ ...current, [section]: open }));
 	};
 	const presetScope: PortraitPresetScope = activeTab.startsWith("body")
 		? "body"
@@ -709,24 +733,29 @@ export function MediaPortraitProperties({
 								{locale === "zh" ? "全部人物" : "All people"}
 							</span>
 						</div>
-						<Tabs
-							value={activeBodyTab}
-							onValueChange={(value) => setActiveBodyTab(value as BodyPanelTab)}
-						>
-							<TabsList className="grid h-8 w-full grid-cols-2 gap-0.5 rounded-sm p-0.5">
-								<TabsTrigger value="automatic" className="px-1 text-[10px]">
-									{locale === "zh" ? "自动美体" : "Auto body"}
-								</TabsTrigger>
-								<TabsTrigger value="manual" className="px-1 text-[10px]">
-									{locale === "zh" ? "手动美体" : "Manual body"}
-								</TabsTrigger>
-							</TabsList>
-							<TabsContent value="automatic" className="mt-4">
+						<div className="border-t border-border/70">
+							<PortraitCollapsibleGroup
+								active={bodySectionActivity.smart}
+								label={locale === "zh" ? "智能美体" : "Smart body"}
+								open={openBodySections.smart}
+								onOpenChange={(open) =>
+									setBodySectionOpen({ open, section: "smart" })
+								}
+								testId="portrait-group-smart-body"
+							>
 								<PortraitAdjustmentSection {...sectionProps("body")} />
-							</TabsContent>
-							<TabsContent value="manual" className="mt-4">
+							</PortraitCollapsibleGroup>
+							<PortraitCollapsibleGroup
+								active={bodySectionActivity.manual}
+								label={locale === "zh" ? "手动美体" : "Manual body"}
+								open={openBodySections.manual}
+								onOpenChange={(open) =>
+									setBodySectionOpen({ open, section: "manual" })
+								}
+								testId="portrait-group-manual-body"
+							>
 								<PortraitManualBodyControls
-									active={activeTab === "body" && activeBodyTab === "manual"}
+									active={activeTab === "body" && openBodySections.manual}
 									adjustments={adjustments}
 									disabled={nativeDisabled || !adjustments.enabled}
 									elementId={elementId}
@@ -736,8 +765,8 @@ export function MediaPortraitProperties({
 									onInteractionStart={onInteractionStart}
 									onInteractionEnd={onInteractionEnd}
 								/>
-							</TabsContent>
-						</Tabs>
+							</PortraitCollapsibleGroup>
+						</div>
 					</TabsContent>
 					{(["face-presets", "body-presets"] as const).map((tab) => (
 						<TabsContent key={tab} value={tab} className="mt-4">

--- a/qcut/apps/web/src/components/editor/segmentation/CutoutTaskStatus.tsx
+++ b/qcut/apps/web/src/components/editor/segmentation/CutoutTaskStatus.tsx
@@ -95,7 +95,7 @@ export function CutoutTaskStatus({
 					<span>{PHASE_LABELS[phase]}</span>
 				</div>
 				<span className="shrink-0 text-muted-foreground">
-					{Math.max(0, Math.floor(elapsedTime))}s
+					{Math.max(0, Math.floor(elapsedTime))} 秒
 				</span>
 			</div>
 

--- a/qcut/apps/web/src/components/editor/segmentation/LocalPersonCutoutPanel.tsx
+++ b/qcut/apps/web/src/components/editor/segmentation/LocalPersonCutoutPanel.tsx
@@ -1,16 +1,24 @@
 "use client";
 
-import { Download, Loader2 } from "lucide-react";
+import { ChevronDown, Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { createObjectURL } from "@/lib/media/blob-manager";
 import { registerCloudTaskRuntimeActions } from "@/lib/cloud-tasks/task-runtime-actions";
-import { exportPersonCutoutVideo } from "@/lib/segmentation/person-cutout-export";
+import {
+	exportPersonCutoutVideo,
+	type PersonCutoutQuality,
+} from "@/lib/segmentation/person-cutout-export";
+import {
+	BASIC_PERSON_CUTOUT_SETTINGS,
+	FINE_PERSON_CUTOUT_SETTINGS,
+} from "@/lib/segmentation/person-cutout-presets";
 import {
 	detachGeneratedMask,
 	pauseGeneratedMaskTracking,
 } from "@/lib/segmentation/generated-mask-attachment";
+import type { GeneratedMaskSource } from "@/lib/segmentation/generated-mask-attachment";
 import { registerActiveMaskTrackingRuntime } from "@/lib/segmentation/mask-tracking-runtime";
 import { useSegmentationStore } from "@/stores/ai/segmentation-store";
 import { useCloudTaskStore } from "@/stores/cloud-task-store";
@@ -19,21 +27,23 @@ import { useMediaPanelStore } from "@/components/editor/media-panel/store";
 import type { MediaStore } from "@/stores/media/media-store-types";
 import type { MediaMaskTrackingSample } from "@/lib/video/media-mask-tracking";
 import { CutoutTaskStatus, type CutoutTaskPhase } from "./CutoutTaskStatus";
-import { PersonCutoutPreview } from "./PersonCutoutPreview";
 import { PersonCutoutSettings } from "./PersonCutoutSettings";
 
 interface LocalPersonCutoutPanelProps {
 	projectId: string;
 	sourceFile: File;
+	sourcePath?: string;
 	sourceUrl: string;
 	autoStartRequestId?: string;
 	addMediaItem?: MediaStore["addMediaItem"];
 	onMaskReady?: ({
+		source,
 		sourceMediaId,
 		trackingSamples,
 		targetElementId,
 		trackingRequestId,
 	}: {
+		source: GeneratedMaskSource;
 		sourceMediaId: string;
 		trackingSamples: MediaMaskTrackingSample[];
 		targetElementId?: string;
@@ -42,9 +52,11 @@ interface LocalPersonCutoutPanelProps {
 	onMaskError?: (message: string) => void;
 	onProgress?: ({
 		progress,
+		source,
 		status,
 	}: {
 		progress: number;
+		source: GeneratedMaskSource;
 		status: string;
 	}) => void;
 }
@@ -54,18 +66,10 @@ function cutoutFilename(sourceName: string): string {
 	return `${base}-person-cutout.webm`;
 }
 
-const checkerBackground = {
-	backgroundColor: "#202020",
-	backgroundImage:
-		"linear-gradient(45deg, #303030 25%, transparent 25%), linear-gradient(-45deg, #303030 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #303030 75%), linear-gradient(-45deg, transparent 75%, #303030 75%)",
-	backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
-	backgroundSize: "16px 16px",
-};
-
 export function LocalPersonCutoutPanel({
 	projectId,
 	sourceFile,
-	sourceUrl,
+	sourcePath,
 	autoStartRequestId,
 	addMediaItem,
 	onMaskReady,
@@ -92,6 +96,27 @@ export function LocalPersonCutoutPanel({
 	const sourceFileRef = useRef(sourceFile);
 	const [taskPhase, setTaskPhase] = useState<CutoutTaskPhase>("idle");
 	const [taskError, setTaskError] = useState<string>();
+	const [quality, setQuality] = useState<PersonCutoutQuality>("basic");
+	const qualitySettingsRef = useRef({
+		basic: { ...personCutoutSettings },
+		fine: { ...FINE_PERSON_CUTOUT_SETTINGS },
+	});
+	const [fineStatus, setFineStatus] = useState<string>();
+
+	useEffect(() => {
+		let active = true;
+		void window.electronAPI?.jianyingPersonCutout
+			?.inspect()
+			.then((status) => {
+				if (active) setFineStatus(status.message);
+			})
+			.catch(() => {
+				if (active) setFineStatus("精细抠像暂不可用");
+			});
+		return () => {
+			active = false;
+		};
+	}, []);
 
 	useEffect(() => {
 		const sourceChanged = sourceFileRef.current !== sourceFile;
@@ -133,7 +158,7 @@ export function LocalPersonCutoutPanel({
 				kind: "cutout",
 				label: `人物抠像：${sourceFile.name}`,
 				payload: { projectId, sourceName: sourceFile.name },
-				message: "正在准备本地人物抠像",
+				message: "正在准备人物抠像",
 			});
 		const existingTask = cloudTasks.tasks.find(
 			(candidate) => candidate.id === taskId
@@ -145,6 +170,8 @@ export function LocalPersonCutoutPanel({
 		const controller = new AbortController();
 		abortControllerRef.current = controller;
 		const trackingRequest = useSegmentationStore.getState().trackingRequest;
+		const cutoutSource: GeneratedMaskSource =
+			quality === "fine" ? "jianying-gru" : "mediapipe";
 		let unregisterMaskTrackingRuntime = () => {};
 		const cancel = () => {
 			controller.abort();
@@ -156,7 +183,7 @@ export function LocalPersonCutoutPanel({
 				runtime: {
 					elementId: trackingRequest.elementId,
 					maskId: trackingRequest.maskId,
-					source: "mediapipe",
+					source: cutoutSource,
 					direction: trackingRequest.direction,
 					cancel,
 					resume: retry,
@@ -169,21 +196,23 @@ export function LocalPersonCutoutPanel({
 			taskId,
 			actions: { cancel, retry, open },
 		});
-		cloudTasks.startTask({ id: taskId, message: "正在准备本地人物抠像" });
+		cloudTasks.startTask({ id: taskId, message: "正在准备人物抠像" });
 		const startedAt = Date.now();
 		setTaskPhase("processing");
 		setTaskError(undefined);
 		setProcessingState({
 			isProcessing: true,
 			progress: 0,
-			statusMessage: "正在准备本地人物抠像...",
+			statusMessage: "正在准备人物抠像...",
 			elapsedTime: 0,
 		});
 
 		try {
 			const result = await exportPersonCutoutVideo({
 				file: sourceFile,
+				sourcePath,
 				settings: personCutoutSettings,
+				quality,
 				signal: controller.signal,
 				onProgress: ({ progress: nextProgress, status }) => {
 					if (controller.signal.aborted) return;
@@ -193,7 +222,11 @@ export function LocalPersonCutoutPanel({
 						statusMessage: status,
 						elapsedTime: (Date.now() - startedAt) / 1000,
 					});
-					onProgress?.({ progress: nextProgress, status });
+					onProgress?.({
+						progress: nextProgress,
+						source: cutoutSource,
+						status,
+					});
 					useCloudTaskStore.getState().updateProgress({
 						id: taskId,
 						progress: nextProgress,
@@ -212,7 +245,11 @@ export function LocalPersonCutoutPanel({
 				type: "video/webm",
 				lastModified: Date.now(),
 			});
-			const url = createObjectURL(file, "mediapipe-person-cutout");
+			const source =
+				quality === "fine"
+					? "jianying-gru-person-cutout"
+					: "mediapipe-person-cutout";
+			const url = createObjectURL(file, source);
 			const sourceMediaId = await addMediaItem(projectId, {
 				name: filename,
 				type: "video",
@@ -223,7 +260,9 @@ export function LocalPersonCutoutPanel({
 				height: result.height,
 				fps: result.frameRate,
 				metadata: {
-					source: "mediapipe-person-cutout",
+					blendImplementation: result.blendImplementation,
+					source,
+					quality,
 					hasAlpha: true,
 					codec: result.codec,
 					frameCount: result.frameCount,
@@ -238,6 +277,7 @@ export function LocalPersonCutoutPanel({
 			}
 			const attached =
 				onMaskReady?.({
+					source: cutoutSource,
 					sourceMediaId,
 					trackingSamples: result.trackingSamples,
 					targetElementId: trackingRequest?.elementId,
@@ -324,6 +364,21 @@ export function LocalPersonCutoutPanel({
 	};
 	renderTransparentVideoRef.current = renderTransparentVideo;
 
+	const selectQuality = (nextQuality: PersonCutoutQuality) => {
+		if (nextQuality === quality) return;
+		qualitySettingsRef.current[quality] = { ...personCutoutSettings };
+		setQuality(nextQuality);
+		updatePersonCutoutSettings(qualitySettingsRef.current[nextQuality]);
+	};
+
+	const updateQualitySettings = (
+		updates: Partial<typeof personCutoutSettings>
+	) => {
+		const nextSettings = { ...personCutoutSettings, ...updates };
+		qualitySettingsRef.current[quality] = nextSettings;
+		updatePersonCutoutSettings(nextSettings);
+	};
+
 	useEffect(() => {
 		if (
 			!autoStartRequestId ||
@@ -339,33 +394,56 @@ export function LocalPersonCutoutPanel({
 	return (
 		<div className="flex min-h-0 flex-1 flex-col">
 			<div className="min-h-0 flex-1 space-y-3 overflow-y-auto pb-3 pr-1">
-				<PersonCutoutPreview
-					key={sourceUrl}
-					sourceUrl={sourceUrl}
-					settings={personCutoutSettings}
-				/>
-				<PersonCutoutSettings
-					settings={personCutoutSettings}
-					onChange={updatePersonCutoutSettings}
-					disabled={isProcessing}
-				/>
-				{segmentedVideoUrl && (
-					<div className="space-y-2" data-testid="person-cutout-result">
-						<div className="text-xs font-medium text-muted-foreground">
-							上次透明视频结果
-						</div>
-						<div
-							className="flex min-h-32 items-center justify-center overflow-hidden rounded-sm border"
-							style={checkerBackground}
-						>
-							<video
-								controls
-								playsInline
-								src={segmentedVideoUrl}
-								className="max-h-64 max-w-full"
-							/>
-						</div>
+				<div className="space-y-2" data-testid="person-cutout-quality">
+					<div className="grid grid-cols-2 rounded-sm bg-muted p-0.5">
+						{(["basic", "fine"] as const).map((value) => (
+							<Button
+								type="button"
+								key={value}
+								variant={quality === value ? "secondary" : "text"}
+								size="sm"
+								className="h-7 text-xs"
+								aria-pressed={quality === value}
+								disabled={isProcessing}
+								onClick={() => selectQuality(value)}
+								data-testid={`person-cutout-quality-${value}`}
+							>
+								{value === "basic" ? "基础" : "精细"}
+							</Button>
+						))}
 					</div>
+					<p className="text-xs leading-5 text-muted-foreground">
+						基础处理速度较快，精细效果更佳，但耗时较长
+					</p>
+				</div>
+				<details className="group rounded-sm border px-3 py-2">
+					<summary className="flex cursor-pointer list-none items-center justify-between text-xs font-medium">
+						高级
+						<ChevronDown className="size-3.5 transition-transform group-open:rotate-180" />
+					</summary>
+					<div className="mt-3 space-y-3">
+						<PersonCutoutSettings
+							settings={personCutoutSettings}
+							defaults={
+								quality === "fine"
+									? FINE_PERSON_CUTOUT_SETTINGS
+									: BASIC_PERSON_CUTOUT_SETTINGS
+							}
+							onChange={updateQualitySettings}
+							disabled={isProcessing}
+						/>
+						{quality === "fine" && fineStatus ? (
+							<p className="text-xs text-muted-foreground">{fineStatus}</p>
+						) : null}
+					</div>
+				</details>
+				{segmentedVideoUrl && (
+					<p
+						className="rounded-sm border bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+						data-testid="person-cutout-result"
+					>
+						人物抠像结果已生成并应用
+					</p>
 				)}
 				<CutoutTaskStatus
 					phase={isProcessing ? "processing" : taskPhase}
@@ -402,12 +480,8 @@ export function LocalPersonCutoutPanel({
 					onClick={() => void renderTransparentVideo({})}
 					data-testid="person-cutout-export"
 				>
-					{isProcessing ? (
-						<Loader2 className="size-4 animate-spin" />
-					) : (
-						<Download className="size-4" />
-					)}
-					{onMaskReady ? "生成并应用人物蒙版" : "生成透明 WebM"}
+					{isProcessing ? <Loader2 className="size-4 animate-spin" /> : null}
+					{onMaskReady ? "开始并应用" : "开始人物抠像"}
 				</Button>
 			</div>
 		</div>

--- a/qcut/apps/web/src/components/editor/segmentation/LocalPersonCutoutPanel.tsx
+++ b/qcut/apps/web/src/components/editor/segmentation/LocalPersonCutoutPanel.tsx
@@ -96,6 +96,7 @@ export function LocalPersonCutoutPanel({
 	const sourceFileRef = useRef(sourceFile);
 	const [taskPhase, setTaskPhase] = useState<CutoutTaskPhase>("idle");
 	const [taskError, setTaskError] = useState<string>();
+	const [resultApplied, setResultApplied] = useState(false);
 	const [quality, setQuality] = useState<PersonCutoutQuality>("basic");
 	const qualitySettingsRef = useRef({
 		basic: { ...personCutoutSettings },
@@ -129,6 +130,7 @@ export function LocalPersonCutoutPanel({
 		if (sourceChanged) {
 			setTaskPhase("idle");
 			setTaskError(undefined);
+			setResultApplied(false);
 		}
 
 		return () => {
@@ -171,7 +173,7 @@ export function LocalPersonCutoutPanel({
 		abortControllerRef.current = controller;
 		const trackingRequest = useSegmentationStore.getState().trackingRequest;
 		const cutoutSource: GeneratedMaskSource =
-			quality === "fine" ? "jianying-gru" : "mediapipe";
+			quality === "fine" ? "qcut-person-matting" : "mediapipe";
 		let unregisterMaskTrackingRuntime = () => {};
 		const cancel = () => {
 			controller.abort();
@@ -247,7 +249,7 @@ export function LocalPersonCutoutPanel({
 			});
 			const source =
 				quality === "fine"
-					? "jianying-gru-person-cutout"
+					? "qcut-local-person-cutout"
 					: "mediapipe-person-cutout";
 			const url = createObjectURL(file, source);
 			const sourceMediaId = await addMediaItem(projectId, {
@@ -261,6 +263,13 @@ export function LocalPersonCutoutPanel({
 				fps: result.frameRate,
 				metadata: {
 					blendImplementation: result.blendImplementation,
+					didModelRouteFallback: result.didModelRouteFallback,
+					modelRoute: result.modelRoute,
+					nativeMetalCanary: result.nativeMetalCanary,
+					pipelineId: result.pipelineId,
+					provider: result.provider,
+					refinementProvider: result.refinementProvider,
+					requestedModelRoute: result.requestedModelRoute,
 					source,
 					quality,
 					hasAlpha: true,
@@ -283,6 +292,7 @@ export function LocalPersonCutoutPanel({
 					targetElementId: trackingRequest?.elementId,
 					trackingRequestId: trackingRequest?.requestId,
 				}) ?? false;
+			setResultApplied(attached);
 			setSegmentedVideo(url);
 			setTaskPhase("completed");
 			setProcessingState({
@@ -307,6 +317,7 @@ export function LocalPersonCutoutPanel({
 					.getState()
 					.removeMediaItem(projectId, sourceMediaId);
 				setSegmentedVideo(null);
+				setResultApplied(false);
 				registerCloudTaskRuntimeActions({
 					taskId,
 					actions: { open, retry },
@@ -442,7 +453,9 @@ export function LocalPersonCutoutPanel({
 						className="rounded-sm border bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
 						data-testid="person-cutout-result"
 					>
-						人物抠像结果已生成并应用
+						{resultApplied
+							? "人物抠像结果已生成并应用"
+							: "人物抠像结果已生成，已添加到素材库"}
 					</p>
 				)}
 				<CutoutTaskStatus

--- a/qcut/apps/web/src/components/editor/segmentation/PersonCutoutSettings.tsx
+++ b/qcut/apps/web/src/components/editor/segmentation/PersonCutoutSettings.tsx
@@ -98,7 +98,9 @@ export function PersonCutoutSettings({
 					aria-label="重置边缘调整"
 					title="重置"
 				>
-					<RotateCcw className="size-3.5" />
+					<RotateCcw className="size-3.5" aria-hidden="true">
+						<title>重置边缘调整</title>
+					</RotateCcw>
 				</Button>
 			</div>
 			<SettingRow

--- a/qcut/apps/web/src/components/editor/segmentation/PersonCutoutSettings.tsx
+++ b/qcut/apps/web/src/components/editor/segmentation/PersonCutoutSettings.tsx
@@ -9,16 +9,10 @@ import type { PersonCutoutExportSettings } from "@/lib/segmentation/person-cutou
 
 interface PersonCutoutSettingsProps {
 	settings: PersonCutoutExportSettings;
+	defaults: PersonCutoutExportSettings;
 	onChange: (settings: Partial<PersonCutoutExportSettings>) => void;
 	disabled?: boolean;
 }
-
-const DEFAULT_SETTINGS: PersonCutoutExportSettings = {
-	threshold: 0.5,
-	temporalSmoothing: 0.65,
-	edgeShift: 0,
-	feather: 2,
-};
 
 function clamp(value: number, min: number, max: number) {
 	return Math.min(max, Math.max(min, value));
@@ -86,32 +80,30 @@ function SettingRow({
 
 export function PersonCutoutSettings({
 	settings,
+	defaults,
 	onChange,
 	disabled,
 }: PersonCutoutSettingsProps) {
 	return (
-		<section
-			className="space-y-3 border-y py-3"
-			data-testid="person-cutout-settings"
-		>
+		<section className="space-y-3 py-1" data-testid="person-cutout-settings">
 			<div className="flex items-center justify-between">
-				<h3 className="text-sm font-medium">Person mask</h3>
+				<h3 className="text-sm font-medium">边缘调整</h3>
 				<Button
 					type="button"
 					variant="text"
 					size="icon"
 					className="size-7"
 					disabled={disabled}
-					onClick={() => onChange(DEFAULT_SETTINGS)}
-					aria-label="Reset person mask settings"
-					title="Reset settings"
+					onClick={() => onChange(defaults)}
+					aria-label="重置边缘调整"
+					title="重置"
 				>
 					<RotateCcw className="size-3.5" />
 				</Button>
 			</div>
 			<SettingRow
 				id="person-confidence"
-				label="Confidence"
+				label="识别强度"
 				value={settings.threshold}
 				min={0.1}
 				max={0.9}
@@ -121,7 +113,7 @@ export function PersonCutoutSettings({
 			/>
 			<SettingRow
 				id="person-smoothing"
-				label="Stability"
+				label="画面稳定"
 				value={settings.temporalSmoothing}
 				min={0}
 				max={0.95}
@@ -131,18 +123,18 @@ export function PersonCutoutSettings({
 			/>
 			<SettingRow
 				id="person-feather"
-				label="Feather"
+				label="边缘羽化"
 				value={settings.feather}
 				min={0}
 				max={16}
 				step={0.5}
-				suffix="px"
+				suffix="像素"
 				disabled={disabled}
 				onChange={(feather) => onChange({ feather })}
 			/>
 			<SettingRow
 				id="person-edge"
-				label="Edge"
+				label="边缘收缩"
 				value={settings.edgeShift}
 				min={-12}
 				max={12}

--- a/qcut/apps/web/src/components/editor/segmentation/__tests__/cutout-task-status.test.tsx
+++ b/qcut/apps/web/src/components/editor/segmentation/__tests__/cutout-task-status.test.tsx
@@ -16,7 +16,7 @@ describe("CutoutTaskStatus", () => {
 		);
 
 		expect(screen.getByText("处理中")).toBeVisible();
-		expect(screen.getByText("12s")).toBeVisible();
+		expect(screen.getByText("12 秒")).toBeVisible();
 		expect(screen.getByText("Tracking object...")).toBeVisible();
 		fireEvent.click(screen.getByRole("button", { name: "取消" }));
 		expect(onCancel).toHaveBeenCalledOnce();

--- a/qcut/apps/web/src/components/editor/segmentation/__tests__/local-person-cutout-panel.test.tsx
+++ b/qcut/apps/web/src/components/editor/segmentation/__tests__/local-person-cutout-panel.test.tsx
@@ -26,10 +26,6 @@ vi.mock("@/stores/ai/segmentation-store", () => ({
 	}),
 }));
 
-vi.mock("../PersonCutoutPreview", () => ({
-	PersonCutoutPreview: () => <div data-testid="person-cutout-preview" />,
-}));
-
 vi.mock("../PersonCutoutSettings", () => ({
 	PersonCutoutSettings: () => <div data-testid="person-cutout-settings" />,
 }));
@@ -70,6 +66,7 @@ function renderPanel({
 describe("LocalPersonCutoutPanel", () => {
 	beforeEach(() => {
 		exportMock.mockReset();
+		segmentationState.updatePersonCutoutSettings.mockReset();
 		segmentationState.setProcessingState.mockReset();
 		segmentationState.setSegmentedVideo.mockReset();
 		useCloudTaskStore.getState().resetTasks();
@@ -88,7 +85,7 @@ describe("LocalPersonCutoutPanel", () => {
 		});
 		const { onMaskError } = renderPanel();
 
-		fireEvent.click(screen.getByRole("button", { name: "生成透明 WebM" }));
+		fireEvent.click(screen.getByRole("button", { name: "开始人物抠像" }));
 		fireEvent.click(await screen.findByRole("button", { name: "取消" }));
 
 		expect(await screen.findByText("已取消")).toBeVisible();
@@ -98,18 +95,40 @@ describe("LocalPersonCutoutPanel", () => {
 	});
 
 	it("shows the terminal error and starts a fresh retry", async () => {
-		exportMock.mockRejectedValue(new Error("WebCodecs encoder unavailable"));
+		exportMock.mockRejectedValue(new Error("本机暂时无法生成透明视频"));
 		const { onMaskError } = renderPanel();
 
-		fireEvent.click(screen.getByRole("button", { name: "生成透明 WebM" }));
+		fireEvent.click(screen.getByRole("button", { name: "开始人物抠像" }));
 
-		expect(
-			await screen.findByText("WebCodecs encoder unavailable")
-		).toBeVisible();
-		expect(onMaskError).toHaveBeenCalledWith("WebCodecs encoder unavailable");
+		expect(await screen.findByText("本机暂时无法生成透明视频")).toBeVisible();
+		expect(onMaskError).toHaveBeenCalledWith("本机暂时无法生成透明视频");
 
 		fireEvent.click(screen.getByRole("button", { name: "重试" }));
 		await waitFor(() => expect(exportMock).toHaveBeenCalledTimes(2));
+	});
+
+	it("uses the selected fine quality without showing a preview player", async () => {
+		exportMock.mockRejectedValue(new Error("测试结束"));
+		renderPanel();
+
+		expect(document.querySelector("video")).toBeNull();
+		expect(
+			screen.getByText("基础处理速度较快，精细效果更佳，但耗时较长")
+		).toBeVisible();
+		fireEvent.click(screen.getByTestId("person-cutout-quality-fine"));
+		expect(segmentationState.updatePersonCutoutSettings).toHaveBeenCalledWith({
+			threshold: 0.5,
+			temporalSmoothing: 0,
+			edgeShift: 0,
+			feather: 0,
+		});
+		fireEvent.click(screen.getByRole("button", { name: "开始人物抠像" }));
+
+		await waitFor(() =>
+			expect(exportMock).toHaveBeenCalledWith(
+				expect.objectContaining({ quality: "fine" })
+			)
+		);
 	});
 
 	it("automatically starts each tracking request only once", async () => {

--- a/qcut/apps/web/src/components/editor/segmentation/__tests__/local-person-cutout-panel.test.tsx
+++ b/qcut/apps/web/src/components/editor/segmentation/__tests__/local-person-cutout-panel.test.tsx
@@ -13,7 +13,7 @@ const segmentationState = vi.hoisted(() => ({
 	elapsedTime: 0,
 	setProcessingState: vi.fn(),
 	setSegmentedVideo: vi.fn(),
-	segmentedVideoUrl: null,
+	segmentedVideoUrl: null as string | null,
 }));
 
 vi.mock("@/lib/segmentation/person-cutout-export", () => ({
@@ -39,18 +39,40 @@ vi.mock("sonner", () => ({
 
 const exportMock = vi.mocked(exportPersonCutoutVideo);
 
+const fineExportResult: Awaited<ReturnType<typeof exportPersonCutoutVideo>> = {
+	blendImplementation: "TEMattingBlendEffectV2-compatible",
+	blob: new Blob(["cutout"], { type: "video/webm" }),
+	codec: "vp9",
+	didModelRouteFallback: false,
+	duration: 2,
+	frameCount: 60,
+	frameRate: 30,
+	hasAudio: false,
+	height: 640,
+	modelRoute: "portrait-gru",
+	nativeMetalCanary: "passed",
+	pipelineId: "qcut-gru-vision-fusion-v1",
+	provider: "qcut-local-person-matting-v1",
+	refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+	requestedModelRoute: "auto",
+	trackingSamples: [],
+	width: 360,
+};
+
 function renderPanel({
 	onMaskError = vi.fn(),
+	onMaskReady,
 	autoStartRequestId,
 }: {
 	onMaskError?: (message: string) => void;
+	onMaskReady?: Parameters<typeof LocalPersonCutoutPanel>[0]["onMaskReady"];
 	autoStartRequestId?: string;
 } = {}) {
 	const sourceFile = new File(["video"], "source.mp4", {
 		type: "video/mp4",
 	});
-	const addMediaItem = vi.fn();
-	render(
+	const addMediaItem = vi.fn().mockResolvedValue("cutout-media-1");
+	const panel = () => (
 		<LocalPersonCutoutPanel
 			projectId="project-1"
 			sourceFile={sourceFile}
@@ -58,9 +80,15 @@ function renderPanel({
 			autoStartRequestId={autoStartRequestId}
 			addMediaItem={addMediaItem}
 			onMaskError={onMaskError}
+			onMaskReady={onMaskReady}
 		/>
 	);
-	return { addMediaItem, onMaskError };
+	const rendered = render(panel());
+	return {
+		addMediaItem,
+		onMaskError,
+		rerenderPanel: () => rendered.rerender(panel()),
+	};
 }
 
 describe("LocalPersonCutoutPanel", () => {
@@ -69,6 +97,7 @@ describe("LocalPersonCutoutPanel", () => {
 		segmentationState.updatePersonCutoutSettings.mockReset();
 		segmentationState.setProcessingState.mockReset();
 		segmentationState.setSegmentedVideo.mockReset();
+		segmentationState.segmentedVideoUrl = null;
 		useCloudTaskStore.getState().resetTasks();
 	});
 
@@ -128,6 +157,74 @@ describe("LocalPersonCutoutPanel", () => {
 			expect(exportMock).toHaveBeenCalledWith(
 				expect.objectContaining({ quality: "fine" })
 			)
+		);
+	});
+
+	it("persists fine-mode execution metadata and attaches the QCut matte", async () => {
+		exportMock.mockResolvedValue(fineExportResult);
+		const onMaskReady = vi.fn(() => true);
+		const { addMediaItem, rerenderPanel } = renderPanel({ onMaskReady });
+
+		fireEvent.click(screen.getByTestId("person-cutout-quality-fine"));
+		fireEvent.click(screen.getByRole("button", { name: "开始并应用" }));
+
+		await waitFor(() => expect(addMediaItem).toHaveBeenCalledOnce());
+		expect(addMediaItem).toHaveBeenCalledWith(
+			"project-1",
+			expect.objectContaining({
+				metadata: expect.objectContaining({
+					blendImplementation: "TEMattingBlendEffectV2-compatible",
+					didModelRouteFallback: false,
+					modelRoute: "portrait-gru",
+					nativeMetalCanary: "passed",
+					pipelineId: "qcut-gru-vision-fusion-v1",
+					provider: "qcut-local-person-matting-v1",
+					quality: "fine",
+					refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+					requestedModelRoute: "auto",
+					source: "qcut-local-person-cutout",
+				}),
+			})
+		);
+		expect(onMaskReady).toHaveBeenCalledWith(
+			expect.objectContaining({
+				source: "qcut-person-matting",
+				sourceMediaId: "cutout-media-1",
+			})
+		);
+		expect(segmentationState.setProcessingState).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				isProcessing: false,
+				statusMessage: "人物蒙版已应用到所选片段",
+			})
+		);
+
+		segmentationState.segmentedVideoUrl = "blob:cutout";
+		rerenderPanel();
+		expect(screen.getByTestId("person-cutout-result")).toHaveTextContent(
+			"人物抠像结果已生成并应用"
+		);
+	});
+
+	it("states that an unattached result was only added to the media library", async () => {
+		exportMock.mockResolvedValue(fineExportResult);
+		const { rerenderPanel } = renderPanel({ onMaskReady: () => false });
+
+		fireEvent.click(screen.getByTestId("person-cutout-quality-fine"));
+		fireEvent.click(screen.getByRole("button", { name: "开始并应用" }));
+		await waitFor(() =>
+			expect(segmentationState.setProcessingState).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					isProcessing: false,
+					statusMessage: "透明人物视频已添加到素材库",
+				})
+			)
+		);
+
+		segmentationState.segmentedVideoUrl = "blob:cutout";
+		rerenderPanel();
+		expect(screen.getByTestId("person-cutout-result")).toHaveTextContent(
+			"人物抠像结果已生成，已添加到素材库"
 		);
 	});
 

--- a/qcut/apps/web/src/components/editor/segmentation/index.tsx
+++ b/qcut/apps/web/src/components/editor/segmentation/index.tsx
@@ -401,7 +401,6 @@ export function SegmentationPanel() {
 
 	return (
 		<div className="h-full flex flex-col gap-4 p-4">
-			{/* Mode Tabs */}
 			<Tabs value={mode} onValueChange={(v) => setMode(v as "image" | "video")}>
 				<TabsList className="grid w-full grid-cols-2">
 					<TabsTrigger value="image" className="flex items-center gap-2">
@@ -428,17 +427,16 @@ export function SegmentationPanel() {
 							className="flex items-center gap-2"
 						>
 							<UserRound className="size-4" />
-							本地人物
+							人物抠像
 						</TabsTrigger>
 						<TabsTrigger value="sam3" className="flex items-center gap-2">
 							<ScanSearch className="size-4" />
-							云端物体
+							物体抠像
 						</TabsTrigger>
 					</TabsList>
 				</Tabs>
 			)}
 
-			{/* Segment Button */}
 			{!isLocalPersonVideo && (
 				<div className="flex-shrink-0">
 					<Button
@@ -456,12 +454,12 @@ export function SegmentationPanel() {
 						{isProcessing || segmentationTaskRunning ? (
 							<>
 								<Loader2 className="w-4 h-4 mr-2 animate-spin" />
-								正在分割...
+								正在抠像...
 							</>
 						) : (
 							<>
 								<Wand2 className="w-4 h-4 mr-2" />
-								分割对象
+								开始物体抠像
 							</>
 						)}
 					</Button>
@@ -504,13 +502,14 @@ export function SegmentationPanel() {
 					sourceUrl={sourceVideoUrl}
 					autoStartRequestId={trackingRequest?.requestId}
 					addMediaItem={addMediaItem}
-					onProgress={({ progress }) =>
+					onProgress={({ progress, source }) =>
 						updateGeneratedMaskTrackingProgress({
 							progress,
-							source: "mediapipe",
+							source,
 						})
 					}
 					onMaskReady={({
+						source,
 						sourceMediaId,
 						trackingSamples,
 						targetElementId,
@@ -519,7 +518,7 @@ export function SegmentationPanel() {
 						attachGeneratedMask({
 							sourceMediaId,
 							type: "person",
-							source: "mediapipe",
+							source,
 							name: "MediaPipe person",
 							trackingSamples,
 							targetElementId,

--- a/qcut/apps/web/src/lib/preview/__tests__/generated-mask-audio-preview.test.ts
+++ b/qcut/apps/web/src/lib/preview/__tests__/generated-mask-audio-preview.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { usesOriginalAudioFallbackForGeneratedMask } from "../generated-mask-audio-preview";
+
+describe("usesOriginalAudioFallbackForGeneratedMask", () => {
+	it("does not start a second media decoder when the generated result is silent", () => {
+		expect(
+			usesOriginalAudioFallbackForGeneratedMask({
+				generatedMaskHasAudio: false,
+				hasDerivedAudio: false,
+				hasGeneratedMaskSource: true,
+			})
+		).toBe(false);
+	});
+
+	it("keeps the original-audio fallback for legacy results without metadata", () => {
+		expect(
+			usesOriginalAudioFallbackForGeneratedMask({
+				generatedMaskHasAudio: undefined,
+				hasDerivedAudio: false,
+				hasGeneratedMaskSource: true,
+			})
+		).toBe(true);
+	});
+
+	it("does not duplicate an active derived-audio path", () => {
+		expect(
+			usesOriginalAudioFallbackForGeneratedMask({
+				generatedMaskHasAudio: true,
+				hasDerivedAudio: true,
+				hasGeneratedMaskSource: true,
+			})
+		).toBe(false);
+	});
+
+	it("does not render an audio fallback without a generated mask", () => {
+		expect(
+			usesOriginalAudioFallbackForGeneratedMask({
+				generatedMaskHasAudio: true,
+				hasDerivedAudio: false,
+				hasGeneratedMaskSource: false,
+			})
+		).toBe(false);
+	});
+});

--- a/qcut/apps/web/src/lib/preview/generated-mask-audio-preview.ts
+++ b/qcut/apps/web/src/lib/preview/generated-mask-audio-preview.ts
@@ -1,0 +1,12 @@
+export function usesOriginalAudioFallbackForGeneratedMask({
+	generatedMaskHasAudio,
+	hasDerivedAudio,
+	hasGeneratedMaskSource,
+}: {
+	generatedMaskHasAudio: boolean | undefined;
+	hasDerivedAudio: boolean;
+	hasGeneratedMaskSource: boolean;
+}): boolean {
+	if (!hasGeneratedMaskSource || hasDerivedAudio) return false;
+	return generatedMaskHasAudio !== false;
+}

--- a/qcut/apps/web/src/lib/segmentation/__tests__/generated-mask-attachment.test.ts
+++ b/qcut/apps/web/src/lib/segmentation/__tests__/generated-mask-attachment.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useSegmentationStore } from "@/stores/ai/segmentation-store";
 import { useMaskEditorStore } from "@/stores/editor/mask-editor-store";
 import { createMediaMask } from "@/lib/video/media-mask-stack";
@@ -11,6 +11,12 @@ import {
 	pauseGeneratedMaskTracking,
 	updateGeneratedMaskTrackingProgress,
 } from "../generated-mask-attachment";
+
+const toastInfo = vi.hoisted(() => vi.fn());
+
+vi.mock("sonner", () => ({
+	toast: { info: toastInfo },
+}));
 
 function mediaElement(overrides: Partial<MediaElement> = {}): MediaElement {
 	return {
@@ -28,6 +34,7 @@ function mediaElement(overrides: Partial<MediaElement> = {}): MediaElement {
 
 describe("generated mask attachment", () => {
 	afterEach(() => {
+		toastInfo.mockReset();
 		useTimelineStore.setState({
 			_tracks: [],
 			tracks: [],
@@ -36,6 +43,20 @@ describe("generated mask attachment", () => {
 		});
 		useSegmentationStore.setState({ trackingRequest: null });
 		useMaskEditorStore.getState().clearSelection();
+	});
+
+	it("explains an unattached result in Chinese", () => {
+		expect(
+			attachGeneratedMask({
+				sourceMediaId: "person-alpha",
+				type: "person",
+				source: "qcut-person-matting",
+				name: "人物抠像",
+			})
+		).toBe(false);
+		expect(toastInfo).toHaveBeenCalledWith(
+			"人物抠像结果已添加到素材库，但尚未选择时间线片段"
+		);
 	});
 
 	it("prepends a generated mask without disturbing the existing stack", () => {
@@ -116,7 +137,10 @@ describe("generated mask attachment", () => {
 		});
 	});
 
-	it("keeps the Jianying GRU result out of geometry edit mode", () => {
+	it.each([
+		"qcut-person-matting",
+		"jianying-gru",
+	] as const)("keeps a %s result out of geometry edit mode", (source) => {
 		const track: TimelineTrack = {
 			id: "track-1",
 			name: "Main Track",
@@ -137,7 +161,7 @@ describe("generated mask attachment", () => {
 			attachGeneratedMask({
 				sourceMediaId: "person-alpha",
 				type: "person",
-				source: "jianying-gru",
+				source,
 				name: "人物抠像",
 			})
 		).toBe(true);

--- a/qcut/apps/web/src/lib/segmentation/__tests__/generated-mask-attachment.test.ts
+++ b/qcut/apps/web/src/lib/segmentation/__tests__/generated-mask-attachment.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { useSegmentationStore } from "@/stores/ai/segmentation-store";
+import { useMaskEditorStore } from "@/stores/editor/mask-editor-store";
 import { createMediaMask } from "@/lib/video/media-mask-stack";
 import { useTimelineStore } from "@/stores/timeline/timeline-store";
 import type { MediaElement, TimelineTrack } from "@/types/timeline";
@@ -34,6 +35,7 @@ describe("generated mask attachment", () => {
 			redoStack: [],
 		});
 		useSegmentationStore.setState({ trackingRequest: null });
+		useMaskEditorStore.getState().clearSelection();
 	});
 
 	it("prepends a generated mask without disturbing the existing stack", () => {
@@ -60,6 +62,8 @@ describe("generated mask attachment", () => {
 			"existing",
 		]);
 		expect(result.masks[0]).toMatchObject({
+			width: 1,
+			height: 1,
 			sourceMediaId: "person-alpha",
 			type: "person",
 			tracking: {
@@ -109,6 +113,37 @@ describe("generated mask attachment", () => {
 				status: "ready",
 				source: "sam3",
 			},
+		});
+	});
+
+	it("keeps the Jianying GRU result out of geometry edit mode", () => {
+		const track: TimelineTrack = {
+			id: "track-1",
+			name: "Main Track",
+			type: "media",
+			isMain: true,
+			elements: [mediaElement()],
+		};
+		useTimelineStore.setState({
+			_tracks: [track],
+			tracks: [track],
+			selectedElements: [{ trackId: "track-1", elementId: "clip-1" }],
+			history: [],
+			redoStack: [],
+		});
+		useMaskEditorStore.getState().setEditing(true);
+
+		expect(
+			attachGeneratedMask({
+				sourceMediaId: "person-alpha",
+				type: "person",
+				source: "jianying-gru",
+				name: "人物抠像",
+			})
+		).toBe(true);
+		expect(useMaskEditorStore.getState()).toMatchObject({
+			selectedElementId: "clip-1",
+			isEditing: false,
 		});
 	});
 

--- a/qcut/apps/web/src/lib/segmentation/__tests__/jianying-person-cutout-client.test.ts
+++ b/qcut/apps/web/src/lib/segmentation/__tests__/jianying-person-cutout-client.test.ts
@@ -2,143 +2,208 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { exportJianyingPersonCutout } from "../jianying-person-cutout-client";
 
 const settings = {
-	threshold: 0.5,
-	temporalSmoothing: 0.65,
-	edgeShift: 0,
-	feather: 2,
+  threshold: 0.5,
+  temporalSmoothing: 0.65,
+  edgeShift: 0,
+  feather: 2,
 };
 
 function installElectronAPI({
-	available = true,
+  available = true,
 }: {
-	available?: boolean;
+  available?: boolean;
 } = {}) {
-	const inspect = vi.fn().mockResolvedValue({
-		available,
-		blendImplementation: "TEMattingBlendEffectV2-native-metal",
-		message: available ? "精细抠像已就绪" : "精细抠像不可用",
-		offlineReady: available,
-		provider: "jianying-gru-local-v1",
-	});
-	const render = vi.fn().mockResolvedValue({
-		blendImplementation: "TEMattingBlendEffectV2-native-metal",
-		provider: "jianying-gru-local-v1",
-		outputPath: "/tmp/person-cutout.webm",
-		width: 360,
-		height: 640,
-		duration: 2,
-		frameRate: 30,
-		frameCount: 60,
-		hasAudio: false,
-		codec: "vp9",
-	});
-	const release = vi.fn().mockResolvedValue(undefined);
-	const cancel = vi.fn().mockResolvedValue(undefined);
-	const unsubscribeProgress = vi.fn();
-	const onProgress = vi.fn().mockReturnValue(unsubscribeProgress);
-	Object.defineProperty(window, "electronAPI", {
-		configurable: true,
-		value: {
-			getPathForFile: vi.fn().mockReturnValue("/tmp/source.mp4"),
-			readFile: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
-			jianyingPersonCutout: {
-				cancel,
-				inspect,
-				onProgress,
-				render,
-				release,
-			},
-		},
-	});
-	return { cancel, inspect, onProgress, render, release, unsubscribeProgress };
+  const inspect = vi.fn().mockResolvedValue({
+    available,
+    blendImplementation: "TEMattingBlendEffectV2-compatible",
+    message: available ? "精细抠像已就绪" : "精细抠像不可用",
+    nativeMetalCanaryEnabled: true,
+    offlineReady: available,
+    pipelineId: "qcut-gru-vision-fusion-v1",
+    provider: "qcut-local-person-matting-v1",
+    refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+  });
+  const renderResult = {
+    blendImplementation: "TEMattingBlendEffectV2-compatible",
+    didModelRouteFallback: false,
+    modelRoute: "portrait-gru",
+    nativeMetalCanary: "passed",
+    pipelineId: "qcut-gru-vision-fusion-v1",
+    provider: "qcut-local-person-matting-v1",
+    refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+    requestedModelRoute: "auto",
+    outputPath: "/tmp/person-cutout.webm",
+    width: 360,
+    height: 640,
+    duration: 2,
+    frameRate: 30,
+    frameCount: 60,
+    hasAudio: false,
+    codec: "vp9",
+  } as const;
+  const render = vi.fn().mockResolvedValue(renderResult);
+  const readFile = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+  const release = vi.fn().mockResolvedValue(undefined);
+  const cancel = vi.fn().mockResolvedValue(undefined);
+  const unsubscribeProgress = vi.fn();
+  const onProgress = vi.fn().mockReturnValue(unsubscribeProgress);
+  Object.defineProperty(window, "electronAPI", {
+    configurable: true,
+    value: {
+      getPathForFile: vi.fn().mockReturnValue("/tmp/source.mp4"),
+      readFile,
+      jianyingPersonCutout: {
+        cancel,
+        inspect,
+        onProgress,
+        render,
+        release,
+      },
+    },
+  });
+  return {
+    cancel,
+    inspect,
+    onProgress,
+    readFile,
+    render,
+    renderResult,
+    release,
+    unsubscribeProgress,
+  };
 }
 
 describe("exportJianyingPersonCutout", () => {
-	afterEach(() => {
-		Reflect.deleteProperty(window, "electronAPI");
-	});
+  afterEach(() => {
+    Reflect.deleteProperty(window, "electronAPI");
+  });
 
-	it("renders through the cached GRU provider and releases its temporary file", async () => {
-		const api = installElectronAPI();
-		const progress = vi.fn();
-		const result = await exportJianyingPersonCutout({
-			file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-			settings,
-			onProgress: progress,
-		});
+  it("renders through the cached GRU provider and releases its temporary file", async () => {
+    const api = installElectronAPI();
+    const progress = vi.fn();
+    const result = await exportJianyingPersonCutout({
+      file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+      settings,
+      onProgress: progress,
+    });
 
-		expect(api.render).toHaveBeenCalledWith({
-			sourcePath: "/tmp/source.mp4",
-			settings,
-			taskId: expect.any(String),
-		});
-		expect(result.blob.type).toBe("video/webm");
-		expect(result.frameCount).toBe(60);
-		expect(result.blendImplementation).toBe(
-			"TEMattingBlendEffectV2-native-metal"
-		);
-		expect(api.release).toHaveBeenCalledWith({
-			outputPath: "/tmp/person-cutout.webm",
-		});
-		expect(progress).toHaveBeenLastCalledWith({
-			progress: 100,
-			status: "人物抠像已完成",
-		});
-		expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
-	});
+    expect(api.render).toHaveBeenCalledWith({
+      sourcePath: "/tmp/source.mp4",
+      settings,
+      taskId: expect.any(String),
+    });
+    expect(result.blob.type).toBe("video/webm");
+    expect(result.frameCount).toBe(60);
+    expect(result.blendImplementation).toBe(
+      "TEMattingBlendEffectV2-compatible",
+    );
+    expect(result).toMatchObject({
+      didModelRouteFallback: false,
+      modelRoute: "portrait-gru",
+      nativeMetalCanary: "passed",
+      pipelineId: "qcut-gru-vision-fusion-v1",
+      provider: "qcut-local-person-matting-v1",
+      refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+      requestedModelRoute: "auto",
+    });
+    expect(api.release).toHaveBeenCalledWith({
+      outputPath: "/tmp/person-cutout.webm",
+    });
+    expect(progress).toHaveBeenLastCalledWith({
+      progress: 100,
+      status: "人物抠像已完成",
+    });
+    expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
+  });
 
-	it("prefers the project-owned source path for restored media", async () => {
-		const api = installElectronAPI();
-		await exportJianyingPersonCutout({
-			file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-			sourcePath: "/project/media/source.mp4",
-			settings,
-		});
+  it("prefers the project-owned source path for restored media", async () => {
+    const api = installElectronAPI();
+    await exportJianyingPersonCutout({
+      file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+      sourcePath: "/project/media/source.mp4",
+      settings,
+    });
 
-		expect(api.render).toHaveBeenCalledWith({
-			sourcePath: "/project/media/source.mp4",
-			settings,
-			taskId: expect.any(String),
-		});
-	});
+    expect(api.render).toHaveBeenCalledWith({
+      sourcePath: "/project/media/source.mp4",
+      settings,
+      taskId: expect.any(String),
+    });
+  });
 
-	it("reports the private runtime status before rendering", async () => {
-		const api = installElectronAPI({ available: false });
+  it("releases the rendered output when cancellation arrives after render", async () => {
+    const controller = new AbortController();
+    const api = installElectronAPI();
+    api.render.mockImplementation(async () => {
+      controller.abort();
+      return api.renderResult;
+    });
 
-		await expect(
-			exportJianyingPersonCutout({
-				file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-				settings,
-			})
-		).rejects.toThrow("精细抠像不可用");
-		expect(api.render).not.toHaveBeenCalled();
-		expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
-	});
+    await expect(
+      exportJianyingPersonCutout({
+        file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+        settings,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(api.release).toHaveBeenCalledWith({
+      outputPath: api.renderResult.outputPath,
+    });
+    expect(api.readFile).not.toHaveBeenCalled();
+  });
 
-	it("cancels the native pipeline when the caller aborts", async () => {
-		const api = installElectronAPI();
-		const controller = new AbortController();
-		api.render.mockImplementation(
-			() =>
-				new Promise((resolve) => {
-					controller.signal.addEventListener(
-						"abort",
-						() => resolve(undefined),
-						{
-							once: true,
-						}
-					);
-				})
-		);
-		const pending = exportJianyingPersonCutout({
-			file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-			settings,
-			signal: controller.signal,
-		});
-		await Promise.resolve();
-		controller.abort();
-		await expect(pending).rejects.toMatchObject({ name: "AbortError" });
-		expect(api.cancel).toHaveBeenCalledWith({ taskId: expect.any(String) });
-		expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
-	});
+  it("releases the rendered output when reading it fails", async () => {
+    const api = installElectronAPI();
+    api.readFile.mockRejectedValueOnce(new Error("read failed"));
+
+    await expect(
+      exportJianyingPersonCutout({
+        file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+        settings,
+      }),
+    ).rejects.toThrow("read failed");
+    expect(api.release).toHaveBeenCalledWith({
+      outputPath: api.renderResult.outputPath,
+    });
+  });
+
+  it("reports the private runtime status before rendering", async () => {
+    const api = installElectronAPI({ available: false });
+
+    await expect(
+      exportJianyingPersonCutout({
+        file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+        settings,
+      }),
+    ).rejects.toThrow("精细抠像不可用");
+    expect(api.render).not.toHaveBeenCalled();
+    expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
+  });
+
+  it("cancels the native pipeline when the caller aborts", async () => {
+    const api = installElectronAPI();
+    const controller = new AbortController();
+    api.render.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          controller.signal.addEventListener(
+            "abort",
+            () => resolve(undefined),
+            {
+              once: true,
+            },
+          );
+        }),
+    );
+    const pending = exportJianyingPersonCutout({
+      file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+      settings,
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(api.cancel).toHaveBeenCalledWith({ taskId: expect.any(String) });
+    expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
+  });
 });

--- a/qcut/apps/web/src/lib/segmentation/__tests__/jianying-person-cutout-client.test.ts
+++ b/qcut/apps/web/src/lib/segmentation/__tests__/jianying-person-cutout-client.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { exportJianyingPersonCutout } from "../jianying-person-cutout-client";
+
+const settings = {
+	threshold: 0.5,
+	temporalSmoothing: 0.65,
+	edgeShift: 0,
+	feather: 2,
+};
+
+function installElectronAPI({
+	available = true,
+}: {
+	available?: boolean;
+} = {}) {
+	const inspect = vi.fn().mockResolvedValue({
+		available,
+		blendImplementation: "TEMattingBlendEffectV2-native-metal",
+		message: available ? "精细抠像已就绪" : "精细抠像不可用",
+		offlineReady: available,
+		provider: "jianying-gru-local-v1",
+	});
+	const render = vi.fn().mockResolvedValue({
+		blendImplementation: "TEMattingBlendEffectV2-native-metal",
+		provider: "jianying-gru-local-v1",
+		outputPath: "/tmp/person-cutout.webm",
+		width: 360,
+		height: 640,
+		duration: 2,
+		frameRate: 30,
+		frameCount: 60,
+		hasAudio: false,
+		codec: "vp9",
+	});
+	const release = vi.fn().mockResolvedValue(undefined);
+	const cancel = vi.fn().mockResolvedValue(undefined);
+	const unsubscribeProgress = vi.fn();
+	const onProgress = vi.fn().mockReturnValue(unsubscribeProgress);
+	Object.defineProperty(window, "electronAPI", {
+		configurable: true,
+		value: {
+			getPathForFile: vi.fn().mockReturnValue("/tmp/source.mp4"),
+			readFile: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+			jianyingPersonCutout: {
+				cancel,
+				inspect,
+				onProgress,
+				render,
+				release,
+			},
+		},
+	});
+	return { cancel, inspect, onProgress, render, release, unsubscribeProgress };
+}
+
+describe("exportJianyingPersonCutout", () => {
+	afterEach(() => {
+		Reflect.deleteProperty(window, "electronAPI");
+	});
+
+	it("renders through the cached GRU provider and releases its temporary file", async () => {
+		const api = installElectronAPI();
+		const progress = vi.fn();
+		const result = await exportJianyingPersonCutout({
+			file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+			settings,
+			onProgress: progress,
+		});
+
+		expect(api.render).toHaveBeenCalledWith({
+			sourcePath: "/tmp/source.mp4",
+			settings,
+			taskId: expect.any(String),
+		});
+		expect(result.blob.type).toBe("video/webm");
+		expect(result.frameCount).toBe(60);
+		expect(result.blendImplementation).toBe(
+			"TEMattingBlendEffectV2-native-metal"
+		);
+		expect(api.release).toHaveBeenCalledWith({
+			outputPath: "/tmp/person-cutout.webm",
+		});
+		expect(progress).toHaveBeenLastCalledWith({
+			progress: 100,
+			status: "人物抠像已完成",
+		});
+		expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
+	});
+
+	it("prefers the project-owned source path for restored media", async () => {
+		const api = installElectronAPI();
+		await exportJianyingPersonCutout({
+			file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+			sourcePath: "/project/media/source.mp4",
+			settings,
+		});
+
+		expect(api.render).toHaveBeenCalledWith({
+			sourcePath: "/project/media/source.mp4",
+			settings,
+			taskId: expect.any(String),
+		});
+	});
+
+	it("reports the private runtime status before rendering", async () => {
+		const api = installElectronAPI({ available: false });
+
+		await expect(
+			exportJianyingPersonCutout({
+				file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+				settings,
+			})
+		).rejects.toThrow("精细抠像不可用");
+		expect(api.render).not.toHaveBeenCalled();
+		expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
+	});
+
+	it("cancels the native pipeline when the caller aborts", async () => {
+		const api = installElectronAPI();
+		const controller = new AbortController();
+		api.render.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					controller.signal.addEventListener(
+						"abort",
+						() => resolve(undefined),
+						{
+							once: true,
+						}
+					);
+				})
+		);
+		const pending = exportJianyingPersonCutout({
+			file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+			settings,
+			signal: controller.signal,
+		});
+		await Promise.resolve();
+		controller.abort();
+		await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+		expect(api.cancel).toHaveBeenCalledWith({ taskId: expect.any(String) });
+		expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
+	});
+});

--- a/qcut/apps/web/src/lib/segmentation/__tests__/jianying-person-cutout-client.test.ts
+++ b/qcut/apps/web/src/lib/segmentation/__tests__/jianying-person-cutout-client.test.ts
@@ -2,208 +2,208 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { exportJianyingPersonCutout } from "../jianying-person-cutout-client";
 
 const settings = {
-  threshold: 0.5,
-  temporalSmoothing: 0.65,
-  edgeShift: 0,
-  feather: 2,
+	threshold: 0.5,
+	temporalSmoothing: 0.65,
+	edgeShift: 0,
+	feather: 2,
 };
 
 function installElectronAPI({
-  available = true,
+	available = true,
 }: {
-  available?: boolean;
+	available?: boolean;
 } = {}) {
-  const inspect = vi.fn().mockResolvedValue({
-    available,
-    blendImplementation: "TEMattingBlendEffectV2-compatible",
-    message: available ? "精细抠像已就绪" : "精细抠像不可用",
-    nativeMetalCanaryEnabled: true,
-    offlineReady: available,
-    pipelineId: "qcut-gru-vision-fusion-v1",
-    provider: "qcut-local-person-matting-v1",
-    refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
-  });
-  const renderResult = {
-    blendImplementation: "TEMattingBlendEffectV2-compatible",
-    didModelRouteFallback: false,
-    modelRoute: "portrait-gru",
-    nativeMetalCanary: "passed",
-    pipelineId: "qcut-gru-vision-fusion-v1",
-    provider: "qcut-local-person-matting-v1",
-    refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
-    requestedModelRoute: "auto",
-    outputPath: "/tmp/person-cutout.webm",
-    width: 360,
-    height: 640,
-    duration: 2,
-    frameRate: 30,
-    frameCount: 60,
-    hasAudio: false,
-    codec: "vp9",
-  } as const;
-  const render = vi.fn().mockResolvedValue(renderResult);
-  const readFile = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
-  const release = vi.fn().mockResolvedValue(undefined);
-  const cancel = vi.fn().mockResolvedValue(undefined);
-  const unsubscribeProgress = vi.fn();
-  const onProgress = vi.fn().mockReturnValue(unsubscribeProgress);
-  Object.defineProperty(window, "electronAPI", {
-    configurable: true,
-    value: {
-      getPathForFile: vi.fn().mockReturnValue("/tmp/source.mp4"),
-      readFile,
-      jianyingPersonCutout: {
-        cancel,
-        inspect,
-        onProgress,
-        render,
-        release,
-      },
-    },
-  });
-  return {
-    cancel,
-    inspect,
-    onProgress,
-    readFile,
-    render,
-    renderResult,
-    release,
-    unsubscribeProgress,
-  };
+	const inspect = vi.fn().mockResolvedValue({
+		available,
+		blendImplementation: "TEMattingBlendEffectV2-compatible",
+		message: available ? "精细抠像已就绪" : "精细抠像不可用",
+		nativeMetalCanaryEnabled: true,
+		offlineReady: available,
+		pipelineId: "qcut-gru-vision-fusion-v1",
+		provider: "qcut-local-person-matting-v1",
+		refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+	});
+	const renderResult = {
+		blendImplementation: "TEMattingBlendEffectV2-compatible",
+		didModelRouteFallback: false,
+		modelRoute: "portrait-gru",
+		nativeMetalCanary: "passed",
+		pipelineId: "qcut-gru-vision-fusion-v1",
+		provider: "qcut-local-person-matting-v1",
+		refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+		requestedModelRoute: "auto",
+		outputPath: "/tmp/person-cutout.webm",
+		width: 360,
+		height: 640,
+		duration: 2,
+		frameRate: 30,
+		frameCount: 60,
+		hasAudio: false,
+		codec: "vp9",
+	} as const;
+	const render = vi.fn().mockResolvedValue(renderResult);
+	const readFile = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+	const release = vi.fn().mockResolvedValue(undefined);
+	const cancel = vi.fn().mockResolvedValue(undefined);
+	const unsubscribeProgress = vi.fn();
+	const onProgress = vi.fn().mockReturnValue(unsubscribeProgress);
+	Object.defineProperty(window, "electronAPI", {
+		configurable: true,
+		value: {
+			getPathForFile: vi.fn().mockReturnValue("/tmp/source.mp4"),
+			readFile,
+			jianyingPersonCutout: {
+				cancel,
+				inspect,
+				onProgress,
+				render,
+				release,
+			},
+		},
+	});
+	return {
+		cancel,
+		inspect,
+		onProgress,
+		readFile,
+		render,
+		renderResult,
+		release,
+		unsubscribeProgress,
+	};
 }
 
 describe("exportJianyingPersonCutout", () => {
-  afterEach(() => {
-    Reflect.deleteProperty(window, "electronAPI");
-  });
+	afterEach(() => {
+		Reflect.deleteProperty(window, "electronAPI");
+	});
 
-  it("renders through the cached GRU provider and releases its temporary file", async () => {
-    const api = installElectronAPI();
-    const progress = vi.fn();
-    const result = await exportJianyingPersonCutout({
-      file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-      settings,
-      onProgress: progress,
-    });
+	it("renders through the cached GRU provider and releases its temporary file", async () => {
+		const api = installElectronAPI();
+		const progress = vi.fn();
+		const result = await exportJianyingPersonCutout({
+			file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+			settings,
+			onProgress: progress,
+		});
 
-    expect(api.render).toHaveBeenCalledWith({
-      sourcePath: "/tmp/source.mp4",
-      settings,
-      taskId: expect.any(String),
-    });
-    expect(result.blob.type).toBe("video/webm");
-    expect(result.frameCount).toBe(60);
-    expect(result.blendImplementation).toBe(
-      "TEMattingBlendEffectV2-compatible",
-    );
-    expect(result).toMatchObject({
-      didModelRouteFallback: false,
-      modelRoute: "portrait-gru",
-      nativeMetalCanary: "passed",
-      pipelineId: "qcut-gru-vision-fusion-v1",
-      provider: "qcut-local-person-matting-v1",
-      refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
-      requestedModelRoute: "auto",
-    });
-    expect(api.release).toHaveBeenCalledWith({
-      outputPath: "/tmp/person-cutout.webm",
-    });
-    expect(progress).toHaveBeenLastCalledWith({
-      progress: 100,
-      status: "人物抠像已完成",
-    });
-    expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
-  });
+		expect(api.render).toHaveBeenCalledWith({
+			sourcePath: "/tmp/source.mp4",
+			settings,
+			taskId: expect.any(String),
+		});
+		expect(result.blob.type).toBe("video/webm");
+		expect(result.frameCount).toBe(60);
+		expect(result.blendImplementation).toBe(
+			"TEMattingBlendEffectV2-compatible"
+		);
+		expect(result).toMatchObject({
+			didModelRouteFallback: false,
+			modelRoute: "portrait-gru",
+			nativeMetalCanary: "passed",
+			pipelineId: "qcut-gru-vision-fusion-v1",
+			provider: "qcut-local-person-matting-v1",
+			refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+			requestedModelRoute: "auto",
+		});
+		expect(api.release).toHaveBeenCalledWith({
+			outputPath: "/tmp/person-cutout.webm",
+		});
+		expect(progress).toHaveBeenLastCalledWith({
+			progress: 100,
+			status: "人物抠像已完成",
+		});
+		expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
+	});
 
-  it("prefers the project-owned source path for restored media", async () => {
-    const api = installElectronAPI();
-    await exportJianyingPersonCutout({
-      file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-      sourcePath: "/project/media/source.mp4",
-      settings,
-    });
+	it("prefers the project-owned source path for restored media", async () => {
+		const api = installElectronAPI();
+		await exportJianyingPersonCutout({
+			file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+			sourcePath: "/project/media/source.mp4",
+			settings,
+		});
 
-    expect(api.render).toHaveBeenCalledWith({
-      sourcePath: "/project/media/source.mp4",
-      settings,
-      taskId: expect.any(String),
-    });
-  });
+		expect(api.render).toHaveBeenCalledWith({
+			sourcePath: "/project/media/source.mp4",
+			settings,
+			taskId: expect.any(String),
+		});
+	});
 
-  it("releases the rendered output when cancellation arrives after render", async () => {
-    const controller = new AbortController();
-    const api = installElectronAPI();
-    api.render.mockImplementation(async () => {
-      controller.abort();
-      return api.renderResult;
-    });
+	it("releases the rendered output when cancellation arrives after render", async () => {
+		const controller = new AbortController();
+		const api = installElectronAPI();
+		api.render.mockImplementation(async () => {
+			controller.abort();
+			return api.renderResult;
+		});
 
-    await expect(
-      exportJianyingPersonCutout({
-        file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-        settings,
-        signal: controller.signal,
-      }),
-    ).rejects.toMatchObject({ name: "AbortError" });
-    expect(api.release).toHaveBeenCalledWith({
-      outputPath: api.renderResult.outputPath,
-    });
-    expect(api.readFile).not.toHaveBeenCalled();
-  });
+		await expect(
+			exportJianyingPersonCutout({
+				file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+				settings,
+				signal: controller.signal,
+			})
+		).rejects.toMatchObject({ name: "AbortError" });
+		expect(api.release).toHaveBeenCalledWith({
+			outputPath: api.renderResult.outputPath,
+		});
+		expect(api.readFile).not.toHaveBeenCalled();
+	});
 
-  it("releases the rendered output when reading it fails", async () => {
-    const api = installElectronAPI();
-    api.readFile.mockRejectedValueOnce(new Error("read failed"));
+	it("releases the rendered output when reading it fails", async () => {
+		const api = installElectronAPI();
+		api.readFile.mockRejectedValueOnce(new Error("read failed"));
 
-    await expect(
-      exportJianyingPersonCutout({
-        file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-        settings,
-      }),
-    ).rejects.toThrow("read failed");
-    expect(api.release).toHaveBeenCalledWith({
-      outputPath: api.renderResult.outputPath,
-    });
-  });
+		await expect(
+			exportJianyingPersonCutout({
+				file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+				settings,
+			})
+		).rejects.toThrow("read failed");
+		expect(api.release).toHaveBeenCalledWith({
+			outputPath: api.renderResult.outputPath,
+		});
+	});
 
-  it("reports the private runtime status before rendering", async () => {
-    const api = installElectronAPI({ available: false });
+	it("reports the private runtime status before rendering", async () => {
+		const api = installElectronAPI({ available: false });
 
-    await expect(
-      exportJianyingPersonCutout({
-        file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-        settings,
-      }),
-    ).rejects.toThrow("精细抠像不可用");
-    expect(api.render).not.toHaveBeenCalled();
-    expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
-  });
+		await expect(
+			exportJianyingPersonCutout({
+				file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+				settings,
+			})
+		).rejects.toThrow("精细抠像不可用");
+		expect(api.render).not.toHaveBeenCalled();
+		expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
+	});
 
-  it("cancels the native pipeline when the caller aborts", async () => {
-    const api = installElectronAPI();
-    const controller = new AbortController();
-    api.render.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          controller.signal.addEventListener(
-            "abort",
-            () => resolve(undefined),
-            {
-              once: true,
-            },
-          );
-        }),
-    );
-    const pending = exportJianyingPersonCutout({
-      file: new File(["video"], "source.mp4", { type: "video/mp4" }),
-      settings,
-      signal: controller.signal,
-    });
-    await Promise.resolve();
-    controller.abort();
-    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
-    expect(api.cancel).toHaveBeenCalledWith({ taskId: expect.any(String) });
-    expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
-  });
+	it("cancels the native pipeline when the caller aborts", async () => {
+		const api = installElectronAPI();
+		const controller = new AbortController();
+		api.render.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					controller.signal.addEventListener(
+						"abort",
+						() => resolve(undefined),
+						{
+							once: true,
+						}
+					);
+				})
+		);
+		const pending = exportJianyingPersonCutout({
+			file: new File(["video"], "source.mp4", { type: "video/mp4" }),
+			settings,
+			signal: controller.signal,
+		});
+		await Promise.resolve();
+		controller.abort();
+		await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+		expect(api.cancel).toHaveBeenCalledWith({ taskId: expect.any(String) });
+		expect(api.unsubscribeProgress).toHaveBeenCalledOnce();
+	});
 });

--- a/qcut/apps/web/src/lib/segmentation/generated-mask-attachment.ts
+++ b/qcut/apps/web/src/lib/segmentation/generated-mask-attachment.ts
@@ -19,6 +19,7 @@ import { resolveMediaMasks } from "@/lib/video/video-properties";
 import { getMediaTimelineDuration } from "@/lib/video/video-timing";
 
 type TrackingRequest = SegmentationState["trackingRequest"];
+export type GeneratedMaskSource = "mediapipe" | "jianying-gru" | "sam3";
 
 interface TimelineMediaTarget {
 	trackId: string;
@@ -30,7 +31,7 @@ interface BuildGeneratedMaskStackOptions {
 	existingMasks: MediaMask[];
 	sourceMediaId: string;
 	type: "person" | "object";
-	source: "mediapipe" | "sam3";
+	source: GeneratedMaskSource;
 	name: string;
 	trackingSamples?: MediaMaskTrackingSample[];
 	trackingRequest?: TrackingRequest;
@@ -66,8 +67,11 @@ export function buildGeneratedMaskStack({
 		trackingRequest?.anchorFrame ??
 		Math.max(0, Math.round((currentTime - element.startTime) * fps));
 	let mask: MediaMask = {
-		...(existingMask ??
-			createMediaMask({ id: selectedMaskId, type, index: 0, name })),
+		...(existingMask ?? {
+			...createMediaMask({ id: selectedMaskId, type, index: 0, name }),
+			width: 1,
+			height: 1,
+		}),
 		sourceMediaId,
 		tracking: {
 			direction,
@@ -142,7 +146,7 @@ export function attachGeneratedMask({
 }: {
 	sourceMediaId: string;
 	type: "person" | "object";
-	source: "mediapipe" | "sam3";
+	source: GeneratedMaskSource;
 	name: string;
 	trackingSamples?: MediaMaskTrackingSample[];
 	targetElementId?: string;
@@ -190,7 +194,7 @@ export function attachGeneratedMask({
 	useMaskEditorStore
 		.getState()
 		.selectMask(target.element.id, result.selectedMaskId);
-	useMaskEditorStore.getState().setEditing(true);
+	useMaskEditorStore.getState().setEditing(source !== "jianying-gru");
 	if (matchingRequest) segmentationState.clearTrackingRequest();
 	return true;
 }
@@ -304,7 +308,7 @@ export function updateGeneratedMaskTrackingProgress({
 	source,
 }: {
 	progress: number;
-	source?: "mediapipe" | "sam3";
+	source?: GeneratedMaskSource;
 }) {
 	const segmentationState = useSegmentationStore.getState();
 	const request = segmentationState.trackingRequest;

--- a/qcut/apps/web/src/lib/segmentation/generated-mask-attachment.ts
+++ b/qcut/apps/web/src/lib/segmentation/generated-mask-attachment.ts
@@ -174,7 +174,11 @@ export function attachGeneratedMask({
 		elementId: targetElementId ?? matchingRequest?.elementId,
 	});
 	if (!target) {
-		toast.info("人物抠像结果已添加到素材库，但尚未选择时间线片段");
+		toast.info(
+			type === "person"
+				? "人物抠像结果已添加到素材库，但尚未选择时间线片段"
+				: "分割结果已添加到素材库，但尚未选择时间线片段"
+		);
 		return false;
 	}
 

--- a/qcut/apps/web/src/lib/segmentation/generated-mask-attachment.ts
+++ b/qcut/apps/web/src/lib/segmentation/generated-mask-attachment.ts
@@ -19,7 +19,11 @@ import { resolveMediaMasks } from "@/lib/video/video-properties";
 import { getMediaTimelineDuration } from "@/lib/video/video-timing";
 
 type TrackingRequest = SegmentationState["trackingRequest"];
-export type GeneratedMaskSource = "mediapipe" | "jianying-gru" | "sam3";
+export type GeneratedMaskSource =
+	| "mediapipe"
+	| "qcut-person-matting"
+	| "jianying-gru"
+	| "sam3";
 
 interface TimelineMediaTarget {
 	trackId: string;
@@ -170,7 +174,7 @@ export function attachGeneratedMask({
 		elementId: targetElementId ?? matchingRequest?.elementId,
 	});
 	if (!target) {
-		toast.info("Mask media was added, but no timeline clip is selected");
+		toast.info("人物抠像结果已添加到素材库，但尚未选择时间线片段");
 		return false;
 	}
 
@@ -194,7 +198,9 @@ export function attachGeneratedMask({
 	useMaskEditorStore
 		.getState()
 		.selectMask(target.element.id, result.selectedMaskId);
-	useMaskEditorStore.getState().setEditing(source !== "jianying-gru");
+	const usesPrecomputedPersonMatting =
+		source === "qcut-person-matting" || source === "jianying-gru";
+	useMaskEditorStore.getState().setEditing(!usesPrecomputedPersonMatting);
 	if (matchingRequest) segmentationState.clearTrackingRequest();
 	return true;
 }

--- a/qcut/apps/web/src/lib/segmentation/jianying-person-cutout-client.ts
+++ b/qcut/apps/web/src/lib/segmentation/jianying-person-cutout-client.ts
@@ -1,86 +1,111 @@
 import type { MediaMaskTrackingSample } from "@/lib/video/media-mask-tracking";
 import type { PersonCutoutMaskOptions } from "./person-cutout-mask";
-import type { TemattingBlendImplementation } from "@/types/electron/api-jianying-person-cutout";
+import type {
+  JianyingPersonCutoutRenderResult,
+  TemattingOutputBlendImplementation,
+} from "@/types/electron/api-jianying-person-cutout";
 
-export interface JianyingPersonCutoutClientResult {
-	blendImplementation: TemattingBlendImplementation;
-	blob: Blob;
-	width: number;
-	height: number;
-	duration: number;
-	frameRate: number;
-	frameCount: number;
-	codec: "vp9";
-	hasAudio: boolean;
-	trackingSamples: MediaMaskTrackingSample[];
+export type PersonCutoutExecutionMetadata = Pick<
+  JianyingPersonCutoutRenderResult,
+  | "didModelRouteFallback"
+  | "modelRoute"
+  | "pipelineId"
+  | "provider"
+  | "refinementProvider"
+  | "requestedModelRoute"
+>;
+
+export interface JianyingPersonCutoutClientResult extends PersonCutoutExecutionMetadata {
+  blendImplementation: TemattingOutputBlendImplementation;
+  blob: Blob;
+  width: number;
+  height: number;
+  duration: number;
+  frameRate: number;
+  frameCount: number;
+  codec: "vp9";
+  hasAudio: boolean;
+  nativeMetalCanary?: JianyingPersonCutoutRenderResult["nativeMetalCanary"];
+  trackingSamples: MediaMaskTrackingSample[];
 }
 
 function throwIfAborted({ signal }: { signal?: AbortSignal }) {
-	if (signal?.aborted) throw new DOMException("人物抠像已取消", "AbortError");
+  if (signal?.aborted) throw new DOMException("人物抠像已取消", "AbortError");
 }
 
 export async function exportJianyingPersonCutout({
-	file,
-	sourcePath: explicitSourcePath,
-	settings,
-	onProgress,
-	signal,
+  file,
+  sourcePath: explicitSourcePath,
+  settings,
+  onProgress,
+  signal,
 }: {
-	file: File;
-	sourcePath?: string;
-	settings: PersonCutoutMaskOptions;
-	onProgress?: (progress: { progress: number; status: string }) => void;
-	signal?: AbortSignal;
+  file: File;
+  sourcePath?: string;
+  settings: PersonCutoutMaskOptions;
+  onProgress?: (progress: { progress: number; status: string }) => void;
+  signal?: AbortSignal;
 }): Promise<JianyingPersonCutoutClientResult> {
-	throwIfAborted({ signal });
-	const api = window.electronAPI?.jianyingPersonCutout;
-	const readFile = window.electronAPI?.readFile;
-	const getPathForFile = window.electronAPI?.getPathForFile;
-	if (!api || !readFile || !getPathForFile) {
-		throw new Error("精细抠像需要 QCut 桌面版");
-	}
-	const sourcePath = explicitSourcePath ?? getPathForFile(file);
-	if (!sourcePath) throw new Error("无法读取所选视频");
-	const taskId = crypto.randomUUID();
-	const unsubscribeProgress = api.onProgress((update) => {
-		if (update.taskId !== taskId) return;
-		onProgress?.({ progress: update.progress, status: update.status });
-	});
-	const cancel = () => {
-		void api.cancel({ taskId });
-	};
-	signal?.addEventListener("abort", cancel, { once: true });
-	onProgress?.({ progress: 3, status: "正在加载精细抠像..." });
-	try {
-		const runtime = await api.inspect();
-		if (!runtime.available) throw new Error(runtime.message);
-		throwIfAborted({ signal });
-		onProgress?.({ progress: 8, status: "正在精细抠除背景..." });
-		const result = await api.render({ sourcePath, settings, taskId });
-		throwIfAborted({ signal });
-		onProgress?.({ progress: 94, status: "正在准备抠像结果..." });
-		const bytes = await readFile(result.outputPath);
-		if (!bytes) throw new Error("无法读取精细抠像结果");
-		throwIfAborted({ signal });
-		onProgress?.({ progress: 100, status: "人物抠像已完成" });
-		try {
-			return {
-				blendImplementation: result.blendImplementation,
-				blob: new Blob([new Uint8Array(bytes)], { type: "video/webm" }),
-				width: result.width,
-				height: result.height,
-				duration: result.duration,
-				frameRate: result.frameRate,
-				frameCount: result.frameCount,
-				codec: result.codec,
-				hasAudio: result.hasAudio,
-				trackingSamples: [],
-			};
-		} finally {
-			await api.release({ outputPath: result.outputPath });
-		}
-	} finally {
-		signal?.removeEventListener("abort", cancel);
-		unsubscribeProgress();
-	}
+  throwIfAborted({ signal });
+  const api = window.electronAPI?.jianyingPersonCutout;
+  const readFile = window.electronAPI?.readFile;
+  const getPathForFile = window.electronAPI?.getPathForFile;
+  if (!api || !readFile || !getPathForFile) {
+    throw new Error("精细抠像需要 QCut 桌面版");
+  }
+  const sourcePath = explicitSourcePath ?? getPathForFile(file);
+  if (!sourcePath) throw new Error("无法读取所选视频");
+  const taskId = crypto.randomUUID();
+  const unsubscribeProgress = api.onProgress((update) => {
+    if (update.taskId !== taskId) return;
+    onProgress?.({ progress: update.progress, status: update.status });
+  });
+  const cancel = () => {
+    void api.cancel({ taskId });
+  };
+  signal?.addEventListener("abort", cancel, { once: true });
+  onProgress?.({ progress: 3, status: "正在加载精细抠像..." });
+  try {
+    const runtime = await api.inspect();
+    if (!runtime.available) throw new Error(runtime.message);
+    throwIfAborted({ signal });
+    onProgress?.({ progress: 8, status: "正在精细抠除背景..." });
+    const result = await api.render({ sourcePath, settings, taskId });
+    if (!result) {
+      throwIfAborted({ signal });
+      throw new Error("人物抠像未返回结果");
+    }
+    try {
+      throwIfAborted({ signal });
+      onProgress?.({ progress: 94, status: "正在准备抠像结果..." });
+      const bytes = await readFile(result.outputPath);
+      if (!bytes) throw new Error("无法读取精细抠像结果");
+      throwIfAborted({ signal });
+      onProgress?.({ progress: 100, status: "人物抠像已完成" });
+      return {
+        blendImplementation: result.blendImplementation,
+        didModelRouteFallback: result.didModelRouteFallback,
+        blob: new Blob([new Uint8Array(bytes)], { type: "video/webm" }),
+        width: result.width,
+        height: result.height,
+        duration: result.duration,
+        frameRate: result.frameRate,
+        frameCount: result.frameCount,
+        codec: result.codec,
+        hasAudio: result.hasAudio,
+        modelRoute: result.modelRoute,
+        nativeMetalCanary: result.nativeMetalCanary,
+        pipelineId: result.pipelineId,
+        provider: result.provider,
+        refinementProvider: result.refinementProvider,
+        requestedModelRoute: result.requestedModelRoute,
+        trackingSamples: [],
+      };
+    } finally {
+      await api.release({ outputPath: result.outputPath });
+    }
+  } finally {
+    signal?.removeEventListener("abort", cancel);
+    unsubscribeProgress();
+  }
 }

--- a/qcut/apps/web/src/lib/segmentation/jianying-person-cutout-client.ts
+++ b/qcut/apps/web/src/lib/segmentation/jianying-person-cutout-client.ts
@@ -1,111 +1,112 @@
 import type { MediaMaskTrackingSample } from "@/lib/video/media-mask-tracking";
 import type { PersonCutoutMaskOptions } from "./person-cutout-mask";
 import type {
-  JianyingPersonCutoutRenderResult,
-  TemattingOutputBlendImplementation,
+	JianyingPersonCutoutRenderResult,
+	TemattingOutputBlendImplementation,
 } from "@/types/electron/api-jianying-person-cutout";
 
 export type PersonCutoutExecutionMetadata = Pick<
-  JianyingPersonCutoutRenderResult,
-  | "didModelRouteFallback"
-  | "modelRoute"
-  | "pipelineId"
-  | "provider"
-  | "refinementProvider"
-  | "requestedModelRoute"
+	JianyingPersonCutoutRenderResult,
+	| "didModelRouteFallback"
+	| "modelRoute"
+	| "pipelineId"
+	| "provider"
+	| "refinementProvider"
+	| "requestedModelRoute"
 >;
 
-export interface JianyingPersonCutoutClientResult extends PersonCutoutExecutionMetadata {
-  blendImplementation: TemattingOutputBlendImplementation;
-  blob: Blob;
-  width: number;
-  height: number;
-  duration: number;
-  frameRate: number;
-  frameCount: number;
-  codec: "vp9";
-  hasAudio: boolean;
-  nativeMetalCanary?: JianyingPersonCutoutRenderResult["nativeMetalCanary"];
-  trackingSamples: MediaMaskTrackingSample[];
+export interface JianyingPersonCutoutClientResult
+	extends PersonCutoutExecutionMetadata {
+	blendImplementation: TemattingOutputBlendImplementation;
+	blob: Blob;
+	width: number;
+	height: number;
+	duration: number;
+	frameRate: number;
+	frameCount: number;
+	codec: "vp9";
+	hasAudio: boolean;
+	nativeMetalCanary?: JianyingPersonCutoutRenderResult["nativeMetalCanary"];
+	trackingSamples: MediaMaskTrackingSample[];
 }
 
 function throwIfAborted({ signal }: { signal?: AbortSignal }) {
-  if (signal?.aborted) throw new DOMException("人物抠像已取消", "AbortError");
+	if (signal?.aborted) throw new DOMException("人物抠像已取消", "AbortError");
 }
 
 export async function exportJianyingPersonCutout({
-  file,
-  sourcePath: explicitSourcePath,
-  settings,
-  onProgress,
-  signal,
+	file,
+	sourcePath: explicitSourcePath,
+	settings,
+	onProgress,
+	signal,
 }: {
-  file: File;
-  sourcePath?: string;
-  settings: PersonCutoutMaskOptions;
-  onProgress?: (progress: { progress: number; status: string }) => void;
-  signal?: AbortSignal;
+	file: File;
+	sourcePath?: string;
+	settings: PersonCutoutMaskOptions;
+	onProgress?: (progress: { progress: number; status: string }) => void;
+	signal?: AbortSignal;
 }): Promise<JianyingPersonCutoutClientResult> {
-  throwIfAborted({ signal });
-  const api = window.electronAPI?.jianyingPersonCutout;
-  const readFile = window.electronAPI?.readFile;
-  const getPathForFile = window.electronAPI?.getPathForFile;
-  if (!api || !readFile || !getPathForFile) {
-    throw new Error("精细抠像需要 QCut 桌面版");
-  }
-  const sourcePath = explicitSourcePath ?? getPathForFile(file);
-  if (!sourcePath) throw new Error("无法读取所选视频");
-  const taskId = crypto.randomUUID();
-  const unsubscribeProgress = api.onProgress((update) => {
-    if (update.taskId !== taskId) return;
-    onProgress?.({ progress: update.progress, status: update.status });
-  });
-  const cancel = () => {
-    void api.cancel({ taskId });
-  };
-  signal?.addEventListener("abort", cancel, { once: true });
-  onProgress?.({ progress: 3, status: "正在加载精细抠像..." });
-  try {
-    const runtime = await api.inspect();
-    if (!runtime.available) throw new Error(runtime.message);
-    throwIfAborted({ signal });
-    onProgress?.({ progress: 8, status: "正在精细抠除背景..." });
-    const result = await api.render({ sourcePath, settings, taskId });
-    if (!result) {
-      throwIfAborted({ signal });
-      throw new Error("人物抠像未返回结果");
-    }
-    try {
-      throwIfAborted({ signal });
-      onProgress?.({ progress: 94, status: "正在准备抠像结果..." });
-      const bytes = await readFile(result.outputPath);
-      if (!bytes) throw new Error("无法读取精细抠像结果");
-      throwIfAborted({ signal });
-      onProgress?.({ progress: 100, status: "人物抠像已完成" });
-      return {
-        blendImplementation: result.blendImplementation,
-        didModelRouteFallback: result.didModelRouteFallback,
-        blob: new Blob([new Uint8Array(bytes)], { type: "video/webm" }),
-        width: result.width,
-        height: result.height,
-        duration: result.duration,
-        frameRate: result.frameRate,
-        frameCount: result.frameCount,
-        codec: result.codec,
-        hasAudio: result.hasAudio,
-        modelRoute: result.modelRoute,
-        nativeMetalCanary: result.nativeMetalCanary,
-        pipelineId: result.pipelineId,
-        provider: result.provider,
-        refinementProvider: result.refinementProvider,
-        requestedModelRoute: result.requestedModelRoute,
-        trackingSamples: [],
-      };
-    } finally {
-      await api.release({ outputPath: result.outputPath });
-    }
-  } finally {
-    signal?.removeEventListener("abort", cancel);
-    unsubscribeProgress();
-  }
+	throwIfAborted({ signal });
+	const api = window.electronAPI?.jianyingPersonCutout;
+	const readFile = window.electronAPI?.readFile;
+	const getPathForFile = window.electronAPI?.getPathForFile;
+	if (!api || !readFile || !getPathForFile) {
+		throw new Error("精细抠像需要 QCut 桌面版");
+	}
+	const sourcePath = explicitSourcePath ?? getPathForFile(file);
+	if (!sourcePath) throw new Error("无法读取所选视频");
+	const taskId = crypto.randomUUID();
+	const unsubscribeProgress = api.onProgress((update) => {
+		if (update.taskId !== taskId) return;
+		onProgress?.({ progress: update.progress, status: update.status });
+	});
+	const cancel = () => {
+		void api.cancel({ taskId });
+	};
+	signal?.addEventListener("abort", cancel, { once: true });
+	onProgress?.({ progress: 3, status: "正在加载精细抠像..." });
+	try {
+		const runtime = await api.inspect();
+		if (!runtime.available) throw new Error(runtime.message);
+		throwIfAborted({ signal });
+		onProgress?.({ progress: 8, status: "正在精细抠除背景..." });
+		const result = await api.render({ sourcePath, settings, taskId });
+		if (!result) {
+			throwIfAborted({ signal });
+			throw new Error("人物抠像未返回结果");
+		}
+		try {
+			throwIfAborted({ signal });
+			onProgress?.({ progress: 94, status: "正在准备抠像结果..." });
+			const bytes = await readFile(result.outputPath);
+			if (!bytes) throw new Error("无法读取精细抠像结果");
+			throwIfAborted({ signal });
+			onProgress?.({ progress: 100, status: "人物抠像已完成" });
+			return {
+				blendImplementation: result.blendImplementation,
+				didModelRouteFallback: result.didModelRouteFallback,
+				blob: new Blob([new Uint8Array(bytes)], { type: "video/webm" }),
+				width: result.width,
+				height: result.height,
+				duration: result.duration,
+				frameRate: result.frameRate,
+				frameCount: result.frameCount,
+				codec: result.codec,
+				hasAudio: result.hasAudio,
+				modelRoute: result.modelRoute,
+				nativeMetalCanary: result.nativeMetalCanary,
+				pipelineId: result.pipelineId,
+				provider: result.provider,
+				refinementProvider: result.refinementProvider,
+				requestedModelRoute: result.requestedModelRoute,
+				trackingSamples: [],
+			};
+		} finally {
+			await api.release({ outputPath: result.outputPath });
+		}
+	} finally {
+		signal?.removeEventListener("abort", cancel);
+		unsubscribeProgress();
+	}
 }

--- a/qcut/apps/web/src/lib/segmentation/jianying-person-cutout-client.ts
+++ b/qcut/apps/web/src/lib/segmentation/jianying-person-cutout-client.ts
@@ -1,0 +1,86 @@
+import type { MediaMaskTrackingSample } from "@/lib/video/media-mask-tracking";
+import type { PersonCutoutMaskOptions } from "./person-cutout-mask";
+import type { TemattingBlendImplementation } from "@/types/electron/api-jianying-person-cutout";
+
+export interface JianyingPersonCutoutClientResult {
+	blendImplementation: TemattingBlendImplementation;
+	blob: Blob;
+	width: number;
+	height: number;
+	duration: number;
+	frameRate: number;
+	frameCount: number;
+	codec: "vp9";
+	hasAudio: boolean;
+	trackingSamples: MediaMaskTrackingSample[];
+}
+
+function throwIfAborted({ signal }: { signal?: AbortSignal }) {
+	if (signal?.aborted) throw new DOMException("人物抠像已取消", "AbortError");
+}
+
+export async function exportJianyingPersonCutout({
+	file,
+	sourcePath: explicitSourcePath,
+	settings,
+	onProgress,
+	signal,
+}: {
+	file: File;
+	sourcePath?: string;
+	settings: PersonCutoutMaskOptions;
+	onProgress?: (progress: { progress: number; status: string }) => void;
+	signal?: AbortSignal;
+}): Promise<JianyingPersonCutoutClientResult> {
+	throwIfAborted({ signal });
+	const api = window.electronAPI?.jianyingPersonCutout;
+	const readFile = window.electronAPI?.readFile;
+	const getPathForFile = window.electronAPI?.getPathForFile;
+	if (!api || !readFile || !getPathForFile) {
+		throw new Error("精细抠像需要 QCut 桌面版");
+	}
+	const sourcePath = explicitSourcePath ?? getPathForFile(file);
+	if (!sourcePath) throw new Error("无法读取所选视频");
+	const taskId = crypto.randomUUID();
+	const unsubscribeProgress = api.onProgress((update) => {
+		if (update.taskId !== taskId) return;
+		onProgress?.({ progress: update.progress, status: update.status });
+	});
+	const cancel = () => {
+		void api.cancel({ taskId });
+	};
+	signal?.addEventListener("abort", cancel, { once: true });
+	onProgress?.({ progress: 3, status: "正在加载精细抠像..." });
+	try {
+		const runtime = await api.inspect();
+		if (!runtime.available) throw new Error(runtime.message);
+		throwIfAborted({ signal });
+		onProgress?.({ progress: 8, status: "正在精细抠除背景..." });
+		const result = await api.render({ sourcePath, settings, taskId });
+		throwIfAborted({ signal });
+		onProgress?.({ progress: 94, status: "正在准备抠像结果..." });
+		const bytes = await readFile(result.outputPath);
+		if (!bytes) throw new Error("无法读取精细抠像结果");
+		throwIfAborted({ signal });
+		onProgress?.({ progress: 100, status: "人物抠像已完成" });
+		try {
+			return {
+				blendImplementation: result.blendImplementation,
+				blob: new Blob([new Uint8Array(bytes)], { type: "video/webm" }),
+				width: result.width,
+				height: result.height,
+				duration: result.duration,
+				frameRate: result.frameRate,
+				frameCount: result.frameCount,
+				codec: result.codec,
+				hasAudio: result.hasAudio,
+				trackingSamples: [],
+			};
+		} finally {
+			await api.release({ outputPath: result.outputPath });
+		}
+	} finally {
+		signal?.removeEventListener("abort", cancel);
+		unsubscribeProgress();
+	}
+}

--- a/qcut/apps/web/src/lib/segmentation/mask-tracking-runtime.ts
+++ b/qcut/apps/web/src/lib/segmentation/mask-tracking-runtime.ts
@@ -1,9 +1,10 @@
 import type { MediaMaskTrackingDirection } from "@/types/timeline";
+import type { GeneratedMaskSource } from "./generated-mask-attachment";
 
 export interface ActiveMaskTrackingRuntime {
 	elementId: string;
 	maskId: string;
-	source: "mediapipe" | "sam3";
+	source: GeneratedMaskSource;
 	direction: MediaMaskTrackingDirection;
 	cancel: () => void | Promise<void>;
 	resume?: () => void | Promise<void>;

--- a/qcut/apps/web/src/lib/segmentation/person-cutout-export.ts
+++ b/qcut/apps/web/src/lib/segmentation/person-cutout-export.ts
@@ -9,8 +9,11 @@ import {
 	alphaMaskTrackingSample,
 	type MediaMaskTrackingSample,
 } from "@/lib/video/media-mask-tracking";
+import { exportJianyingPersonCutout } from "./jianying-person-cutout-client";
+import type { TemattingBlendImplementation } from "@/types/electron/api-jianying-person-cutout";
 
 export type PersonCutoutExportSettings = PersonCutoutMaskOptions;
+export type PersonCutoutQuality = "basic" | "fine";
 
 export interface PersonCutoutExportProgress {
 	progress: number;
@@ -18,6 +21,7 @@ export interface PersonCutoutExportProgress {
 }
 
 export interface PersonCutoutExportResult {
+	blendImplementation?: TemattingBlendImplementation;
 	blob: Blob;
 	duration: number;
 	width: number;
@@ -31,7 +35,9 @@ export interface PersonCutoutExportResult {
 
 interface ExportPersonCutoutVideoOptions {
 	file: File;
+	sourcePath?: string;
 	settings: PersonCutoutExportSettings;
+	quality?: PersonCutoutQuality;
 	includeAudio?: boolean;
 	absentPersonMode?: PersonCutoutAbsentMode;
 	onProgress?: (progress: PersonCutoutExportProgress) => void;
@@ -111,14 +117,25 @@ export function getPersonCutoutVideoBitrate({
 
 export async function exportPersonCutoutVideo({
 	file,
+	sourcePath,
 	settings,
+	quality = "basic",
 	includeAudio = true,
 	absentPersonMode = "transparent",
 	onProgress,
 	signal,
 }: ExportPersonCutoutVideoOptions): Promise<PersonCutoutExportResult> {
+	if (quality === "fine") {
+		return exportJianyingPersonCutout({
+			file,
+			sourcePath,
+			settings,
+			onProgress,
+			signal,
+		});
+	}
 	throwIfAborted(signal);
-	onProgress?.({ progress: 0, status: "Reading source video..." });
+	onProgress?.({ progress: 0, status: "正在读取视频..." });
 
 	const {
 		ALL_FORMATS,
@@ -141,9 +158,9 @@ export async function exportPersonCutoutVideo({
 
 	try {
 		const videoTrack = await input.getPrimaryVideoTrack();
-		if (!videoTrack) throw new Error("The selected file has no video track");
+		if (!videoTrack) throw new Error("所选文件没有视频画面");
 		if (!(await videoTrack.canDecode())) {
-			throw new Error("This video's codec cannot be decoded on this device");
+			throw new Error("这段视频暂时无法在本机解码");
 		}
 
 		const width = videoTrack.displayWidth;
@@ -179,7 +196,7 @@ export async function exportPersonCutoutVideo({
 			}
 		}
 		if (!codec) {
-			throw new Error("This device cannot encode VP9 or VP8 transparent video");
+			throw new Error("本机暂时无法生成透明视频");
 		}
 
 		const outputCanvas = document.createElement("canvas");
@@ -189,7 +206,7 @@ export async function exportPersonCutoutVideo({
 		sourceCanvas.width = width;
 		sourceCanvas.height = height;
 		const sourceContext = sourceCanvas.getContext("2d");
-		if (!sourceContext) throw new Error("Unable to create video frame canvas");
+		if (!sourceContext) throw new Error("无法准备视频画面");
 		const maskCanvas = document.createElement("canvas");
 
 		const target = new BufferTarget();
@@ -259,28 +276,28 @@ export async function exportPersonCutoutVideo({
 			);
 			throw new Error(
 				videoFailure
-					? `Transparent video setup failed: ${videoFailure.reason}`
-					: "Transparent video setup is not supported on this device"
+					? `透明视频准备失败：${videoFailure.reason}`
+					: "本机暂不支持透明视频"
 			);
 		}
 
 		conversion.onProgress = (progress) => {
 			onProgress?.({
 				progress: Math.round(Math.min(0.98, progress) * 100),
-				status: `Removing background... ${Math.round(progress * 100)}%`,
+				status: `正在抠除背景... ${Math.round(progress * 100)}%`,
 			});
 		};
 		abortHandler = () => void conversion?.cancel();
 		signal?.addEventListener("abort", abortHandler, { once: true });
 
-		onProgress?.({ progress: 1, status: "Loading local person model..." });
+		onProgress?.({ progress: 1, status: "正在加载人物抠像..." });
 		await conversion.execute();
 		throwIfAborted(signal);
 
 		if (!target.buffer) {
-			throw new Error("Transparent video encoder returned no output");
+			throw new Error("透明视频没有生成结果");
 		}
-		onProgress?.({ progress: 100, status: "Transparent video ready" });
+		onProgress?.({ progress: 100, status: "人物抠像已完成" });
 
 		return {
 			blob: new Blob([target.buffer], { type: "video/webm" }),

--- a/qcut/apps/web/src/lib/segmentation/person-cutout-export.ts
+++ b/qcut/apps/web/src/lib/segmentation/person-cutout-export.ts
@@ -9,8 +9,14 @@ import {
 	alphaMaskTrackingSample,
 	type MediaMaskTrackingSample,
 } from "@/lib/video/media-mask-tracking";
-import { exportJianyingPersonCutout } from "./jianying-person-cutout-client";
-import type { TemattingBlendImplementation } from "@/types/electron/api-jianying-person-cutout";
+import {
+	exportJianyingPersonCutout,
+	type PersonCutoutExecutionMetadata,
+} from "./jianying-person-cutout-client";
+import type {
+	JianyingPersonCutoutRenderResult,
+	TemattingOutputBlendImplementation,
+} from "@/types/electron/api-jianying-person-cutout";
 
 export type PersonCutoutExportSettings = PersonCutoutMaskOptions;
 export type PersonCutoutQuality = "basic" | "fine";
@@ -20,8 +26,9 @@ export interface PersonCutoutExportProgress {
 	status: string;
 }
 
-export interface PersonCutoutExportResult {
-	blendImplementation?: TemattingBlendImplementation;
+export interface PersonCutoutExportResult
+	extends Partial<PersonCutoutExecutionMetadata> {
+	blendImplementation?: TemattingOutputBlendImplementation;
 	blob: Blob;
 	duration: number;
 	width: number;
@@ -29,6 +36,7 @@ export interface PersonCutoutExportResult {
 	frameRate: number;
 	frameCount: number;
 	hasAudio: boolean;
+	nativeMetalCanary?: JianyingPersonCutoutRenderResult["nativeMetalCanary"];
 	codec: "vp9" | "vp8";
 	trackingSamples: MediaMaskTrackingSample[];
 }

--- a/qcut/apps/web/src/lib/segmentation/person-cutout-presets.ts
+++ b/qcut/apps/web/src/lib/segmentation/person-cutout-presets.ts
@@ -1,0 +1,15 @@
+import type { PersonCutoutMaskOptions } from "./person-cutout-mask";
+
+export const BASIC_PERSON_CUTOUT_SETTINGS: PersonCutoutMaskOptions = {
+	threshold: 0.5,
+	temporalSmoothing: 0.65,
+	edgeShift: 0,
+	feather: 2,
+};
+
+export const FINE_PERSON_CUTOUT_SETTINGS: PersonCutoutMaskOptions = {
+	threshold: 0.5,
+	temporalSmoothing: 0,
+	edgeShift: 0,
+	feather: 0,
+};

--- a/qcut/apps/web/src/stores/ai/segmentation-store.ts
+++ b/qcut/apps/web/src/stores/ai/segmentation-store.ts
@@ -16,6 +16,7 @@ import type {
 	Sam3SegmentationMode,
 } from "@/types/sam3";
 import type { PersonCutoutMaskOptions } from "@/lib/segmentation/person-cutout-mask";
+import { BASIC_PERSON_CUTOUT_SETTINGS } from "@/lib/segmentation/person-cutout-presets";
 import type { MediaMaskTrackingDirection } from "@/types/timeline";
 
 // ============================================
@@ -221,12 +222,7 @@ const initialState: SegmentationState = {
 	showBoundingBoxes: false,
 
 	videoBackend: "local-person",
-	personCutoutSettings: {
-		threshold: 0.5,
-		temporalSmoothing: 0.65,
-		edgeShift: 0,
-		feather: 2,
-	},
+	personCutoutSettings: { ...BASIC_PERSON_CUTOUT_SETTINGS },
 	currentFrame: 0,
 	totalFrames: 0,
 	segmentedVideoUrl: null,

--- a/qcut/apps/web/src/test/e2e/jianying-manual-body.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/jianying-manual-body.e2e.ts
@@ -195,10 +195,34 @@ test.describe("Jianying manual body product flow", () => {
 		).toContainText("离线就绪", { timeout: 30_000 });
 		await panel.getByRole("switch", { name: "启用原版美颜美体" }).click();
 		await panel.getByRole("tab", { name: "美体", exact: true }).click();
-		await panel.getByRole("tab", { name: "手动美体", exact: true }).click();
+		const smartBodyGroup = page.getByTestId("portrait-group-smart-body");
+		const manualBodyGroup = page.getByTestId("portrait-group-manual-body");
+		const smartBodyTrigger = smartBodyGroup.getByRole("button", {
+			name: "智能美体",
+			exact: true,
+		});
+		const manualBodyTrigger = manualBodyGroup.getByRole("button", {
+			name: "手动美体",
+			exact: true,
+		});
+		await expect(smartBodyTrigger).toHaveAttribute("aria-expanded", "true");
+		await smartBodyTrigger.click();
+		await expect(smartBodyTrigger).toHaveAttribute("aria-expanded", "false");
+		await page.screenshot({
+			path: path.join(outputDirectory, "00-collapsible-body-groups.png"),
+			animations: "disabled",
+		});
+		await smartBodyTrigger.click();
+		await manualBodyTrigger.click();
+		await expect(manualBodyTrigger).toHaveAttribute("aria-expanded", "true");
+		await expect(smartBodyTrigger).toHaveAttribute("aria-expanded", "true");
 		const controls = page.getByTestId("portrait-manual-body-controls");
 		await expect(controls).toBeVisible();
 		const overlay = page.getByTestId("portrait-manual-body-overlay");
+		await expect(overlay).toBeVisible();
+		await manualBodyTrigger.click();
+		await expect(overlay).toBeHidden();
+		await manualBodyTrigger.click();
 		await expect(overlay).toBeVisible();
 		await expect
 			.poll(async () => (await overlay.boundingBox())?.width ?? 0)
@@ -392,7 +416,7 @@ test.describe("Jianying manual body product flow", () => {
 			.click();
 		await page
 			.getByTestId("jianying-portrait-adjustments")
-			.getByRole("tab", { name: "手动美体", exact: true })
+			.getByRole("button", { name: "手动美体", exact: true })
 			.click();
 		await expect(
 			page.getByTestId("portrait-manual-body-overlay")

--- a/qcut/apps/web/src/test/e2e/jianying-person-cutout.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/jianying-person-cutout.e2e.ts
@@ -1,0 +1,288 @@
+import { _electron as electron } from "playwright";
+import { existsSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "@playwright/test";
+import {
+	createTestProject,
+	navigateToProjects,
+} from "./helpers/electron-helpers";
+import { uploadTestMedia } from "./helpers/e2e-panel-helpers";
+
+const sourcePath =
+	process.env.QCUT_PERSON_VIDEO_PATH ??
+	"/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/real-person-input-2s.mp4";
+const evidenceDirectory =
+	process.env.QCUT_PERSON_CUTOUT_EVIDENCE_DIRECTORY ??
+	"/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-native-metal";
+const outputPath = join(evidenceDirectory, "desktop-person-cutout.webm");
+const expectedRoute =
+	process.env.QCUT_PERSON_CUTOUT_EXPECTED_ROUTE ?? "portrait-gru";
+const expectedBlendImplementation =
+	expectedRoute === "portrait-gru"
+		? "TEMattingBlendEffectV2-native-metal"
+		: "TEMattingBlendEffectV2-compatible";
+
+interface CutoutMediaItem {
+	id: string;
+	duration: number;
+	file: File;
+	height: number;
+	metadata?: {
+		blendImplementation?: string;
+		hasAlpha?: boolean;
+		source?: string;
+	};
+	width: number;
+}
+
+interface CutoutHarnessWindow extends Window {
+	__mediaStore: {
+		getState: () => { mediaItems: CutoutMediaItem[] };
+	};
+	__timelineStore: {
+		getState: () => {
+			setSelectedElements: (
+				elements: Array<{ trackId: string; elementId: string }>
+			) => void;
+			tracks: Array<{
+				elements: Array<{
+					id: string;
+					masks?: Array<{
+						sourceMediaId?: string;
+						tracking?: { source?: string };
+						type: string;
+					}>;
+					startTime: number;
+					type: string;
+				}>;
+			}>;
+		};
+	};
+	__playbackStore: {
+		getState: () => { seek: (time: number) => void };
+	};
+	electronAPI: {
+		writeFile: (path: string, bytes: ArrayBuffer) => Promise<boolean>;
+	};
+}
+
+test.describe("Jianying-routed local person cutout", () => {
+	test.setTimeout(180_000);
+	test.skip(!existsSync(sourcePath), "Real-person video fixture is missing");
+
+	// biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixtures before testInfo.
+	test("renders, attaches, and plays a routed native mask in QCut", async ({}, testInfo) => {
+		const profileDirectory = join(
+			tmpdir(),
+			`qcut-jianying-person-cutout-${process.pid}-${Date.now()}`
+		);
+		await rm(evidenceDirectory, { recursive: true, force: true });
+		await mkdir(evidenceDirectory, { recursive: true });
+		const electronApp = await electron.launch({
+			args: [`--user-data-dir=${profileDirectory}`, "dist/electron/main.js"],
+			cwd: process.cwd(),
+			env: { ...process.env, NODE_ENV: "test" },
+		});
+
+		try {
+			const page = await electronApp.firstWindow();
+			await page.waitForLoadState("domcontentloaded");
+			await page.waitForFunction(
+				() => Boolean(document.querySelector("#root")?.children.length),
+				undefined,
+				{ timeout: 30_000 }
+			);
+			await page.evaluate(() => {
+				localStorage.setItem("hasSeenOnboarding", "true");
+			});
+			await navigateToProjects(page);
+			await createTestProject(page, "Native Metal Person Cutout E2E");
+			await uploadTestMedia(page, sourcePath);
+			await page
+				.getByTestId("media-item")
+				.last()
+				.dragTo(page.getByTestId("timeline-track").first());
+			const timelineClip = page.getByTestId("timeline-element").last();
+			await expect(timelineClip).toBeVisible();
+			await timelineClip.click();
+			const properties = page.getByTestId("media-properties");
+			await expect(properties).toBeVisible();
+			await properties
+				.getByTestId("media-properties-visual-tabs")
+				.getByRole("tab", { name: "抠像", exact: true })
+				.click();
+			await expect(
+				properties.getByTestId("person-cutout-quality-fine")
+			).toBeVisible();
+			await properties.getByTestId("person-cutout-quality-fine").click();
+			await properties
+				.getByTestId("person-cutout-quality")
+				.locator("..")
+				.locator("summary")
+				.click();
+			await expect(properties.getByText("精细抠像已就绪")).toBeVisible({
+				timeout: 30_000,
+			});
+			await properties.screenshot({
+				path: join(evidenceDirectory, "01-fine-cutout-ready.png"),
+				animations: "disabled",
+			});
+
+			await properties.getByRole("button", { name: "开始并应用" }).click();
+			await expect(properties.getByTestId("person-cutout-result")).toBeVisible({
+				timeout: 120_000,
+			});
+			const exported = await page.evaluate(async (destination) => {
+				const harness = window as unknown as CutoutHarnessWindow;
+				const item = [...harness.__mediaStore.getState().mediaItems]
+					.reverse()
+					.find(
+						(candidate) =>
+							candidate.metadata?.source === "jianying-gru-person-cutout"
+					);
+				if (!item) throw new Error("Native person cutout was not added");
+				const written = await harness.electronAPI.writeFile(
+					destination,
+					await item.file.arrayBuffer()
+				);
+				const mask = harness.__timelineStore
+					.getState()
+					.tracks.flatMap((track) => track.elements)
+					.flatMap((element) => element.masks ?? [])
+					.find((candidate) => candidate.sourceMediaId === item.id);
+				return {
+					blendImplementation: item.metadata?.blendImplementation,
+					duration: item.duration,
+					hasAlpha: item.metadata?.hasAlpha,
+					height: item.height,
+					mask,
+					outputMediaId: item.id,
+					size: item.file.size,
+					width: item.width,
+					written,
+				};
+			}, outputPath);
+			expect(exported).toMatchObject({
+				blendImplementation: expectedBlendImplementation,
+				hasAlpha: true,
+				height: 640,
+				mask: {
+					height: 1,
+					sourceMediaId: exported.outputMediaId,
+					tracking: { source: "jianying-gru" },
+					type: "person",
+					width: 1,
+				},
+				width: 360,
+				written: true,
+			});
+			expect(exported.duration).toBeGreaterThan(
+				expectedRoute === "saliency-script" ? 0.4 : 1.5
+			);
+			expect(exported.size).toBeGreaterThan(10_000);
+			await page.evaluate((sourceMediaId) => {
+				const harness = window as unknown as CutoutHarnessWindow;
+				const element = harness.__timelineStore
+					.getState()
+					.tracks.flatMap((track) => track.elements)
+					.find((candidate) =>
+						candidate.masks?.some(
+							(mask) => mask.sourceMediaId === sourceMediaId
+						)
+					);
+				if (!element) throw new Error("Masked timeline clip is missing");
+				harness.__playbackStore.getState().seek(element.startTime + 0.25);
+			}, exported.outputMediaId);
+
+			const previewPanel = page.getByTestId("preview-panel");
+			const maskVideo = previewPanel.locator(
+				'video[data-video-id*="-mask-"]:not([data-video-id$="-mask-audio"])'
+			);
+			await expect(maskVideo).toHaveCount(1);
+			await expect
+				.poll(
+					() =>
+						maskVideo.evaluate(
+							(video) => (video as HTMLVideoElement).readyState
+						),
+					{ timeout: 30_000 }
+				)
+				.toBeGreaterThanOrEqual(2);
+			await expect
+				.poll(() =>
+					maskVideo.evaluate((video) => (video as HTMLVideoElement).videoWidth)
+				)
+				.toBe(360);
+			let decodedAlphaStats:
+				| { centerMean: number; topBandMean: number }
+				| undefined;
+			if (basename(sourcePath) === "real-person-wide-2s.mp4") {
+				decodedAlphaStats = await maskVideo.evaluate((element) => {
+					const video = element as HTMLVideoElement;
+					const canvas = document.createElement("canvas");
+					canvas.width = video.videoWidth;
+					canvas.height = video.videoHeight;
+					const context = canvas.getContext("2d", { willReadFrequently: true });
+					if (!context) throw new Error("Unable to inspect decoded alpha");
+					context.drawImage(video, 0, 0);
+					const pixels = context.getImageData(
+						0,
+						0,
+						canvas.width,
+						canvas.height
+					).data;
+					let topBandAlpha = 0;
+					for (let y = 0; y < 32; y += 1) {
+						for (let x = 0; x < canvas.width; x += 1) {
+							topBandAlpha += pixels[(y * canvas.width + x) * 4 + 3];
+						}
+					}
+					let centerAlpha = 0;
+					for (let y = 160; y < 480; y += 1) {
+						for (let x = 90; x < 270; x += 1) {
+							centerAlpha += pixels[(y * canvas.width + x) * 4 + 3];
+						}
+					}
+					return {
+						centerMean: centerAlpha / (180 * 320),
+						topBandMean: topBandAlpha / (canvas.width * 32),
+					};
+				});
+				expect(decodedAlphaStats.topBandMean).toBeLessThan(1);
+				expect(decodedAlphaStats.centerMean).toBeGreaterThan(100);
+			}
+			await properties.screenshot({
+				path: join(evidenceDirectory, "02-cutout-completed.png"),
+				animations: "disabled",
+			});
+			await page.evaluate(() => {
+				const harness = window as unknown as CutoutHarnessWindow;
+				harness.__timelineStore.getState().setSelectedElements([]);
+			});
+			await previewPanel.screenshot({
+				path: join(evidenceDirectory, "03-mask-playing-in-preview.png"),
+				animations: "disabled",
+			});
+			await writeFile(
+				join(evidenceDirectory, "e2e-evidence.json"),
+				`${JSON.stringify(
+					{
+						...exported,
+						decodedAlphaStats,
+						expectedRoute,
+						outputPath,
+						sourcePath,
+						testOutputDirectory: testInfo.outputDir,
+					},
+					null,
+					2
+				)}\n`
+			);
+		} finally {
+			await electronApp.close();
+			await rm(profileDirectory, { recursive: true, force: true });
+		}
+	});
+});

--- a/qcut/apps/web/src/test/e2e/jianying-person-cutout.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/jianying-person-cutout.e2e.ts
@@ -5,572 +5,570 @@ import { basename, join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "@playwright/test";
 import {
-  createTestProject,
-  navigateToProjects,
+	createTestProject,
+	navigateToProjects,
 } from "./helpers/electron-helpers";
 import { uploadTestMedia } from "./helpers/e2e-panel-helpers";
 
-const sourcePath =
-  process.env.QCUT_PERSON_VIDEO_PATH ??
-  "/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/real-person-input-2s.mp4";
+const sourcePath = process.env.QCUT_PERSON_VIDEO_PATH ?? "";
 const evidenceDirectory =
-  process.env.QCUT_PERSON_CUTOUT_EVIDENCE_DIRECTORY ??
-  "/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-compatible";
+	process.env.QCUT_PERSON_CUTOUT_EVIDENCE_DIRECTORY ??
+	join(tmpdir(), "qcut-person-cutout-e2e");
 const outputPath = join(evidenceDirectory, "desktop-person-cutout.webm");
 const expectedRequestedRoute =
-  process.env.QCUT_PERSON_CUTOUT_EXPECTED_REQUESTED_ROUTE ?? "auto";
+	process.env.QCUT_PERSON_CUTOUT_EXPECTED_REQUESTED_ROUTE ?? "auto";
 const expectedActualRouteValue =
-  process.env.QCUT_PERSON_CUTOUT_EXPECTED_ACTUAL_ROUTE ?? "portrait-gru";
+	process.env.QCUT_PERSON_CUTOUT_EXPECTED_ACTUAL_ROUTE ?? "portrait-gru";
 const personCutoutRoutes = [
-  "portrait-gru",
-  "video-object",
-  "saliency-script",
+	"portrait-gru",
+	"video-object",
+	"saliency-script",
 ] as const;
 type PersonCutoutRoute = (typeof personCutoutRoutes)[number];
 if (
-  !personCutoutRoutes.includes(expectedActualRouteValue as PersonCutoutRoute)
+	!personCutoutRoutes.includes(expectedActualRouteValue as PersonCutoutRoute)
 ) {
-  throw new Error(
-    `Unsupported expected person-cutout route: ${expectedActualRouteValue}`,
-  );
+	throw new Error(
+		`Unsupported expected person-cutout route: ${expectedActualRouteValue}`
+	);
 }
 const expectedActualRoute = expectedActualRouteValue as PersonCutoutRoute;
 const expectedRouteFallback =
-  process.env.QCUT_PERSON_CUTOUT_EXPECTED_ROUTE_FALLBACK === undefined
-    ? true
-    : process.env.QCUT_PERSON_CUTOUT_EXPECTED_ROUTE_FALLBACK === "1";
+	process.env.QCUT_PERSON_CUTOUT_EXPECTED_ROUTE_FALLBACK === undefined
+		? true
+		: process.env.QCUT_PERSON_CUTOUT_EXPECTED_ROUTE_FALLBACK === "1";
 const expectedSecondRouteFallback =
-  process.env.QCUT_PERSON_CUTOUT_EXPECTED_SECOND_ROUTE_FALLBACK === "1";
+	process.env.QCUT_PERSON_CUTOUT_EXPECTED_SECOND_ROUTE_FALLBACK === "1";
 const expectedBlendImplementation =
-  process.env.QCUT_PERSON_CUTOUT_EXPECTED_BLEND ??
-  (expectedActualRoute === "video-object"
-    ? "TEMattingBlendEffectV2-vendor-exact"
-    : "TEMattingBlendEffectV2-compatible");
+	process.env.QCUT_PERSON_CUTOUT_EXPECTED_BLEND ??
+	(expectedActualRoute === "video-object"
+		? "TEMattingBlendEffectV2-vendor-exact"
+		: "TEMattingBlendEffectV2-compatible");
 const expectedWidth = Number(
-  process.env.QCUT_PERSON_CUTOUT_EXPECTED_WIDTH ?? 360,
+	process.env.QCUT_PERSON_CUTOUT_EXPECTED_WIDTH ?? 360
 );
 const expectedHeight = Number(
-  process.env.QCUT_PERSON_CUTOUT_EXPECTED_HEIGHT ?? 640,
+	process.env.QCUT_PERSON_CUTOUT_EXPECTED_HEIGHT ?? 640
 );
 
 interface ExpectedExecutionDescriptor {
-  pipelineId: string;
-  provider: string;
-  refinementProvider: string;
+	pipelineId: string;
+	provider: string;
+	refinementProvider: string;
 }
 
 const portraitDescriptor: ExpectedExecutionDescriptor =
-  process.env.QCUT_DISABLE_VISION_PERSON_FUSION === "1"
-    ? {
-        pipelineId: "qcut-gru-only-v1",
-        provider: "qcut-local-person-matting-v1",
-        refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
-      }
-    : {
-        pipelineId: "qcut-gru-vision-fusion-v1",
-        provider: "qcut-local-person-matting-v1",
-        refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
-      };
+	process.env.QCUT_DISABLE_VISION_PERSON_FUSION === "1"
+		? {
+				pipelineId: "qcut-gru-only-v1",
+				provider: "qcut-local-person-matting-v1",
+				refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+			}
+		: {
+				pipelineId: "qcut-gru-vision-fusion-v1",
+				provider: "qcut-local-person-matting-v1",
+				refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+			};
 const expectedDescriptorByRoute: Record<
-  PersonCutoutRoute,
-  ExpectedExecutionDescriptor
+	PersonCutoutRoute,
+	ExpectedExecutionDescriptor
 > = {
-  "portrait-gru": portraitDescriptor,
-  "video-object": {
-    pipelineId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
-    provider: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
-    refinementProvider: "vendor-v2-exact-no-qcut-refinement-v1",
-  },
-  "saliency-script": {
-    pipelineId: "qcut-saliency-script-interop-experimental-v1",
-    provider: "qcut-saliency-interop-experimental-v1",
-    refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
-  },
+	"portrait-gru": portraitDescriptor,
+	"video-object": {
+		pipelineId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+		provider: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+		refinementProvider: "vendor-v2-exact-no-qcut-refinement-v1",
+	},
+	"saliency-script": {
+		pipelineId: "qcut-saliency-script-interop-experimental-v1",
+		provider: "qcut-saliency-interop-experimental-v1",
+		refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
+	},
 };
 const expectedExecutionDescriptor =
-  expectedDescriptorByRoute[expectedActualRoute];
+	expectedDescriptorByRoute[expectedActualRoute];
 
 interface AlphaQualityRegion {
-  height: number;
-  maxMean?: number;
-  minMean?: number;
-  name: string;
-  width: number;
-  x: number;
-  y: number;
+	height: number;
+	maxMean?: number;
+	minMean?: number;
+	name: string;
+	width: number;
+	x: number;
+	y: number;
 }
 
 interface AlphaQualityProfile {
-  regions: AlphaQualityRegion[];
-  sampleTime: number;
+	regions: AlphaQualityRegion[];
+	sampleTime: number;
 }
 
 const alphaQualityProfiles: Record<string, AlphaQualityProfile> = {
-  "real-person-input-2s.mp4": {
-    sampleTime: 0.25,
-    regions: [
-      {
-        name: "leftPersonCore",
-        x: 15,
-        y: 15,
-        width: 135,
-        height: 185,
-        minMean: 100,
-      },
-      {
-        name: "foregroundHands",
-        x: 55,
-        y: 285,
-        width: 230,
-        height: 205,
-        minMean: 80,
-      },
-      {
-        name: "upperRightBackground",
-        x: 270,
-        y: 60,
-        width: 80,
-        height: 130,
-        maxMean: 64,
-      },
-    ],
-  },
-  "real-person-wide-2s.mp4": {
-    sampleTime: 0.25,
-    regions: [
-      {
-        name: "topBackground",
-        x: 0,
-        y: 0,
-        width: 360,
-        height: 32,
-        maxMean: 8,
-      },
-      {
-        name: "centerPerson",
-        x: 90,
-        y: 160,
-        width: 180,
-        height: 320,
-        minMean: 100,
-      },
-    ],
-  },
+	"real-person-input-2s.mp4": {
+		sampleTime: 0.25,
+		regions: [
+			{
+				name: "leftPersonCore",
+				x: 15,
+				y: 15,
+				width: 135,
+				height: 185,
+				minMean: 100,
+			},
+			{
+				name: "foregroundHands",
+				x: 55,
+				y: 285,
+				width: 230,
+				height: 205,
+				minMean: 80,
+			},
+			{
+				name: "upperRightBackground",
+				x: 270,
+				y: 60,
+				width: 80,
+				height: 130,
+				maxMean: 64,
+			},
+		],
+	},
+	"real-person-wide-2s.mp4": {
+		sampleTime: 0.25,
+		regions: [
+			{
+				name: "topBackground",
+				x: 0,
+				y: 0,
+				width: 360,
+				height: 32,
+				maxMean: 8,
+			},
+			{
+				name: "centerPerson",
+				x: 90,
+				y: 160,
+				width: 180,
+				height: 320,
+				minMean: 100,
+			},
+		],
+	},
 };
 const alphaQualityProfile = alphaQualityProfiles[basename(sourcePath)];
 
 interface CutoutMediaItem {
-  id: string;
-  duration: number;
-  file: File;
-  height: number;
-  metadata?: {
-    blendImplementation?: string;
-    didModelRouteFallback?: boolean;
-    hasAlpha?: boolean;
-    hasAudio?: boolean;
-    modelRoute?: string;
-    pipelineId?: string;
-    provider?: string;
-    refinementProvider?: string;
-    requestedModelRoute?: string;
-    source?: string;
-  };
-  width: number;
+	id: string;
+	duration: number;
+	file: File;
+	height: number;
+	metadata?: {
+		blendImplementation?: string;
+		didModelRouteFallback?: boolean;
+		hasAlpha?: boolean;
+		hasAudio?: boolean;
+		modelRoute?: string;
+		pipelineId?: string;
+		provider?: string;
+		refinementProvider?: string;
+		requestedModelRoute?: string;
+		source?: string;
+	};
+	width: number;
 }
 
 interface CutoutHarnessWindow extends Window {
-  __personCutoutStatusMessages?: string[];
-  __personCutoutStatusObserver?: MutationObserver;
-  __mediaStore: {
-    getState: () => { mediaItems: CutoutMediaItem[] };
-  };
-  __timelineStore: {
-    getState: () => {
-      setSelectedElements: (
-        elements: Array<{ trackId: string; elementId: string }>,
-      ) => void;
-      tracks: Array<{
-        elements: Array<{
-          id: string;
-          masks?: Array<{
-            sourceMediaId?: string;
-            tracking?: { source?: string };
-            type: string;
-          }>;
-          startTime: number;
-          type: string;
-        }>;
-      }>;
-    };
-  };
-  __playbackStore: {
-    getState: () => { seek: (time: number) => void };
-  };
-  electronAPI: {
-    writeFile: (path: string, bytes: ArrayBuffer) => Promise<boolean>;
-  };
+	__personCutoutStatusMessages?: string[];
+	__personCutoutStatusObserver?: MutationObserver;
+	__mediaStore: {
+		getState: () => { mediaItems: CutoutMediaItem[] };
+	};
+	__timelineStore: {
+		getState: () => {
+			setSelectedElements: (
+				elements: Array<{ trackId: string; elementId: string }>
+			) => void;
+			tracks: Array<{
+				elements: Array<{
+					id: string;
+					masks?: Array<{
+						sourceMediaId?: string;
+						tracking?: { source?: string };
+						type: string;
+					}>;
+					startTime: number;
+					type: string;
+				}>;
+			}>;
+		};
+	};
+	__playbackStore: {
+		getState: () => { seek: (time: number) => void };
+	};
+	electronAPI: {
+		writeFile: (path: string, bytes: ArrayBuffer) => Promise<boolean>;
+	};
 }
 
 test.describe("QCut local person cutout", () => {
-  test.setTimeout(180_000);
-  test.skip(!existsSync(sourcePath), "Real-person video fixture is missing");
+	test.setTimeout(180_000);
+	test.skip(!existsSync(sourcePath), "Real-person video fixture is missing");
 
-  // biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixtures before testInfo.
-  test("renders, attaches, and plays an automatically routed mask", async ({}, testInfo) => {
-    const profileDirectory = join(
-      tmpdir(),
-      `qcut-jianying-person-cutout-${process.pid}-${Date.now()}`,
-    );
-    const cacheRoot = join(profileDirectory, "person-cutout-cache");
-    await rm(evidenceDirectory, { recursive: true, force: true });
-    await mkdir(evidenceDirectory, { recursive: true });
-    const electronApp = await electron.launch({
-      args: [`--user-data-dir=${profileDirectory}`, "dist/electron/main.js"],
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        NODE_ENV: "test",
-        QCUT_PERSON_CUTOUT_CACHE_ROOT: cacheRoot,
-      },
-    });
-    const runtimeLogChunks: string[] = [];
-    if (process.env.QCUT_PERSON_CUTOUT_CAPTURE_RUNTIME_LOG === "1") {
-      for (const stream of [
-        electronApp.process().stdout,
-        electronApp.process().stderr,
-      ]) {
-        stream?.on("data", (chunk: Buffer) => {
-          runtimeLogChunks.push(chunk.toString("utf8"));
-        });
-      }
-    }
+	// biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixtures before testInfo.
+	test("renders, attaches, and plays an automatically routed mask", async ({}, testInfo) => {
+		const profileDirectory = join(
+			tmpdir(),
+			`qcut-jianying-person-cutout-${process.pid}-${Date.now()}`
+		);
+		const cacheRoot = join(profileDirectory, "person-cutout-cache");
+		await rm(evidenceDirectory, { recursive: true, force: true });
+		await mkdir(evidenceDirectory, { recursive: true });
+		const electronApp = await electron.launch({
+			args: [`--user-data-dir=${profileDirectory}`, "dist/electron/main.js"],
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				NODE_ENV: "test",
+				QCUT_PERSON_CUTOUT_CACHE_ROOT: cacheRoot,
+			},
+		});
+		const runtimeLogChunks: string[] = [];
+		if (process.env.QCUT_PERSON_CUTOUT_CAPTURE_RUNTIME_LOG === "1") {
+			for (const stream of [
+				electronApp.process().stdout,
+				electronApp.process().stderr,
+			]) {
+				stream?.on("data", (chunk: Buffer) => {
+					runtimeLogChunks.push(chunk.toString("utf8"));
+				});
+			}
+		}
 
-    try {
-      const page = await electronApp.firstWindow();
-      await page.waitForLoadState("domcontentloaded");
-      await page.waitForFunction(
-        () => Boolean(document.querySelector("#root")?.children.length),
-        undefined,
-        { timeout: 30_000 },
-      );
-      await page.evaluate(() => {
-        localStorage.setItem("hasSeenOnboarding", "true");
-      });
-      await navigateToProjects(page);
-      await createTestProject(page, "Automatic Person Cutout E2E");
-      await uploadTestMedia(page, sourcePath);
-      await page
-        .getByTestId("media-item")
-        .last()
-        .dragTo(page.getByTestId("timeline-track").first());
-      const timelineClip = page.getByTestId("timeline-element").last();
-      await expect(timelineClip).toBeVisible();
-      await timelineClip.click();
-      const properties = page.getByTestId("media-properties");
-      await expect(properties).toBeVisible();
-      await properties
-        .getByTestId("media-properties-visual-tabs")
-        .getByRole("tab", { name: "抠像", exact: true })
-        .click();
-      await expect(
-        properties.getByTestId("person-cutout-quality-fine"),
-      ).toBeVisible();
-      await properties.getByTestId("person-cutout-quality-fine").click();
-      await properties
-        .getByTestId("person-cutout-quality")
-        .locator("..")
-        .locator("summary")
-        .click();
-      await expect(properties.getByText("精细抠像已就绪")).toBeVisible({
-        timeout: 30_000,
-      });
-      await properties.screenshot({
-        path: join(evidenceDirectory, "01-fine-cutout-ready.png"),
-        animations: "disabled",
-      });
+		try {
+			const page = await electronApp.firstWindow();
+			await page.waitForLoadState("domcontentloaded");
+			await page.waitForFunction(
+				() => Boolean(document.querySelector("#root")?.children.length),
+				undefined,
+				{ timeout: 30_000 }
+			);
+			await page.evaluate(() => {
+				localStorage.setItem("hasSeenOnboarding", "true");
+			});
+			await navigateToProjects(page);
+			await createTestProject(page, "Automatic Person Cutout E2E");
+			await uploadTestMedia(page, sourcePath);
+			await page
+				.getByTestId("media-item")
+				.last()
+				.dragTo(page.getByTestId("timeline-track").first());
+			const timelineClip = page.getByTestId("timeline-element").last();
+			await expect(timelineClip).toBeVisible();
+			await timelineClip.click();
+			const properties = page.getByTestId("media-properties");
+			await expect(properties).toBeVisible();
+			await properties
+				.getByTestId("media-properties-visual-tabs")
+				.getByRole("tab", { name: "抠像", exact: true })
+				.click();
+			await expect(
+				properties.getByTestId("person-cutout-quality-fine")
+			).toBeVisible();
+			await properties.getByTestId("person-cutout-quality-fine").click();
+			await properties
+				.getByTestId("person-cutout-quality")
+				.locator("..")
+				.locator("summary")
+				.click();
+			await expect(properties.getByText("精细抠像已就绪")).toBeVisible({
+				timeout: 30_000,
+			});
+			await properties.screenshot({
+				path: join(evidenceDirectory, "01-fine-cutout-ready.png"),
+				animations: "disabled",
+			});
 
-      const startButton = properties.getByRole("button", {
-        name: "开始并应用",
-      });
-      await startButton.click();
-      await expect(properties.getByTestId("person-cutout-result")).toBeVisible({
-        timeout: 120_000,
-      });
-      const exported = await page.evaluate(async (destination) => {
-        const harness = window as unknown as CutoutHarnessWindow;
-        const item = [...harness.__mediaStore.getState().mediaItems]
-          .reverse()
-          .find(
-            (candidate) =>
-              candidate.metadata?.source === "qcut-local-person-cutout",
-          );
-        if (!item) throw new Error("QCut person cutout was not added");
-        const written = await harness.electronAPI.writeFile(
-          destination,
-          await item.file.arrayBuffer(),
-        );
-        const mask = harness.__timelineStore
-          .getState()
-          .tracks.flatMap((track) => track.elements)
-          .flatMap((element) => element.masks ?? [])
-          .find((candidate) => candidate.sourceMediaId === item.id);
-        return {
-          blendImplementation: item.metadata?.blendImplementation,
-          didModelRouteFallback: item.metadata?.didModelRouteFallback,
-          duration: item.duration,
-          hasAlpha: item.metadata?.hasAlpha,
-          hasAudio: item.metadata?.hasAudio,
-          height: item.height,
-          mask,
-          modelRoute: item.metadata?.modelRoute,
-          outputMediaId: item.id,
-          pipelineId: item.metadata?.pipelineId,
-          provider: item.metadata?.provider,
-          refinementProvider: item.metadata?.refinementProvider,
-          requestedModelRoute: item.metadata?.requestedModelRoute,
-          size: item.file.size,
-          width: item.width,
-          written,
-        };
-      }, outputPath);
-      expect(exported).toMatchObject({
-        blendImplementation: expectedBlendImplementation,
-        didModelRouteFallback: expectedRouteFallback,
-        hasAlpha: true,
-        height: expectedHeight,
-        mask: {
-          height: 1,
-          sourceMediaId: exported.outputMediaId,
-          tracking: { source: "qcut-person-matting" },
-          type: "person",
-          width: 1,
-        },
-        modelRoute: expectedActualRoute,
-        ...expectedExecutionDescriptor,
-        requestedModelRoute: expectedRequestedRoute,
-        width: expectedWidth,
-        written: true,
-      });
-      expect(exported.duration).toBeGreaterThan(1.5);
-      expect(exported.size).toBeGreaterThan(10_000);
-      if (exported.hasAudio === false) {
-        await expect(
-          page.locator('video[data-video-id$="-mask-audio"]'),
-        ).toHaveCount(0);
-      }
-      await page.evaluate((sourceMediaId) => {
-        const harness = window as unknown as CutoutHarnessWindow;
-        const element = harness.__timelineStore
-          .getState()
-          .tracks.flatMap((track) => track.elements)
-          .find((candidate) =>
-            candidate.masks?.some(
-              (mask) => mask.sourceMediaId === sourceMediaId,
-            ),
-          );
-        if (!element) throw new Error("Masked timeline clip is missing");
-        harness.__playbackStore.getState().seek(element.startTime + 0.25);
-      }, exported.outputMediaId);
+			const startButton = properties.getByRole("button", {
+				name: "开始并应用",
+			});
+			await startButton.click();
+			await expect(properties.getByTestId("person-cutout-result")).toBeVisible({
+				timeout: 120_000,
+			});
+			const exported = await page.evaluate(async (destination) => {
+				const harness = window as unknown as CutoutHarnessWindow;
+				const item = [...harness.__mediaStore.getState().mediaItems]
+					.reverse()
+					.find(
+						(candidate) =>
+							candidate.metadata?.source === "qcut-local-person-cutout"
+					);
+				if (!item) throw new Error("QCut person cutout was not added");
+				const written = await harness.electronAPI.writeFile(
+					destination,
+					await item.file.arrayBuffer()
+				);
+				const mask = harness.__timelineStore
+					.getState()
+					.tracks.flatMap((track) => track.elements)
+					.flatMap((element) => element.masks ?? [])
+					.find((candidate) => candidate.sourceMediaId === item.id);
+				return {
+					blendImplementation: item.metadata?.blendImplementation,
+					didModelRouteFallback: item.metadata?.didModelRouteFallback,
+					duration: item.duration,
+					hasAlpha: item.metadata?.hasAlpha,
+					hasAudio: item.metadata?.hasAudio,
+					height: item.height,
+					mask,
+					modelRoute: item.metadata?.modelRoute,
+					outputMediaId: item.id,
+					pipelineId: item.metadata?.pipelineId,
+					provider: item.metadata?.provider,
+					refinementProvider: item.metadata?.refinementProvider,
+					requestedModelRoute: item.metadata?.requestedModelRoute,
+					size: item.file.size,
+					width: item.width,
+					written,
+				};
+			}, outputPath);
+			expect(exported).toMatchObject({
+				blendImplementation: expectedBlendImplementation,
+				didModelRouteFallback: expectedRouteFallback,
+				hasAlpha: true,
+				height: expectedHeight,
+				mask: {
+					height: 1,
+					sourceMediaId: exported.outputMediaId,
+					tracking: { source: "qcut-person-matting" },
+					type: "person",
+					width: 1,
+				},
+				modelRoute: expectedActualRoute,
+				...expectedExecutionDescriptor,
+				requestedModelRoute: expectedRequestedRoute,
+				width: expectedWidth,
+				written: true,
+			});
+			expect(exported.duration).toBeGreaterThan(1.5);
+			expect(exported.size).toBeGreaterThan(10_000);
+			if (exported.hasAudio === false) {
+				await expect(
+					page.locator('video[data-video-id$="-mask-audio"]')
+				).toHaveCount(0);
+			}
+			await page.evaluate((sourceMediaId) => {
+				const harness = window as unknown as CutoutHarnessWindow;
+				const element = harness.__timelineStore
+					.getState()
+					.tracks.flatMap((track) => track.elements)
+					.find((candidate) =>
+						candidate.masks?.some(
+							(mask) => mask.sourceMediaId === sourceMediaId
+						)
+					);
+				if (!element) throw new Error("Masked timeline clip is missing");
+				harness.__playbackStore.getState().seek(element.startTime + 0.25);
+			}, exported.outputMediaId);
 
-      const previewPanel = page.getByTestId("preview-panel");
-      const maskVideo = previewPanel.locator(
-        'video[data-video-id*="-mask-"]:not([data-video-id$="-mask-audio"])',
-      );
-      await expect(maskVideo).toHaveCount(1);
-      await expect
-        .poll(
-          () =>
-            maskVideo.evaluate(
-              (video) => (video as HTMLVideoElement).readyState,
-            ),
-          { timeout: 30_000 },
-        )
-        .toBeGreaterThanOrEqual(2);
-      await expect
-        .poll(() =>
-          maskVideo.evaluate((video) => (video as HTMLVideoElement).videoWidth),
-        )
-        .toBe(expectedWidth);
-      let decodedAlphaStats: Record<string, number> | undefined;
-      if (alphaQualityProfile) {
-        decodedAlphaStats = await maskVideo.evaluate(
-          async (element, profile) => {
-            const video = element as HTMLVideoElement;
-            if (Math.abs(video.currentTime - profile.sampleTime) > 0.02) {
-              await new Promise<void>((resolve, reject) => {
-                const timeout = window.setTimeout(
-                  () => reject(new Error("Timed out seeking alpha sample")),
-                  5000,
-                );
-                video.addEventListener(
-                  "seeked",
-                  () => {
-                    window.clearTimeout(timeout);
-                    resolve();
-                  },
-                  { once: true },
-                );
-                video.currentTime = profile.sampleTime;
-              });
-            }
-            const canvas = document.createElement("canvas");
-            canvas.width = video.videoWidth;
-            canvas.height = video.videoHeight;
-            const context = canvas.getContext("2d", {
-              willReadFrequently: true,
-            });
-            if (!context) throw new Error("Unable to inspect decoded alpha");
-            context.drawImage(video, 0, 0);
-            const pixels = context.getImageData(
-              0,
-              0,
-              canvas.width,
-              canvas.height,
-            ).data;
-            const means: Record<string, number> = {};
-            for (const region of profile.regions) {
-              let alphaTotal = 0;
-              for (let y = region.y; y < region.y + region.height; y += 1) {
-                for (let x = region.x; x < region.x + region.width; x += 1) {
-                  alphaTotal += pixels[(y * canvas.width + x) * 4 + 3];
-                }
-              }
-              means[region.name] = alphaTotal / (region.width * region.height);
-            }
-            return means;
-          },
-          alphaQualityProfile,
-        );
-        for (const region of alphaQualityProfile.regions) {
-          const mean = decodedAlphaStats[region.name];
-          expect(Number.isFinite(mean)).toBe(true);
-          if (region.minMean !== undefined) {
-            expect(mean).toBeGreaterThan(region.minMean);
-          }
-          if (region.maxMean !== undefined) {
-            expect(mean).toBeLessThan(region.maxMean);
-          }
-        }
-      }
-      await properties.screenshot({
-        path: join(evidenceDirectory, "02-cutout-completed.png"),
-        animations: "disabled",
-      });
-      await page.evaluate(() => {
-        const harness = window as unknown as CutoutHarnessWindow;
-        harness.__personCutoutStatusObserver?.disconnect();
-        harness.__personCutoutStatusMessages = [];
-        const panel = document.querySelector(
-          '[data-testid="media-properties"]',
-        );
-        if (!panel)
-          throw new Error("Person-cutout properties panel is missing");
-        const recordStatus = () => {
-          const text = panel.textContent ?? "";
-          if (!text.includes("人物蒙版缓存完整")) return;
-          harness.__personCutoutStatusMessages?.push(text);
-        };
-        const observer = new MutationObserver(recordStatus);
-        observer.observe(panel, {
-          characterData: true,
-          childList: true,
-          subtree: true,
-        });
-        harness.__personCutoutStatusObserver = observer;
-        recordStatus();
-      });
-      const secondRunStartedAt = Date.now();
-      await startButton.click();
-      await expect(startButton).toBeDisabled();
-      await expect(startButton).toBeEnabled({ timeout: 120_000 });
-      await expect
-        .poll(() =>
-          page.evaluate(() => {
-            const harness = window as unknown as CutoutHarnessWindow;
-            return (
-              harness.__personCutoutStatusMessages?.some((message) =>
-                message.includes("人物蒙版缓存完整"),
-              ) ?? false
-            );
-          }),
-        )
-        .toBe(true);
-      const cacheHitObserved = true;
-      const secondRun = await page.evaluate(() => {
-        const harness = window as unknown as CutoutHarnessWindow;
-        const items = harness.__mediaStore
-          .getState()
-          .mediaItems.filter(
-            (candidate) =>
-              candidate.metadata?.source === "qcut-local-person-cutout",
-          );
-        const item = items.at(-1);
-        if (!item) throw new Error("Cached QCut person cutout was not added");
-        return {
-          blendImplementation: item.metadata?.blendImplementation,
-          count: items.length,
-          didModelRouteFallback: item.metadata?.didModelRouteFallback,
-          modelRoute: item.metadata?.modelRoute,
-          pipelineId: item.metadata?.pipelineId,
-          provider: item.metadata?.provider,
-          refinementProvider: item.metadata?.refinementProvider,
-          requestedModelRoute: item.metadata?.requestedModelRoute,
-        };
-      });
-      expect(secondRun).toMatchObject({
-        blendImplementation: expectedBlendImplementation,
-        count: 2,
-        didModelRouteFallback: expectedSecondRouteFallback,
-        modelRoute: expectedActualRoute,
-        ...expectedExecutionDescriptor,
-        requestedModelRoute: expectedRequestedRoute,
-      });
-      await page.evaluate(() => {
-        const harness = window as unknown as CutoutHarnessWindow;
-        harness.__personCutoutStatusObserver?.disconnect();
-      });
-      await page.evaluate(() => {
-        const harness = window as unknown as CutoutHarnessWindow;
-        harness.__timelineStore.getState().setSelectedElements([]);
-      });
-      await previewPanel.screenshot({
-        path: join(evidenceDirectory, "03-mask-playing-in-preview.png"),
-        animations: "disabled",
-      });
-      await writeFile(
-        join(evidenceDirectory, "e2e-evidence.json"),
-        `${JSON.stringify(
-          {
-            ...exported,
-            decodedAlphaStats,
-            alphaQualityProfile,
-            cacheHitObserved,
-            secondRun: {
-              ...secondRun,
-              elapsedMs: Date.now() - secondRunStartedAt,
-            },
-            expectedActualRoute,
-            expectedRequestedRoute,
-            expectedRouteFallback,
-            expectedSecondRouteFallback,
-            outputPath,
-            sourcePath,
-            testOutputDirectory: testInfo.outputDir,
-          },
-          null,
-          2,
-        )}\n`,
-      );
-    } finally {
-      await electronApp.close();
-      if (runtimeLogChunks.length > 0) {
-        await writeFile(
-          join(evidenceDirectory, "electron-runtime.log"),
-          runtimeLogChunks.join(""),
-        );
-      }
-      await rm(profileDirectory, { recursive: true, force: true });
-    }
-  });
+			const previewPanel = page.getByTestId("preview-panel");
+			const maskVideo = previewPanel.locator(
+				'video[data-video-id*="-mask-"]:not([data-video-id$="-mask-audio"])'
+			);
+			await expect(maskVideo).toHaveCount(1);
+			await expect
+				.poll(
+					() =>
+						maskVideo.evaluate(
+							(video) => (video as HTMLVideoElement).readyState
+						),
+					{ timeout: 30_000 }
+				)
+				.toBeGreaterThanOrEqual(2);
+			await expect
+				.poll(() =>
+					maskVideo.evaluate((video) => (video as HTMLVideoElement).videoWidth)
+				)
+				.toBe(expectedWidth);
+			let decodedAlphaStats: Record<string, number> | undefined;
+			if (alphaQualityProfile) {
+				decodedAlphaStats = await maskVideo.evaluate(
+					async (element, profile) => {
+						const video = element as HTMLVideoElement;
+						if (Math.abs(video.currentTime - profile.sampleTime) > 0.02) {
+							await new Promise<void>((resolve, reject) => {
+								const timeout = window.setTimeout(
+									() => reject(new Error("Timed out seeking alpha sample")),
+									5000
+								);
+								video.addEventListener(
+									"seeked",
+									() => {
+										window.clearTimeout(timeout);
+										resolve();
+									},
+									{ once: true }
+								);
+								video.currentTime = profile.sampleTime;
+							});
+						}
+						const canvas = document.createElement("canvas");
+						canvas.width = video.videoWidth;
+						canvas.height = video.videoHeight;
+						const context = canvas.getContext("2d", {
+							willReadFrequently: true,
+						});
+						if (!context) throw new Error("Unable to inspect decoded alpha");
+						context.drawImage(video, 0, 0);
+						const pixels = context.getImageData(
+							0,
+							0,
+							canvas.width,
+							canvas.height
+						).data;
+						const means: Record<string, number> = {};
+						for (const region of profile.regions) {
+							let alphaTotal = 0;
+							for (let y = region.y; y < region.y + region.height; y += 1) {
+								for (let x = region.x; x < region.x + region.width; x += 1) {
+									alphaTotal += pixels[(y * canvas.width + x) * 4 + 3];
+								}
+							}
+							means[region.name] = alphaTotal / (region.width * region.height);
+						}
+						return means;
+					},
+					alphaQualityProfile
+				);
+				for (const region of alphaQualityProfile.regions) {
+					const mean = decodedAlphaStats[region.name];
+					expect(Number.isFinite(mean)).toBe(true);
+					if (region.minMean !== undefined) {
+						expect(mean).toBeGreaterThan(region.minMean);
+					}
+					if (region.maxMean !== undefined) {
+						expect(mean).toBeLessThan(region.maxMean);
+					}
+				}
+			}
+			await properties.screenshot({
+				path: join(evidenceDirectory, "02-cutout-completed.png"),
+				animations: "disabled",
+			});
+			await page.evaluate(() => {
+				const harness = window as unknown as CutoutHarnessWindow;
+				harness.__personCutoutStatusObserver?.disconnect();
+				harness.__personCutoutStatusMessages = [];
+				const panel = document.querySelector(
+					'[data-testid="media-properties"]'
+				);
+				if (!panel)
+					throw new Error("Person-cutout properties panel is missing");
+				const recordStatus = () => {
+					const text = panel.textContent ?? "";
+					if (!text.includes("人物蒙版缓存完整")) return;
+					harness.__personCutoutStatusMessages?.push(text);
+				};
+				const observer = new MutationObserver(recordStatus);
+				observer.observe(panel, {
+					characterData: true,
+					childList: true,
+					subtree: true,
+				});
+				harness.__personCutoutStatusObserver = observer;
+				recordStatus();
+			});
+			const secondRunStartedAt = Date.now();
+			await startButton.click();
+			await expect(startButton).toBeDisabled();
+			await expect(startButton).toBeEnabled({ timeout: 120_000 });
+			await expect
+				.poll(() =>
+					page.evaluate(() => {
+						const harness = window as unknown as CutoutHarnessWindow;
+						return (
+							harness.__personCutoutStatusMessages?.some((message) =>
+								message.includes("人物蒙版缓存完整")
+							) ?? false
+						);
+					})
+				)
+				.toBe(true);
+			const cacheHitObserved = true;
+			const secondRun = await page.evaluate(() => {
+				const harness = window as unknown as CutoutHarnessWindow;
+				const items = harness.__mediaStore
+					.getState()
+					.mediaItems.filter(
+						(candidate) =>
+							candidate.metadata?.source === "qcut-local-person-cutout"
+					);
+				const item = items.at(-1);
+				if (!item) throw new Error("Cached QCut person cutout was not added");
+				return {
+					blendImplementation: item.metadata?.blendImplementation,
+					count: items.length,
+					didModelRouteFallback: item.metadata?.didModelRouteFallback,
+					modelRoute: item.metadata?.modelRoute,
+					pipelineId: item.metadata?.pipelineId,
+					provider: item.metadata?.provider,
+					refinementProvider: item.metadata?.refinementProvider,
+					requestedModelRoute: item.metadata?.requestedModelRoute,
+				};
+			});
+			expect(secondRun).toMatchObject({
+				blendImplementation: expectedBlendImplementation,
+				count: 2,
+				didModelRouteFallback: expectedSecondRouteFallback,
+				modelRoute: expectedActualRoute,
+				...expectedExecutionDescriptor,
+				requestedModelRoute: expectedRequestedRoute,
+			});
+			await page.evaluate(() => {
+				const harness = window as unknown as CutoutHarnessWindow;
+				harness.__personCutoutStatusObserver?.disconnect();
+			});
+			await page.evaluate(() => {
+				const harness = window as unknown as CutoutHarnessWindow;
+				harness.__timelineStore.getState().setSelectedElements([]);
+			});
+			await previewPanel.screenshot({
+				path: join(evidenceDirectory, "03-mask-playing-in-preview.png"),
+				animations: "disabled",
+			});
+			await writeFile(
+				join(evidenceDirectory, "e2e-evidence.json"),
+				`${JSON.stringify(
+					{
+						...exported,
+						decodedAlphaStats,
+						alphaQualityProfile,
+						cacheHitObserved,
+						secondRun: {
+							...secondRun,
+							elapsedMs: Date.now() - secondRunStartedAt,
+						},
+						expectedActualRoute,
+						expectedRequestedRoute,
+						expectedRouteFallback,
+						expectedSecondRouteFallback,
+						outputPath,
+						sourcePath,
+						testOutputDirectory: testInfo.outputDir,
+					},
+					null,
+					2
+				)}\n`
+			);
+		} finally {
+			await electronApp.close();
+			if (runtimeLogChunks.length > 0) {
+				await writeFile(
+					join(evidenceDirectory, "electron-runtime.log"),
+					runtimeLogChunks.join("")
+				);
+			}
+			await rm(profileDirectory, { recursive: true, force: true });
+		}
+	});
 });

--- a/qcut/apps/web/src/test/e2e/jianying-person-cutout.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/jianying-person-cutout.e2e.ts
@@ -5,284 +5,572 @@ import { basename, join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "@playwright/test";
 import {
-	createTestProject,
-	navigateToProjects,
+  createTestProject,
+  navigateToProjects,
 } from "./helpers/electron-helpers";
 import { uploadTestMedia } from "./helpers/e2e-panel-helpers";
 
 const sourcePath =
-	process.env.QCUT_PERSON_VIDEO_PATH ??
-	"/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/real-person-input-2s.mp4";
+  process.env.QCUT_PERSON_VIDEO_PATH ??
+  "/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/real-person-input-2s.mp4";
 const evidenceDirectory =
-	process.env.QCUT_PERSON_CUTOUT_EVIDENCE_DIRECTORY ??
-	"/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-native-metal";
+  process.env.QCUT_PERSON_CUTOUT_EVIDENCE_DIRECTORY ??
+  "/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-compatible";
 const outputPath = join(evidenceDirectory, "desktop-person-cutout.webm");
-const expectedRoute =
-	process.env.QCUT_PERSON_CUTOUT_EXPECTED_ROUTE ?? "portrait-gru";
+const expectedRequestedRoute =
+  process.env.QCUT_PERSON_CUTOUT_EXPECTED_REQUESTED_ROUTE ?? "auto";
+const expectedActualRouteValue =
+  process.env.QCUT_PERSON_CUTOUT_EXPECTED_ACTUAL_ROUTE ?? "portrait-gru";
+const personCutoutRoutes = [
+  "portrait-gru",
+  "video-object",
+  "saliency-script",
+] as const;
+type PersonCutoutRoute = (typeof personCutoutRoutes)[number];
+if (
+  !personCutoutRoutes.includes(expectedActualRouteValue as PersonCutoutRoute)
+) {
+  throw new Error(
+    `Unsupported expected person-cutout route: ${expectedActualRouteValue}`,
+  );
+}
+const expectedActualRoute = expectedActualRouteValue as PersonCutoutRoute;
+const expectedRouteFallback =
+  process.env.QCUT_PERSON_CUTOUT_EXPECTED_ROUTE_FALLBACK === undefined
+    ? true
+    : process.env.QCUT_PERSON_CUTOUT_EXPECTED_ROUTE_FALLBACK === "1";
+const expectedSecondRouteFallback =
+  process.env.QCUT_PERSON_CUTOUT_EXPECTED_SECOND_ROUTE_FALLBACK === "1";
 const expectedBlendImplementation =
-	expectedRoute === "portrait-gru"
-		? "TEMattingBlendEffectV2-native-metal"
-		: "TEMattingBlendEffectV2-compatible";
+  process.env.QCUT_PERSON_CUTOUT_EXPECTED_BLEND ??
+  (expectedActualRoute === "video-object"
+    ? "TEMattingBlendEffectV2-vendor-exact"
+    : "TEMattingBlendEffectV2-compatible");
+const expectedWidth = Number(
+  process.env.QCUT_PERSON_CUTOUT_EXPECTED_WIDTH ?? 360,
+);
+const expectedHeight = Number(
+  process.env.QCUT_PERSON_CUTOUT_EXPECTED_HEIGHT ?? 640,
+);
+
+interface ExpectedExecutionDescriptor {
+  pipelineId: string;
+  provider: string;
+  refinementProvider: string;
+}
+
+const portraitDescriptor: ExpectedExecutionDescriptor =
+  process.env.QCUT_DISABLE_VISION_PERSON_FUSION === "1"
+    ? {
+        pipelineId: "qcut-gru-only-v1",
+        provider: "qcut-local-person-matting-v1",
+        refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+      }
+    : {
+        pipelineId: "qcut-gru-vision-fusion-v1",
+        provider: "qcut-local-person-matting-v1",
+        refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+      };
+const expectedDescriptorByRoute: Record<
+  PersonCutoutRoute,
+  ExpectedExecutionDescriptor
+> = {
+  "portrait-gru": portraitDescriptor,
+  "video-object": {
+    pipelineId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+    provider: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+    refinementProvider: "vendor-v2-exact-no-qcut-refinement-v1",
+  },
+  "saliency-script": {
+    pipelineId: "qcut-saliency-script-interop-experimental-v1",
+    provider: "qcut-saliency-interop-experimental-v1",
+    refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
+  },
+};
+const expectedExecutionDescriptor =
+  expectedDescriptorByRoute[expectedActualRoute];
+
+interface AlphaQualityRegion {
+  height: number;
+  maxMean?: number;
+  minMean?: number;
+  name: string;
+  width: number;
+  x: number;
+  y: number;
+}
+
+interface AlphaQualityProfile {
+  regions: AlphaQualityRegion[];
+  sampleTime: number;
+}
+
+const alphaQualityProfiles: Record<string, AlphaQualityProfile> = {
+  "real-person-input-2s.mp4": {
+    sampleTime: 0.25,
+    regions: [
+      {
+        name: "leftPersonCore",
+        x: 15,
+        y: 15,
+        width: 135,
+        height: 185,
+        minMean: 100,
+      },
+      {
+        name: "foregroundHands",
+        x: 55,
+        y: 285,
+        width: 230,
+        height: 205,
+        minMean: 80,
+      },
+      {
+        name: "upperRightBackground",
+        x: 270,
+        y: 60,
+        width: 80,
+        height: 130,
+        maxMean: 64,
+      },
+    ],
+  },
+  "real-person-wide-2s.mp4": {
+    sampleTime: 0.25,
+    regions: [
+      {
+        name: "topBackground",
+        x: 0,
+        y: 0,
+        width: 360,
+        height: 32,
+        maxMean: 8,
+      },
+      {
+        name: "centerPerson",
+        x: 90,
+        y: 160,
+        width: 180,
+        height: 320,
+        minMean: 100,
+      },
+    ],
+  },
+};
+const alphaQualityProfile = alphaQualityProfiles[basename(sourcePath)];
 
 interface CutoutMediaItem {
-	id: string;
-	duration: number;
-	file: File;
-	height: number;
-	metadata?: {
-		blendImplementation?: string;
-		hasAlpha?: boolean;
-		source?: string;
-	};
-	width: number;
+  id: string;
+  duration: number;
+  file: File;
+  height: number;
+  metadata?: {
+    blendImplementation?: string;
+    didModelRouteFallback?: boolean;
+    hasAlpha?: boolean;
+    hasAudio?: boolean;
+    modelRoute?: string;
+    pipelineId?: string;
+    provider?: string;
+    refinementProvider?: string;
+    requestedModelRoute?: string;
+    source?: string;
+  };
+  width: number;
 }
 
 interface CutoutHarnessWindow extends Window {
-	__mediaStore: {
-		getState: () => { mediaItems: CutoutMediaItem[] };
-	};
-	__timelineStore: {
-		getState: () => {
-			setSelectedElements: (
-				elements: Array<{ trackId: string; elementId: string }>
-			) => void;
-			tracks: Array<{
-				elements: Array<{
-					id: string;
-					masks?: Array<{
-						sourceMediaId?: string;
-						tracking?: { source?: string };
-						type: string;
-					}>;
-					startTime: number;
-					type: string;
-				}>;
-			}>;
-		};
-	};
-	__playbackStore: {
-		getState: () => { seek: (time: number) => void };
-	};
-	electronAPI: {
-		writeFile: (path: string, bytes: ArrayBuffer) => Promise<boolean>;
-	};
+  __personCutoutStatusMessages?: string[];
+  __personCutoutStatusObserver?: MutationObserver;
+  __mediaStore: {
+    getState: () => { mediaItems: CutoutMediaItem[] };
+  };
+  __timelineStore: {
+    getState: () => {
+      setSelectedElements: (
+        elements: Array<{ trackId: string; elementId: string }>,
+      ) => void;
+      tracks: Array<{
+        elements: Array<{
+          id: string;
+          masks?: Array<{
+            sourceMediaId?: string;
+            tracking?: { source?: string };
+            type: string;
+          }>;
+          startTime: number;
+          type: string;
+        }>;
+      }>;
+    };
+  };
+  __playbackStore: {
+    getState: () => { seek: (time: number) => void };
+  };
+  electronAPI: {
+    writeFile: (path: string, bytes: ArrayBuffer) => Promise<boolean>;
+  };
 }
 
-test.describe("Jianying-routed local person cutout", () => {
-	test.setTimeout(180_000);
-	test.skip(!existsSync(sourcePath), "Real-person video fixture is missing");
+test.describe("QCut local person cutout", () => {
+  test.setTimeout(180_000);
+  test.skip(!existsSync(sourcePath), "Real-person video fixture is missing");
 
-	// biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixtures before testInfo.
-	test("renders, attaches, and plays a routed native mask in QCut", async ({}, testInfo) => {
-		const profileDirectory = join(
-			tmpdir(),
-			`qcut-jianying-person-cutout-${process.pid}-${Date.now()}`
-		);
-		await rm(evidenceDirectory, { recursive: true, force: true });
-		await mkdir(evidenceDirectory, { recursive: true });
-		const electronApp = await electron.launch({
-			args: [`--user-data-dir=${profileDirectory}`, "dist/electron/main.js"],
-			cwd: process.cwd(),
-			env: { ...process.env, NODE_ENV: "test" },
-		});
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixtures before testInfo.
+  test("renders, attaches, and plays an automatically routed mask", async ({}, testInfo) => {
+    const profileDirectory = join(
+      tmpdir(),
+      `qcut-jianying-person-cutout-${process.pid}-${Date.now()}`,
+    );
+    const cacheRoot = join(profileDirectory, "person-cutout-cache");
+    await rm(evidenceDirectory, { recursive: true, force: true });
+    await mkdir(evidenceDirectory, { recursive: true });
+    const electronApp = await electron.launch({
+      args: [`--user-data-dir=${profileDirectory}`, "dist/electron/main.js"],
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NODE_ENV: "test",
+        QCUT_PERSON_CUTOUT_CACHE_ROOT: cacheRoot,
+      },
+    });
+    const runtimeLogChunks: string[] = [];
+    if (process.env.QCUT_PERSON_CUTOUT_CAPTURE_RUNTIME_LOG === "1") {
+      for (const stream of [
+        electronApp.process().stdout,
+        electronApp.process().stderr,
+      ]) {
+        stream?.on("data", (chunk: Buffer) => {
+          runtimeLogChunks.push(chunk.toString("utf8"));
+        });
+      }
+    }
 
-		try {
-			const page = await electronApp.firstWindow();
-			await page.waitForLoadState("domcontentloaded");
-			await page.waitForFunction(
-				() => Boolean(document.querySelector("#root")?.children.length),
-				undefined,
-				{ timeout: 30_000 }
-			);
-			await page.evaluate(() => {
-				localStorage.setItem("hasSeenOnboarding", "true");
-			});
-			await navigateToProjects(page);
-			await createTestProject(page, "Native Metal Person Cutout E2E");
-			await uploadTestMedia(page, sourcePath);
-			await page
-				.getByTestId("media-item")
-				.last()
-				.dragTo(page.getByTestId("timeline-track").first());
-			const timelineClip = page.getByTestId("timeline-element").last();
-			await expect(timelineClip).toBeVisible();
-			await timelineClip.click();
-			const properties = page.getByTestId("media-properties");
-			await expect(properties).toBeVisible();
-			await properties
-				.getByTestId("media-properties-visual-tabs")
-				.getByRole("tab", { name: "抠像", exact: true })
-				.click();
-			await expect(
-				properties.getByTestId("person-cutout-quality-fine")
-			).toBeVisible();
-			await properties.getByTestId("person-cutout-quality-fine").click();
-			await properties
-				.getByTestId("person-cutout-quality")
-				.locator("..")
-				.locator("summary")
-				.click();
-			await expect(properties.getByText("精细抠像已就绪")).toBeVisible({
-				timeout: 30_000,
-			});
-			await properties.screenshot({
-				path: join(evidenceDirectory, "01-fine-cutout-ready.png"),
-				animations: "disabled",
-			});
+    try {
+      const page = await electronApp.firstWindow();
+      await page.waitForLoadState("domcontentloaded");
+      await page.waitForFunction(
+        () => Boolean(document.querySelector("#root")?.children.length),
+        undefined,
+        { timeout: 30_000 },
+      );
+      await page.evaluate(() => {
+        localStorage.setItem("hasSeenOnboarding", "true");
+      });
+      await navigateToProjects(page);
+      await createTestProject(page, "Automatic Person Cutout E2E");
+      await uploadTestMedia(page, sourcePath);
+      await page
+        .getByTestId("media-item")
+        .last()
+        .dragTo(page.getByTestId("timeline-track").first());
+      const timelineClip = page.getByTestId("timeline-element").last();
+      await expect(timelineClip).toBeVisible();
+      await timelineClip.click();
+      const properties = page.getByTestId("media-properties");
+      await expect(properties).toBeVisible();
+      await properties
+        .getByTestId("media-properties-visual-tabs")
+        .getByRole("tab", { name: "抠像", exact: true })
+        .click();
+      await expect(
+        properties.getByTestId("person-cutout-quality-fine"),
+      ).toBeVisible();
+      await properties.getByTestId("person-cutout-quality-fine").click();
+      await properties
+        .getByTestId("person-cutout-quality")
+        .locator("..")
+        .locator("summary")
+        .click();
+      await expect(properties.getByText("精细抠像已就绪")).toBeVisible({
+        timeout: 30_000,
+      });
+      await properties.screenshot({
+        path: join(evidenceDirectory, "01-fine-cutout-ready.png"),
+        animations: "disabled",
+      });
 
-			await properties.getByRole("button", { name: "开始并应用" }).click();
-			await expect(properties.getByTestId("person-cutout-result")).toBeVisible({
-				timeout: 120_000,
-			});
-			const exported = await page.evaluate(async (destination) => {
-				const harness = window as unknown as CutoutHarnessWindow;
-				const item = [...harness.__mediaStore.getState().mediaItems]
-					.reverse()
-					.find(
-						(candidate) =>
-							candidate.metadata?.source === "jianying-gru-person-cutout"
-					);
-				if (!item) throw new Error("Native person cutout was not added");
-				const written = await harness.electronAPI.writeFile(
-					destination,
-					await item.file.arrayBuffer()
-				);
-				const mask = harness.__timelineStore
-					.getState()
-					.tracks.flatMap((track) => track.elements)
-					.flatMap((element) => element.masks ?? [])
-					.find((candidate) => candidate.sourceMediaId === item.id);
-				return {
-					blendImplementation: item.metadata?.blendImplementation,
-					duration: item.duration,
-					hasAlpha: item.metadata?.hasAlpha,
-					height: item.height,
-					mask,
-					outputMediaId: item.id,
-					size: item.file.size,
-					width: item.width,
-					written,
-				};
-			}, outputPath);
-			expect(exported).toMatchObject({
-				blendImplementation: expectedBlendImplementation,
-				hasAlpha: true,
-				height: 640,
-				mask: {
-					height: 1,
-					sourceMediaId: exported.outputMediaId,
-					tracking: { source: "jianying-gru" },
-					type: "person",
-					width: 1,
-				},
-				width: 360,
-				written: true,
-			});
-			expect(exported.duration).toBeGreaterThan(
-				expectedRoute === "saliency-script" ? 0.4 : 1.5
-			);
-			expect(exported.size).toBeGreaterThan(10_000);
-			await page.evaluate((sourceMediaId) => {
-				const harness = window as unknown as CutoutHarnessWindow;
-				const element = harness.__timelineStore
-					.getState()
-					.tracks.flatMap((track) => track.elements)
-					.find((candidate) =>
-						candidate.masks?.some(
-							(mask) => mask.sourceMediaId === sourceMediaId
-						)
-					);
-				if (!element) throw new Error("Masked timeline clip is missing");
-				harness.__playbackStore.getState().seek(element.startTime + 0.25);
-			}, exported.outputMediaId);
+      const startButton = properties.getByRole("button", {
+        name: "开始并应用",
+      });
+      await startButton.click();
+      await expect(properties.getByTestId("person-cutout-result")).toBeVisible({
+        timeout: 120_000,
+      });
+      const exported = await page.evaluate(async (destination) => {
+        const harness = window as unknown as CutoutHarnessWindow;
+        const item = [...harness.__mediaStore.getState().mediaItems]
+          .reverse()
+          .find(
+            (candidate) =>
+              candidate.metadata?.source === "qcut-local-person-cutout",
+          );
+        if (!item) throw new Error("QCut person cutout was not added");
+        const written = await harness.electronAPI.writeFile(
+          destination,
+          await item.file.arrayBuffer(),
+        );
+        const mask = harness.__timelineStore
+          .getState()
+          .tracks.flatMap((track) => track.elements)
+          .flatMap((element) => element.masks ?? [])
+          .find((candidate) => candidate.sourceMediaId === item.id);
+        return {
+          blendImplementation: item.metadata?.blendImplementation,
+          didModelRouteFallback: item.metadata?.didModelRouteFallback,
+          duration: item.duration,
+          hasAlpha: item.metadata?.hasAlpha,
+          hasAudio: item.metadata?.hasAudio,
+          height: item.height,
+          mask,
+          modelRoute: item.metadata?.modelRoute,
+          outputMediaId: item.id,
+          pipelineId: item.metadata?.pipelineId,
+          provider: item.metadata?.provider,
+          refinementProvider: item.metadata?.refinementProvider,
+          requestedModelRoute: item.metadata?.requestedModelRoute,
+          size: item.file.size,
+          width: item.width,
+          written,
+        };
+      }, outputPath);
+      expect(exported).toMatchObject({
+        blendImplementation: expectedBlendImplementation,
+        didModelRouteFallback: expectedRouteFallback,
+        hasAlpha: true,
+        height: expectedHeight,
+        mask: {
+          height: 1,
+          sourceMediaId: exported.outputMediaId,
+          tracking: { source: "qcut-person-matting" },
+          type: "person",
+          width: 1,
+        },
+        modelRoute: expectedActualRoute,
+        ...expectedExecutionDescriptor,
+        requestedModelRoute: expectedRequestedRoute,
+        width: expectedWidth,
+        written: true,
+      });
+      expect(exported.duration).toBeGreaterThan(1.5);
+      expect(exported.size).toBeGreaterThan(10_000);
+      if (exported.hasAudio === false) {
+        await expect(
+          page.locator('video[data-video-id$="-mask-audio"]'),
+        ).toHaveCount(0);
+      }
+      await page.evaluate((sourceMediaId) => {
+        const harness = window as unknown as CutoutHarnessWindow;
+        const element = harness.__timelineStore
+          .getState()
+          .tracks.flatMap((track) => track.elements)
+          .find((candidate) =>
+            candidate.masks?.some(
+              (mask) => mask.sourceMediaId === sourceMediaId,
+            ),
+          );
+        if (!element) throw new Error("Masked timeline clip is missing");
+        harness.__playbackStore.getState().seek(element.startTime + 0.25);
+      }, exported.outputMediaId);
 
-			const previewPanel = page.getByTestId("preview-panel");
-			const maskVideo = previewPanel.locator(
-				'video[data-video-id*="-mask-"]:not([data-video-id$="-mask-audio"])'
-			);
-			await expect(maskVideo).toHaveCount(1);
-			await expect
-				.poll(
-					() =>
-						maskVideo.evaluate(
-							(video) => (video as HTMLVideoElement).readyState
-						),
-					{ timeout: 30_000 }
-				)
-				.toBeGreaterThanOrEqual(2);
-			await expect
-				.poll(() =>
-					maskVideo.evaluate((video) => (video as HTMLVideoElement).videoWidth)
-				)
-				.toBe(360);
-			let decodedAlphaStats:
-				| { centerMean: number; topBandMean: number }
-				| undefined;
-			if (basename(sourcePath) === "real-person-wide-2s.mp4") {
-				decodedAlphaStats = await maskVideo.evaluate((element) => {
-					const video = element as HTMLVideoElement;
-					const canvas = document.createElement("canvas");
-					canvas.width = video.videoWidth;
-					canvas.height = video.videoHeight;
-					const context = canvas.getContext("2d", { willReadFrequently: true });
-					if (!context) throw new Error("Unable to inspect decoded alpha");
-					context.drawImage(video, 0, 0);
-					const pixels = context.getImageData(
-						0,
-						0,
-						canvas.width,
-						canvas.height
-					).data;
-					let topBandAlpha = 0;
-					for (let y = 0; y < 32; y += 1) {
-						for (let x = 0; x < canvas.width; x += 1) {
-							topBandAlpha += pixels[(y * canvas.width + x) * 4 + 3];
-						}
-					}
-					let centerAlpha = 0;
-					for (let y = 160; y < 480; y += 1) {
-						for (let x = 90; x < 270; x += 1) {
-							centerAlpha += pixels[(y * canvas.width + x) * 4 + 3];
-						}
-					}
-					return {
-						centerMean: centerAlpha / (180 * 320),
-						topBandMean: topBandAlpha / (canvas.width * 32),
-					};
-				});
-				expect(decodedAlphaStats.topBandMean).toBeLessThan(1);
-				expect(decodedAlphaStats.centerMean).toBeGreaterThan(100);
-			}
-			await properties.screenshot({
-				path: join(evidenceDirectory, "02-cutout-completed.png"),
-				animations: "disabled",
-			});
-			await page.evaluate(() => {
-				const harness = window as unknown as CutoutHarnessWindow;
-				harness.__timelineStore.getState().setSelectedElements([]);
-			});
-			await previewPanel.screenshot({
-				path: join(evidenceDirectory, "03-mask-playing-in-preview.png"),
-				animations: "disabled",
-			});
-			await writeFile(
-				join(evidenceDirectory, "e2e-evidence.json"),
-				`${JSON.stringify(
-					{
-						...exported,
-						decodedAlphaStats,
-						expectedRoute,
-						outputPath,
-						sourcePath,
-						testOutputDirectory: testInfo.outputDir,
-					},
-					null,
-					2
-				)}\n`
-			);
-		} finally {
-			await electronApp.close();
-			await rm(profileDirectory, { recursive: true, force: true });
-		}
-	});
+      const previewPanel = page.getByTestId("preview-panel");
+      const maskVideo = previewPanel.locator(
+        'video[data-video-id*="-mask-"]:not([data-video-id$="-mask-audio"])',
+      );
+      await expect(maskVideo).toHaveCount(1);
+      await expect
+        .poll(
+          () =>
+            maskVideo.evaluate(
+              (video) => (video as HTMLVideoElement).readyState,
+            ),
+          { timeout: 30_000 },
+        )
+        .toBeGreaterThanOrEqual(2);
+      await expect
+        .poll(() =>
+          maskVideo.evaluate((video) => (video as HTMLVideoElement).videoWidth),
+        )
+        .toBe(expectedWidth);
+      let decodedAlphaStats: Record<string, number> | undefined;
+      if (alphaQualityProfile) {
+        decodedAlphaStats = await maskVideo.evaluate(
+          async (element, profile) => {
+            const video = element as HTMLVideoElement;
+            if (Math.abs(video.currentTime - profile.sampleTime) > 0.02) {
+              await new Promise<void>((resolve, reject) => {
+                const timeout = window.setTimeout(
+                  () => reject(new Error("Timed out seeking alpha sample")),
+                  5000,
+                );
+                video.addEventListener(
+                  "seeked",
+                  () => {
+                    window.clearTimeout(timeout);
+                    resolve();
+                  },
+                  { once: true },
+                );
+                video.currentTime = profile.sampleTime;
+              });
+            }
+            const canvas = document.createElement("canvas");
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            const context = canvas.getContext("2d", {
+              willReadFrequently: true,
+            });
+            if (!context) throw new Error("Unable to inspect decoded alpha");
+            context.drawImage(video, 0, 0);
+            const pixels = context.getImageData(
+              0,
+              0,
+              canvas.width,
+              canvas.height,
+            ).data;
+            const means: Record<string, number> = {};
+            for (const region of profile.regions) {
+              let alphaTotal = 0;
+              for (let y = region.y; y < region.y + region.height; y += 1) {
+                for (let x = region.x; x < region.x + region.width; x += 1) {
+                  alphaTotal += pixels[(y * canvas.width + x) * 4 + 3];
+                }
+              }
+              means[region.name] = alphaTotal / (region.width * region.height);
+            }
+            return means;
+          },
+          alphaQualityProfile,
+        );
+        for (const region of alphaQualityProfile.regions) {
+          const mean = decodedAlphaStats[region.name];
+          expect(Number.isFinite(mean)).toBe(true);
+          if (region.minMean !== undefined) {
+            expect(mean).toBeGreaterThan(region.minMean);
+          }
+          if (region.maxMean !== undefined) {
+            expect(mean).toBeLessThan(region.maxMean);
+          }
+        }
+      }
+      await properties.screenshot({
+        path: join(evidenceDirectory, "02-cutout-completed.png"),
+        animations: "disabled",
+      });
+      await page.evaluate(() => {
+        const harness = window as unknown as CutoutHarnessWindow;
+        harness.__personCutoutStatusObserver?.disconnect();
+        harness.__personCutoutStatusMessages = [];
+        const panel = document.querySelector(
+          '[data-testid="media-properties"]',
+        );
+        if (!panel)
+          throw new Error("Person-cutout properties panel is missing");
+        const recordStatus = () => {
+          const text = panel.textContent ?? "";
+          if (!text.includes("人物蒙版缓存完整")) return;
+          harness.__personCutoutStatusMessages?.push(text);
+        };
+        const observer = new MutationObserver(recordStatus);
+        observer.observe(panel, {
+          characterData: true,
+          childList: true,
+          subtree: true,
+        });
+        harness.__personCutoutStatusObserver = observer;
+        recordStatus();
+      });
+      const secondRunStartedAt = Date.now();
+      await startButton.click();
+      await expect(startButton).toBeDisabled();
+      await expect(startButton).toBeEnabled({ timeout: 120_000 });
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const harness = window as unknown as CutoutHarnessWindow;
+            return (
+              harness.__personCutoutStatusMessages?.some((message) =>
+                message.includes("人物蒙版缓存完整"),
+              ) ?? false
+            );
+          }),
+        )
+        .toBe(true);
+      const cacheHitObserved = true;
+      const secondRun = await page.evaluate(() => {
+        const harness = window as unknown as CutoutHarnessWindow;
+        const items = harness.__mediaStore
+          .getState()
+          .mediaItems.filter(
+            (candidate) =>
+              candidate.metadata?.source === "qcut-local-person-cutout",
+          );
+        const item = items.at(-1);
+        if (!item) throw new Error("Cached QCut person cutout was not added");
+        return {
+          blendImplementation: item.metadata?.blendImplementation,
+          count: items.length,
+          didModelRouteFallback: item.metadata?.didModelRouteFallback,
+          modelRoute: item.metadata?.modelRoute,
+          pipelineId: item.metadata?.pipelineId,
+          provider: item.metadata?.provider,
+          refinementProvider: item.metadata?.refinementProvider,
+          requestedModelRoute: item.metadata?.requestedModelRoute,
+        };
+      });
+      expect(secondRun).toMatchObject({
+        blendImplementation: expectedBlendImplementation,
+        count: 2,
+        didModelRouteFallback: expectedSecondRouteFallback,
+        modelRoute: expectedActualRoute,
+        ...expectedExecutionDescriptor,
+        requestedModelRoute: expectedRequestedRoute,
+      });
+      await page.evaluate(() => {
+        const harness = window as unknown as CutoutHarnessWindow;
+        harness.__personCutoutStatusObserver?.disconnect();
+      });
+      await page.evaluate(() => {
+        const harness = window as unknown as CutoutHarnessWindow;
+        harness.__timelineStore.getState().setSelectedElements([]);
+      });
+      await previewPanel.screenshot({
+        path: join(evidenceDirectory, "03-mask-playing-in-preview.png"),
+        animations: "disabled",
+      });
+      await writeFile(
+        join(evidenceDirectory, "e2e-evidence.json"),
+        `${JSON.stringify(
+          {
+            ...exported,
+            decodedAlphaStats,
+            alphaQualityProfile,
+            cacheHitObserved,
+            secondRun: {
+              ...secondRun,
+              elapsedMs: Date.now() - secondRunStartedAt,
+            },
+            expectedActualRoute,
+            expectedRequestedRoute,
+            expectedRouteFallback,
+            expectedSecondRouteFallback,
+            outputPath,
+            sourcePath,
+            testOutputDirectory: testInfo.outputDir,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } finally {
+      await electronApp.close();
+      if (runtimeLogChunks.length > 0) {
+        await writeFile(
+          join(evidenceDirectory, "electron-runtime.log"),
+          runtimeLogChunks.join(""),
+        );
+      }
+      await rm(profileDirectory, { recursive: true, force: true });
+    }
+  });
 });

--- a/qcut/apps/web/src/types/electron/api-jianying-person-cutout.ts
+++ b/qcut/apps/web/src/types/electron/api-jianying-person-cutout.ts
@@ -10,4 +10,5 @@ export type {
 	JianyingPersonCutoutRenderResult,
 	JianyingPersonCutoutStatus,
 	TemattingBlendImplementation,
+	TemattingOutputBlendImplementation,
 } from "../../../../../electron/jianying-person-cutout-contract";

--- a/qcut/apps/web/src/types/electron/api-jianying-person-cutout.ts
+++ b/qcut/apps/web/src/types/electron/api-jianying-person-cutout.ts
@@ -1,0 +1,13 @@
+import type { JianyingPersonCutoutAPI } from "../../../../../electron/jianying-person-cutout-contract";
+
+export interface ElectronJianyingPersonCutoutOps {
+	jianyingPersonCutout?: JianyingPersonCutoutAPI;
+}
+
+export type {
+	JianyingPersonCutoutAPI,
+	JianyingPersonCutoutRenderRequest,
+	JianyingPersonCutoutRenderResult,
+	JianyingPersonCutoutStatus,
+	TemattingBlendImplementation,
+} from "../../../../../electron/jianying-person-cutout-contract";

--- a/qcut/apps/web/src/types/electron/electron-api.ts
+++ b/qcut/apps/web/src/types/electron/electron-api.ts
@@ -46,6 +46,7 @@ import type { ElectronJianyingEffectOps } from "./api-jianying-effects";
 import type { ElectronJianyingTransitionOps } from "./api-jianying-transitions";
 import type { ElectronJianyingFilterLabOps } from "./api-jianying-filter-lab";
 import type { ElectronJianyingPortraitAdjustmentOps } from "./api-jianying-portrait-adjustment";
+import type { ElectronJianyingPersonCutoutOps } from "./api-jianying-person-cutout";
 import type { ElectronJianyingFontLabOps } from "./api-jianying-font-lab";
 import type { ElectronJianyingTextStyleLabOps } from "./api-jianying-text-style-lab";
 import type { ElectronJianyingTextRuntimeOps } from "./api-jianying-text-runtime";
@@ -100,6 +101,7 @@ export interface ElectronAPI
 		ElectronJianyingEffectOps,
 		ElectronJianyingFilterLabOps,
 		ElectronJianyingPortraitAdjustmentOps,
+		ElectronJianyingPersonCutoutOps,
 		ElectronJianyingFontLabOps,
 		ElectronJianyingTextStyleLabOps,
 		ElectronJianyingTextRuntimeOps,

--- a/qcut/build/entitlements.transition-bridge.mac.plist
+++ b/qcut/build/entitlements.transition-bridge.mac.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Only the native helper may resolve dependencies from the user's private runtime. -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>

--- a/qcut/bun.lock
+++ b/qcut/bun.lock
@@ -43,6 +43,7 @@
       "devDependencies": {
         "7zip-bin": "5.2.0",
         "@biomejs/biome": "^2.4.2",
+        "@electron/osx-sign": "^1.3.3",
         "@emnapi/core": "^1.4.5",
         "@emnapi/wasi-threads": "^1.1.0",
         "@playwright/test": "^1.58.2",
@@ -628,7 +629,7 @@
 
     "@electron/notarize": ["@electron/notarize@1.2.4", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.1" } }, "sha512-W5GQhJEosFNafewnS28d3bpQ37/s91CDWqxVchHfmv2dQSTWpOzNlUVQwYzC1ay5bChRV/A9BTL68yj0Pa+TSg=="],
 
-    "@electron/osx-sign": ["@electron/osx-sign@1.3.1", "", { "dependencies": { "compare-version": "^0.1.2", "debug": "^4.3.4", "fs-extra": "^10.0.0", "isbinaryfile": "^4.0.8", "minimist": "^1.2.6", "plist": "^3.0.5" }, "bin": { "electron-osx-flat": "bin/electron-osx-flat.js", "electron-osx-sign": "bin/electron-osx-sign.js" } }, "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw=="],
+    "@electron/osx-sign": ["@electron/osx-sign@1.3.3", "", { "dependencies": { "compare-version": "^0.1.2", "debug": "^4.3.4", "fs-extra": "^10.0.0", "isbinaryfile": "^4.0.8", "minimist": "^1.2.6", "plist": "^3.0.5" }, "bin": { "electron-osx-flat": "bin/electron-osx-flat.js", "electron-osx-sign": "bin/electron-osx-sign.js" } }, "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg=="],
 
     "@electron/rebuild": ["@electron/rebuild@4.0.3", "", { "dependencies": { "@malept/cross-spawn-promise": "^2.0.0", "debug": "^4.1.1", "detect-libc": "^2.0.1", "got": "^11.7.0", "graceful-fs": "^4.2.11", "node-abi": "^4.2.0", "node-api-version": "^0.2.1", "node-gyp": "^11.2.0", "ora": "^5.1.0", "read-binary-file-arch": "^1.0.6", "semver": "^7.3.5", "tar": "^7.5.6", "yargs": "^17.0.1" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA=="],
 
@@ -2250,7 +2251,7 @@
 
     "dayjs": ["dayjs@1.11.19", "", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
 
-    "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
@@ -2858,7 +2859,7 @@
 
     "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
-    "isbinaryfile": ["isbinaryfile@5.0.4", "", {}, "sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ=="],
+    "isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
 
     "isbot": ["isbot@5.1.29", "", {}, "sha512-DelDWWoa3mBoyWTq3wjp+GIWx/yZdN7zLUE7NFhKjAiJ+uJVRkbLlwykdduCE4sPUUy8mlTYTmdhBUYu91F+sw=="],
 
@@ -4472,8 +4473,6 @@
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
@@ -4489,8 +4488,6 @@
     "@babel/template/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
 
     "@babel/template/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
-
-    "@babel/traverse/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "@better-auth/core/jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
@@ -4510,6 +4507,8 @@
 
     "@electron/fuses/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
+    "@electron/get/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -4524,21 +4523,23 @@
 
     "@electron/node-gyp/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
+    "@electron/notarize/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
-    "@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
-
     "@electron/rebuild/@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
-
-    "@electron/rebuild/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "@electron/rebuild/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@electron/rebuild/tar": ["tar@7.5.9", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg=="],
 
+    "@electron/universal/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "@electron/universal/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@electron/universal/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@electron/windows-sign/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "@electron/windows-sign/fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
 
@@ -4557,6 +4558,8 @@
     "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
     "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
+
+    "@malept/flatpak-bundler/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
@@ -4678,10 +4681,6 @@
 
     "@types/tailwindcss/tailwindcss": ["tailwindcss@4.1.12", "", {}, "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA=="],
 
-    "@typescript-eslint/project-service/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "@typescript-eslint/typescript-estree/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -4698,6 +4697,8 @@
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "agent-base/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "app-builder-lib/@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
@@ -4706,13 +4707,11 @@
 
     "app-builder-lib/@electron/notarize": ["@electron/notarize@2.5.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.1", "promise-retry": "^2.0.1" } }, "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A=="],
 
-    "app-builder-lib/@electron/osx-sign": ["@electron/osx-sign@1.3.3", "", { "dependencies": { "compare-version": "^0.1.2", "debug": "^4.3.4", "fs-extra": "^10.0.0", "isbinaryfile": "^4.0.8", "minimist": "^1.2.6", "plist": "^3.0.5" }, "bin": { "electron-osx-flat": "bin/electron-osx-flat.js", "electron-osx-sign": "bin/electron-osx-sign.js" } }, "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg=="],
-
     "app-builder-lib/@electron/universal": ["@electron/universal@2.0.3", "", { "dependencies": { "@electron/asar": "^3.3.1", "@malept/cross-spawn-promise": "^2.0.0", "debug": "^4.3.1", "dir-compare": "^4.2.0", "fs-extra": "^11.1.1", "minimatch": "^9.0.3", "plist": "^3.1.0" } }, "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g=="],
 
     "app-builder-lib/ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
 
-    "app-builder-lib/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "app-builder-lib/isbinaryfile": ["isbinaryfile@5.0.4", "", {}, "sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ=="],
 
     "app-builder-lib/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -4730,17 +4729,11 @@
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "browserslist/caniuse-lite": ["caniuse-lite@1.0.30001774", "", {}, "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA=="],
 
-    "builder-util/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "builder-util/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "builder-util-runtime/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "c12/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -4804,15 +4797,23 @@
 
     "electron-builder-squirrel-windows/builder-util": ["builder-util@26.0.11", "", { "dependencies": { "7zip-bin": "~5.2.0", "@types/debug": "^4.1.6", "app-builder-bin": "5.0.0-alpha.12", "builder-util-runtime": "9.3.1", "chalk": "^4.1.2", "cross-spawn": "^7.0.6", "debug": "^4.3.4", "fs-extra": "^10.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "is-ci": "^3.0.0", "js-yaml": "^4.1.0", "sanitize-filename": "^1.6.3", "source-map-support": "^0.5.19", "stat-mode": "^1.0.0", "temp-file": "^3.4.0", "tiny-async-pool": "1.3.0" } }, "sha512-xNjXfsldUEe153h1DraD0XvDOpqGR0L5eKFkdReB7eFW5HqysDZFfly4rckda6y9dF39N3pkPlOblcfHKGw+uA=="],
 
+    "electron-packager/@electron/osx-sign": ["@electron/osx-sign@1.3.1", "", { "dependencies": { "compare-version": "^0.1.2", "debug": "^4.3.4", "fs-extra": "^10.0.0", "isbinaryfile": "^4.0.8", "minimist": "^1.2.6", "plist": "^3.0.5" }, "bin": { "electron-osx-flat": "bin/electron-osx-flat.js", "electron-osx-sign": "bin/electron-osx-sign.js" } }, "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw=="],
+
+    "electron-packager/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "electron-packager/fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
 
     "electron-publish/mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
 
     "electron-updater/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "electron-winstaller/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "electron-winstaller/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
     "error-ex/is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "esbuild-register/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "escodegen/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
@@ -4824,7 +4825,11 @@
 
     "execa/pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
+    "express/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "extract-zip/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "figures/is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
@@ -4834,9 +4839,11 @@
 
     "filing-cabinet/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
-    "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "flora-colossus/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "galactus/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
@@ -4848,8 +4855,6 @@
 
     "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
-    "get-uri/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "giget/citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
     "glob/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
@@ -4859,6 +4864,10 @@
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "http-proxy-agent/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
+    "https-proxy-agent/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "iconv-corefoundation/node-addon-api": ["node-addon-api@1.7.2", "", {}, "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="],
 
@@ -4904,13 +4913,13 @@
 
     "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "madge/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "make-fetch-happen/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "micromark/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -4962,8 +4971,6 @@
 
     "pac-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "pac-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "pac-proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -5004,8 +5011,6 @@
 
     "proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
@@ -5022,6 +5027,8 @@
 
     "react-smooth/fast-equals": ["fast-equals@5.2.2", "", {}, "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw=="],
 
+    "read-binary-file-arch/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "read-pkg/path-type": ["path-type@2.0.0", "", { "dependencies": { "pify": "^2.0.0" } }, "sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ=="],
 
     "readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
@@ -5035,8 +5042,6 @@
     "request/qs": ["qs@6.5.3", "", {}, "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="],
 
     "request/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "require-in-the-middle/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "resize-img/get-stream": ["get-stream@2.3.1", "", { "dependencies": { "object-assign": "^4.0.1", "pinkie-promise": "^2.0.0" } }, "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA=="],
 
@@ -5054,23 +5059,17 @@
 
     "rollup-pluginutils/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
 
-    "router/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "sass-lookup/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "schema-utils/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
 
-    "send/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "socks/ip-address": ["ip-address@9.0.5", "", { "dependencies": { "jsbn": "1.1.0", "sprintf-js": "^1.1.3" } }, "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g=="],
 
     "socks-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "socks-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -5083,6 +5082,8 @@
     "strip-outer/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "stylus-lookup/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "sumchecker/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "temp/rimraf": ["rimraf@2.6.3", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA=="],
 
@@ -5119,8 +5120,6 @@
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
-    "vite-tsconfig-paths/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "webpack/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
@@ -5364,6 +5363,8 @@
 
     "@mariozechner/pi-tui/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
+    "@npmcli/agent/https-proxy-agent/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "@npmcli/move-file/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "@qcut/license-server/better-auth/@better-auth/utils": ["@better-auth/utils@0.2.3", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-Ap1GaSmo6JYhJhxJOpUB0HobkKPTNzfta+bLV89HfpyCAHN7p8ntCrmNFHNAVD0F6v0mywFVEUg1FUhNCc81Rw=="],
@@ -5446,8 +5447,6 @@
 
     "app-builder-lib/@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
-    "app-builder-lib/@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
-
     "app-builder-lib/@electron/universal/@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
     "app-builder-lib/@electron/universal/dir-compare": ["dir-compare@4.2.0", "", { "dependencies": { "minimatch": "^3.0.5", "p-limit": "^3.1.0 " } }, "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ=="],
@@ -5504,15 +5503,21 @@
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/notarize": ["@electron/notarize@2.5.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.1", "promise-retry": "^2.0.1" } }, "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A=="],
 
+    "electron-builder-squirrel-windows/app-builder-lib/@electron/osx-sign": ["@electron/osx-sign@1.3.1", "", { "dependencies": { "compare-version": "^0.1.2", "debug": "^4.3.4", "fs-extra": "^10.0.0", "isbinaryfile": "^4.0.8", "minimist": "^1.2.6", "plist": "^3.0.5" }, "bin": { "electron-osx-flat": "bin/electron-osx-flat.js", "electron-osx-sign": "bin/electron-osx-sign.js" } }, "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw=="],
+
     "electron-builder-squirrel-windows/app-builder-lib/@electron/rebuild": ["@electron/rebuild@3.7.0", "", { "dependencies": { "@electron/node-gyp": "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2", "@malept/cross-spawn-promise": "^2.0.0", "chalk": "^4.0.0", "debug": "^4.1.1", "detect-libc": "^2.0.1", "fs-extra": "^10.0.0", "got": "^11.7.0", "node-abi": "^3.45.0", "node-api-version": "^0.2.0", "ora": "^5.1.0", "read-binary-file-arch": "^1.0.6", "semver": "^7.3.5", "tar": "^6.0.5", "yargs": "^17.0.1" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-VW++CNSlZwMYP7MyXEbrKjpzEwhB5kDNbzGtiPEjwYysqyTCF+YbNJ210Dj3AjWsGSV4iEEwNkmJN9yGZmVvmw=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/universal": ["@electron/universal@2.0.1", "", { "dependencies": { "@electron/asar": "^3.2.7", "@malept/cross-spawn-promise": "^2.0.0", "debug": "^4.3.1", "dir-compare": "^4.2.0", "fs-extra": "^11.1.1", "minimatch": "^9.0.3", "plist": "^3.1.0" } }, "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/builder-util-runtime": ["builder-util-runtime@9.3.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ=="],
 
+    "electron-builder-squirrel-windows/app-builder-lib/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "electron-builder-squirrel-windows/app-builder-lib/dmg-builder": ["dmg-builder@26.0.12", "", { "dependencies": { "app-builder-lib": "26.0.12", "builder-util": "26.0.11", "builder-util-runtime": "9.3.1", "fs-extra": "^10.1.0", "iconv-lite": "^0.6.2", "js-yaml": "^4.1.0" }, "optionalDependencies": { "dmg-license": "^1.0.11" } }, "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/electron-publish": ["electron-publish@26.0.11", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "builder-util": "26.0.11", "builder-util-runtime": "9.3.1", "chalk": "^4.1.2", "form-data": "^4.0.0", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-a8QRH0rAPIWH9WyyS5LbNvW9Ark6qe63/LqDB7vu2JXYpi0Gma5Q60Dh4tmTqhOBQt0xsrzD8qE7C+D7j+B24A=="],
+
+    "electron-builder-squirrel-windows/app-builder-lib/isbinaryfile": ["isbinaryfile@5.0.4", "", {}, "sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
@@ -5520,9 +5525,13 @@
 
     "electron-builder-squirrel-windows/builder-util/builder-util-runtime": ["builder-util-runtime@9.3.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ=="],
 
+    "electron-builder-squirrel-windows/builder-util/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "electron-builder-squirrel-windows/builder-util/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "electron-builder-squirrel-windows/builder-util/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "electron-packager/@electron/osx-sign/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "electron-winstaller/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -5538,6 +5547,8 @@
 
     "gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
+    "gaxios/https-proxy-agent/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "get-package-info/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.2", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw=="],
@@ -5547,6 +5558,8 @@
     "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "jsdom/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "jsdom/https-proxy-agent/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -5816,9 +5829,13 @@
 
     "@electron/node-gyp/make-fetch-happen/cacache/unique-filename": ["unique-filename@2.0.1", "", { "dependencies": { "unique-slug": "^3.0.0" } }, "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A=="],
 
+    "@electron/node-gyp/make-fetch-happen/http-proxy-agent/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "@electron/node-gyp/make-fetch-happen/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "@electron/node-gyp/make-fetch-happen/minipass-fetch/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "@electron/node-gyp/make-fetch-happen/socks-proxy-agent/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "@electron/node-gyp/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -5844,19 +5861,29 @@
 
     "@types/electron-builder/electron-builder/app-builder-lib/@electron/notarize": ["@electron/notarize@2.5.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.1", "promise-retry": "^2.0.1" } }, "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A=="],
 
+    "@types/electron-builder/electron-builder/app-builder-lib/@electron/osx-sign": ["@electron/osx-sign@1.3.1", "", { "dependencies": { "compare-version": "^0.1.2", "debug": "^4.3.4", "fs-extra": "^10.0.0", "isbinaryfile": "^4.0.8", "minimist": "^1.2.6", "plist": "^3.0.5" }, "bin": { "electron-osx-flat": "bin/electron-osx-flat.js", "electron-osx-sign": "bin/electron-osx-sign.js" } }, "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw=="],
+
     "@types/electron-builder/electron-builder/app-builder-lib/@electron/rebuild": ["@electron/rebuild@3.7.0", "", { "dependencies": { "@electron/node-gyp": "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2", "@malept/cross-spawn-promise": "^2.0.0", "chalk": "^4.0.0", "debug": "^4.1.1", "detect-libc": "^2.0.1", "fs-extra": "^10.0.0", "got": "^11.7.0", "node-abi": "^3.45.0", "node-api-version": "^0.2.0", "ora": "^5.1.0", "read-binary-file-arch": "^1.0.6", "semver": "^7.3.5", "tar": "^6.0.5", "yargs": "^17.0.1" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-VW++CNSlZwMYP7MyXEbrKjpzEwhB5kDNbzGtiPEjwYysqyTCF+YbNJ210Dj3AjWsGSV4iEEwNkmJN9yGZmVvmw=="],
 
     "@types/electron-builder/electron-builder/app-builder-lib/@electron/universal": ["@electron/universal@2.0.1", "", { "dependencies": { "@electron/asar": "^3.2.7", "@malept/cross-spawn-promise": "^2.0.0", "debug": "^4.3.1", "dir-compare": "^4.2.0", "fs-extra": "^11.1.1", "minimatch": "^9.0.3", "plist": "^3.1.0" } }, "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA=="],
 
+    "@types/electron-builder/electron-builder/app-builder-lib/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "@types/electron-builder/electron-builder/app-builder-lib/electron-publish": ["electron-publish@26.0.11", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "builder-util": "26.0.11", "builder-util-runtime": "9.3.1", "chalk": "^4.1.2", "form-data": "^4.0.0", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-a8QRH0rAPIWH9WyyS5LbNvW9Ark6qe63/LqDB7vu2JXYpi0Gma5Q60Dh4tmTqhOBQt0xsrzD8qE7C+D7j+B24A=="],
+
+    "@types/electron-builder/electron-builder/app-builder-lib/isbinaryfile": ["isbinaryfile@5.0.4", "", {}, "sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ=="],
 
     "@types/electron-builder/electron-builder/app-builder-lib/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
     "@types/electron-builder/electron-builder/app-builder-lib/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
+    "@types/electron-builder/electron-builder/builder-util/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
     "@types/electron-builder/electron-builder/builder-util/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "@types/electron-builder/electron-builder/builder-util/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "@types/electron-builder/electron-builder/builder-util-runtime/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "@types/electron-builder/electron-builder/dmg-builder/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
@@ -5887,6 +5914,8 @@
     "css-select/domutils/dom-serializer/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "electron-builder-squirrel-windows/app-builder-lib/@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/rebuild/@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
@@ -5969,6 +5998,8 @@
     "@qcut/relay/e2b/glob/minimatch/brace-expansion": ["brace-expansion@5.0.2", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw=="],
 
     "@types/electron-builder/electron-builder/app-builder-lib/@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "@types/electron-builder/electron-builder/app-builder-lib/@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
 
     "@types/electron-builder/electron-builder/app-builder-lib/@electron/rebuild/@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 

--- a/qcut/docs/task/jianying-filter-runtime-research/README.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/README.md
@@ -22,6 +22,18 @@ QCut 当前 77 个控件、15 张美妆卡、多人/CLI E2E、离线状态和剩
 [qcut-retouch-gap-vs-jianying.zh.md](qcut-retouch-gap-vs-jianying.zh.md)。两份文档分别记录“剪映怎样做”与
 “QCut 已有什么、还差什么”，避免用 QCut 的实现反推剪映行为。
 
+剪映人物抠像的 GRU 输入、Alpha 后处理、真人 E2E，以及 GRU reset、人脸模型路由、未来帧预取、
+preview 模型与导出 mask cache 的宿主追踪见
+[portrait-matting-gru-parity-2026-08-27.zh.md](portrait-matting-gru-parity-2026-08-27.zh.md)；原生
+`TEMattingBlendEffectV2` 的 RLDevice 所有权、Metal renderer、三张设备纹理、四种执行计划和真人首帧
+逐通道验证见
+[tematting-blend-v2-native-metal-2026-08-27.zh.md](tematting-blend-v2-native-metal-2026-08-27.zh.md)。
+前一份报告现已补充当前剪映 11.3.0 的动态挂载证据：无缓存 face 路由、逐帧 mask 完成协议、缓存命中的
+seek/跟踪/切分，以及 7 秒真实导出期间只读 mask 后 Blend 的调用计数。可复现的自有动态探针源码位于
+[`probes/jianying-matting-runtime-trace.mm`](probes/jianying-matting-runtime-trace.mm)，原始日志继续只保存在仓库外。
+该人物抠像报告已追加 2026-08-28 的 object graph 宿主边界、失败输出门禁，以及真人验证后的
+`GRU + macOS Vision` 精细模式融合和最终左右白底对照。
+
 剪映专业版 `face.id`、`freid.trackid`、隐藏人脸框包，以及 QCut 项目级 `personBindingId`、
 同帧安全重绑定和真实双人 Electron/CLI 证据见
 [jianying-multi-person-detection-selection-track-id.zh.md](jianying-multi-person-detection-selection-track-id.zh.md)。

--- a/qcut/docs/task/jianying-filter-runtime-research/cache-gap-162-2026-08-26.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/cache-gap-162-2026-08-26.zh.md
@@ -1,0 +1,143 @@
+# 剪映滤镜缺包补齐与严格离线复查
+
+<!-- markdownlint-disable MD013 -->
+
+记录时间：2026-08-26
+
+执行分支：`lutv7`
+
+范围：当前本机目录中的 887 张剪映滤镜卡，不代表剪映服务端的全部滤镜。
+
+## 结论
+
+本轮 162 张缺失效果包全部下载成功，另外补齐了「鲜美年味」的目录指定版本。现在 887 张目录卡均为 `cacheStatus=cached`，缺包与版本不匹配均为 0。
+
+**缓存完整不等于全部可用，更不等于完美复刻。** 当前目录中 788 张为 `available=true`，99 张仍为 `available=false`。本轮没有修改加载器、原生渲染逻辑或 parity 记录，也没有新增逐卡剪映 UI 对照。
+
+## 前后数量
+
+| 项目 | 补齐前 | 补齐后 |
+| --- | ---: | ---: |
+| 目录卡片 | 887 | 887 |
+| `cached` | 724 | 887 |
+| `partial` | 1 | 0 |
+| `uncached` | 162 | 0 |
+| `available=true` | 721 | 788 |
+| `available=false` | 166 | 99 |
+| 私有快照包版本 | 761 | 924 |
+| 私有快照文件 | 28,039 | 35,010 |
+| 运行库文件 / 模型文件 | 23 / 53 | 23 / 53 |
+
+包版本数包含历史版本和已备份的人像等资源，不能与滤镜卡片数直接比较。新增的 67 张 `available=true` 只表示现有加载条件通过，尚未逐张验证输出帧。
+
+补齐前的 `offline-resource-missing=166` 不是 166 张全部没有文件：当时 coverage 把所有 `available=false` 合并到这个 gap，实际是 162 张缺包、1 张版本不匹配、3 张已缓存但不可用。本轮没有修改这个 gap 的分类逻辑，后续判断缺包应读取 `cacheStatus`，不能继续把剩余 99 张称为“缺包”。
+
+## 下载与入库
+
+复用 `electron/jianying-filter-metadata.ts` 和 `electron/jianying-filter-download.ts`，从本机目录元数据取得包地址与版本 MD5。没有请求或绕过额外权限，没有修改剪映缓存。
+
+1. 用实际 LUT references 识别滤镜面板，冻结 162 张目标的 `resourceId` 与版本。
+2. 先下载「晴空海岸」「蓝调时刻」「粉霞」3 张，全部通过校验。
+3. 其余目标最多 6 个并发，成功 162 / 162，失败 0；已通过的 smoke 包通过文件哈希检查后复用。
+4. 额外下载「鲜美年味」`7460115630973340940` 的版本 `d284757f58f3e4ba7343e567e3df7cf8`；旧版本保留。
+5. 每个 ZIP 都由现有下载器检查 MD5、空包和危险路径，然后临时目录解包、原子入库；对解包后的每个文件另记 SHA-256。
+
+| 本轮目标 | 包数 | 文件数 | 解包后字节 |
+| --- | ---: | ---: | ---: |
+| 原缺包清单 | 162 | 6,950 | 226,183,831 |
+| 鲜美年味版本补齐 | 1 | 21 | 62,427 |
+| 合计 | 163 | 6,971 | 226,246,258 |
+
+新增内容约 215.8 MiB。批量下载阶段约 28 秒，另有约 6 秒 smoke 与约 3 秒版本修复；这些是下载阶段耗时，不是整轮审计总耗时。
+
+下载目录：
+
+```text
+/Users/peter/Library/Application Support/QCut/JianyingFilterPackages/artistEffect/
+```
+
+## 私有快照
+
+复用 `backupJianyingFilterRuntime()`，以已有私有快照为来源，合并新下载目录；同时保留旧快照中的全部包标识，避免刷新时丢失先前缓存的人像等资源。
+
+旧快照：`D6342ECD-5432-33F0-A2AD-0C28F5699994-cb04efad88cd637d`。
+
+新快照：
+
+```text
+/Users/peter/Library/Application Support/QCut/PrivateRuntimes/JianyingFilter/
+  D6342ECD-5432-33F0-A2AD-0C28F5699994-c092f19c71af1397/
+```
+
+`current` 已切到新快照，旧快照仍在。新快照总大小为 1,597,135,989 字节，约 1.49 GiB。生成与校验约 14 秒。
+
+逐文件比较确认：旧快照 28,039 个文件在新快照中全部存在，大小与 SHA-256 全部相同，丢失或改变数为 0。新增 163 个目标包的 6,971 个文件也与下载后的哈希清单完全一致。
+
+## 严格离线验证
+
+使用 macOS `sandbox-exec` 对验证进程施加操作系统级限制，不是仅设置环境变量：
+
+- 禁止所有网络；本地 TCP 探针实际返回 `EPERM`。
+- 禁止读取剪映 App bundle `/Applications/VideoFusion-macOS.app`，实际返回 `EPERM`。
+- 禁止读取剪映用户缓存，实际返回 `EPERM`。
+- 禁止读取 QCut 的下载目录，实际返回 `EPERM`，防止下载目录掩盖快照漏包。
+- 另设 `QCUT_JIANYING_DISABLE_APP_BUNDLE=1`、`QCUT_JIANYING_DISABLE_USER_CACHE=1`。
+- `QCUT_JIANYING_FILTER_CACHE_ROOT` 指向新快照的 `Cache`；`QCUT_JIANYING_FILTER_PACKAGE_ROOT` 指向已确认为空的目录。
+
+在上述限制下：
+
+| 检查 | 结果 |
+| --- | --- |
+| 快照文件清单与 SHA-256 | 35,010 / 35,010 通过 |
+| 目标包版本与文件哈希 | 163 / 163 通过 |
+| 目录缓存覆盖 | 887 / 887 cached |
+| 原先可用卡片的可用性回退 | 0 |
+| `runtimeSource` / `modelSource` | `qcut-private` / `qcut-private` |
+| `snapshotReady` / `offlineReady` | `true` / `true` |
+
+这里证明的是快照完整性、离线目录解析和运行时发现。没有在这个隔离测试中逐卡渲染，也没有证明新包依赖的全部动态模型都已经接通。
+
+## 仍需处理的 99 张
+
+所有 99 张都有包，但现有加载或接入条件尚未通过：
+
+| 目录分类 | 数量 |
+| --- | ---: |
+| Shader / 多 Pass | 43 |
+| Face AI | 31 |
+| 双 LUT | 22 |
+| 标为 single-LUT 但不可用 | 3 |
+
+这不是 99 次渲染失败，本轮未对它们执行渲染。下一步应逐类检查加载条件、包结构与模型依赖，再做原生 smoke 和剪映 UI 对标，不能用“包已下载”自动升级 `verification`。
+
+## 证据与测试
+
+完整本机证据目录：
+
+```text
+/Users/peter/Library/Application Support/QCut/Research/JianyingFilter/cache-gap-162-2026-08-26/
+```
+
+- `baseline.json`：补包前数量、162 张清单、1 张版本修复清单。
+- `downloads/<resourceId>.json`：下载结果、MD5 校验标记、逐文件 SHA-256。
+- `smoke-summary.json`、`download-summary.json`、`partial-summary.json`：分阶段成功与失败。
+- `backup.json`：新快照及旧文件保留检查。
+- `strict-offline-verification.json`：权限拒绝探针、全快照哈希、逐包检查、剩余 99 张清单。
+- `strict-offline-catalog.json`：隔离条件下的 887 张目录。
+- `focused-tests.json`：4 个测试文件、14 个测试全部通过。
+
+聚焦测试命令：
+
+```bash
+bunx vitest run \
+  electron/__tests__/jianying-filter-download.test.ts \
+  electron/__tests__/jianying-filter-private-runtime.test.ts \
+  electron/__tests__/jianying-filter-local-runtime-discovery.test.ts \
+  electron/__tests__/jianying-filter-package-inspector.test.ts
+```
+
+本轮只把研究说明写入仓库；剪映二进制、模型、效果包、LUT、Shader、签名下载地址和逐文件私有清单均未加入 Git。
+
+## 后续渲染验证
+
+2026-08-27 已补齐 CLI `filter-lab render` / `apply`，修复大目录 JSON 管道截断，并对 3 张新增可用卡执行真实图片/视频与桌面 UI 抽测。完整命令、成功/失败记录和截图见 [Filter Lab CLI 渲染入口与新增缓存实测](filter-lab-cli-render-2026-08-27.zh.md)。目录数量仍为 788 张可用、99 张不可用；这不是全部滤镜已经验证。

--- a/qcut/docs/task/jianying-filter-runtime-research/cache-gap-162-2026-08-26.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/cache-gap-162-2026-08-26.zh.md
@@ -50,24 +50,13 @@
 
 新增内容约 215.8 MiB。批量下载阶段约 28 秒，另有约 6 秒 smoke 与约 3 秒版本修复；这些是下载阶段耗时，不是整轮审计总耗时。
 
-下载目录：
-
-```text
-/Users/peter/Library/Application Support/QCut/JianyingFilterPackages/artistEffect/
-```
+下载目录：QCut 应用数据目录下的 `JianyingFilterPackages/artistEffect/`（本机绝对路径不入库）。
 
 ## 私有快照
 
 复用 `backupJianyingFilterRuntime()`，以已有私有快照为来源，合并新下载目录；同时保留旧快照中的全部包标识，避免刷新时丢失先前缓存的人像等资源。
 
-旧快照：`D6342ECD-5432-33F0-A2AD-0C28F5699994-cb04efad88cd637d`。
-
-新快照：
-
-```text
-/Users/peter/Library/Application Support/QCut/PrivateRuntimes/JianyingFilter/
-  D6342ECD-5432-33F0-A2AD-0C28F5699994-c092f19c71af1397/
-```
+新快照写入 QCut 应用数据目录下的 `PrivateRuntimes/JianyingFilter/`；新旧快照标识与本机绝对路径均不入库。
 
 `current` 已切到新快照，旧快照仍在。新快照总大小为 1,597,135,989 字节，约 1.49 GiB。生成与校验约 14 秒。
 
@@ -112,11 +101,7 @@
 
 ## 证据与测试
 
-完整本机证据目录：
-
-```text
-/Users/peter/Library/Application Support/QCut/Research/JianyingFilter/cache-gap-162-2026-08-26/
-```
+完整证据保存在本机 QCut 应用数据目录下 `Research/JianyingFilter/` 的本轮子目录（绝对路径不入库）：
 
 - `baseline.json`：补包前数量、162 张清单、1 张版本修复清单。
 - `downloads/<resourceId>.json`：下载结果、MD5 校验标记、逐文件 SHA-256。

--- a/qcut/docs/task/jianying-filter-runtime-research/filter-lab-cli-render-2026-08-27.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/filter-lab-cli-render-2026-08-27.zh.md
@@ -1,0 +1,163 @@
+# Filter Lab CLI 渲染入口与新增缓存实测
+
+<!-- markdownlint-disable MD013 -->
+
+日期：2026-08-27。分支：`lutv7`。对象是剪映专业版，不是 CapCut。
+
+## 结论
+
+补齐 `filter-lab render`，`filter-lab apply` 为同一命令的别名。可以将现有加载器支持的本地滤镜应用到图片或视频，不需要打开剪映。
+
+新增缓存中的「逆光提亮」「蓝调时刻」「奶杏」已分别通过真实 CLI 渲染和 QCut 桌面点选预览。另用已有「迷雾」「食色」覆盖原生多 Pass 和 FFmpeg 结构近似路径。本轮共完成 7 个 PNG、2 个带音轨 MP4，以及 5 张桌面截图。
+
+目录仍为 **887 张已缓存、788 张 available、99 张不可用**。没有修改可用性门槛，没有把缓存存在当作渲染成功，也没有更新任何卡片的剪映 UI parity 等级。
+
+## 修复内容
+
+### 大目录 JSON 被截断
+
+实际复现：`filter-lab catalog --json` 输出到 shell 管道时，原路径只读到 98,305 字节，JSON/UTF-8 被截断。改用 `process.stdout.write()` 输出完整 envelope，并将 JSON 失败路径的立即退出改为 `process.exitCode = 1`，让输出排空。
+
+修复后同一目录管道收到 **455,345 字节、887 张卡**，JSON 可完整解析。成功、失败、异步任务的 wire format 保持不变。这里只记录本机 CLI 的复现，不推断所有 Bun `console.log` 都有相同问题。
+
+### 渲染入口
+
+新增代码按职责拆分：
+
+| 文件 | 职责 |
+| --- | --- |
+| `electron/native-pipeline/cli/cli-handlers-filter-lab-render.ts` | 参数、文件保护、原子发布和结果验证 |
+| `electron/native-pipeline/filters/filter-lab-render-plan.ts` | 复用目录、版本和渲染器解析 |
+| `electron/native-pipeline/filters/filter-lab-media.ts` | FFprobe、FFmpeg 进程和编码参数 |
+| `electron/native-pipeline/filters/filter-lab-render.ts` | 图片/视频执行，原生宿主生命周期 |
+| `electron/native-pipeline/filters/filter-lab-frame-stream.ts` | RGBA 分帧、顺序执行和残帧检查 |
+
+桌面 UI 已有入口，本轮没有修改 UI 源码。新 CLI 复用其 LUT/包检查、原生运行时和现有导出算子，不绕过 `available` 或版本检查。
+
+### 零强度仍改变像素
+
+真实 PNG 检查发现：强度 0 的单 LUT 仍经过恒等 LUT 插值，约 0.1764% 像素存在最大 1/255 的 RGB 差异，RGB MAE 为 0.0005879。
+
+现改为在确认 LUT 可解码后旁路插值。重跑后普通 LUT 和原生双 LUT 的零强度 PNG 都与原始解码 RGBA 完全一致，RGB MAE、最大 RGB 差、Alpha MAE 均为 0。该结论不是有损 MP4 的逐字节一致性保证。
+
+## 使用命令
+
+以下是在当前源码工作区可直接使用的入口；本轮未发布新版本或替换全局安装的 `qcut`。
+
+```bash
+# 获取完整目录，寻找 resourceId、version、available 和 cacheStatus
+bun --silent run qcut -- filter-lab catalog --json
+
+# 单张图片，输出 PNG
+bun --silent run qcut -- filter-lab render \
+  --resource-id 7524288987129810214 \
+  -i portrait.jpg --output filtered.png \
+  --filter-intensity 100 --json
+
+# 双 LUT 真人视频；apply 与 render 等价
+bun --silent run qcut -- filter-lab apply \
+  --resource-id 7392898023505792319 \
+  -i clip.mp4 --output filtered.mp4 \
+  --duration 1 --fps 30 --json
+
+# 检查输入、版本和本地运行时，不输出媒体
+bun --silent run qcut -- filter-lab render \
+  --resource-id 7524288987129810214 \
+  -i portrait.jpg --output filtered.png --dry-run --json
+```
+
+- `--filter-intensity`：0 至 100，默认 100。
+- `--filter-version`：要求目录当前选中的精确版本，不静默换版。
+- `--duration`：最多处理指定秒数，只适用于视频；`--fps` 为 0 至 120 范围内的正数。
+- 视频转为恒定帧率，默认源平均帧率；输出 H.264 / YUV420P MP4，音轨重新编码为 AAC。不是 HDR、VFR 或原始编码无损保留。
+- 图片输出一帧 RGBA PNG；输入支持 PNG/JPEG/WebP/BMP/TIFF，视频支持 MP4/MOV/M4V/MKV/WebM/AVI。
+- 输入最多 `4096 * 4096` 像素，单边最多 8192；MP4 要求偶数宽高，不静默缩放。
+- 不指定 `--output` 时写到 `--output-dir` 下；已有文件必须显式 `--force`，源文件、硬链接和输出软链接仍受保护。
+- 临时结果通过尺寸、视频时长、帧率和音轨检查后才发布；失败不覆盖已有输出。任务有 15 分钟超时和取消清理。
+
+## 渲染路径
+
+| 路径 | 实现 | 结果中的 fidelity |
+| --- | --- | --- |
+| 单 LUT、已识别的纹理 LUT | 共享 LUT 解码与 FFmpeg tetrahedral 插值 | `lut` |
+| 双 LUT | 本机原生宿主与真实 skin segmentation，不回退到肤色猜测 | `native-local` |
+| 已接通的原生多 Pass 卡 | 现有本机原生效果包宿主 | `native-local` |
+| 其余已支持的多 Pass recipe | 现有 FFmpeg 结构近似算子 | `structural` |
+
+`native-local` 只说明使用本机原生渲染，不代表与剪映 UI 导出逐像素相同。原生多 Pass 仍受现有 profile 白名单约束，不能执行任意 Shader 包。
+
+原生视频对同一素材保持一个宿主，按时间戳逐帧串行，避免并发破坏分割时序状态；批量测试中的 9 个任务也顺序运行。
+
+## 真实 CLI 验证
+
+每次 CLI 渲染都在 macOS `sandbox-exec` 内执行：禁止联网、读取剪映安装目录、剪映用户缓存以及 QCut 下载目录。只允许使用 QCut 私有快照，并设置禁用 App bundle / 用户缓存的环境变量。
+
+使用快照 `D6342ECD-5432-33F0-A2AD-0C28F5699994-c092f19c71af1397`。这不是 Daytona/Linux 验证；原生路径依赖本机 macOS 运行库。
+
+图片为已有真人素材，854 x 480。视频为已有真人视频截出的 1280 x 720、1 秒、30 帧片段；原视频没有声音，测试夹具另加 440 Hz 音轨用于检查音频是否丢失。
+
+| 输出 | 卡片 / resourceId | 后端 | 结果 | 耗时 |
+| --- | --- | --- | --- | ---: |
+| `01-backlight.png` | 逆光提亮 / `7524288987129810214` | FFmpeg LUT | 通过 | 2.659 s |
+| `02-blue-hour.png` | 蓝调时刻 / `7392898023505792319` | 原生双 LUT | 通过 | 4.193 s |
+| `03-milk-apricot.png` | 奶杏 / `7127670311775898917` | 纹理 LUT | 通过 | 2.352 s |
+| `04-blue-hour-video.mp4` | 蓝调时刻 | 原生双 LUT | 30 帧、音轨存在 | 7.374 s |
+| `05-native-fog.png` | 迷雾 / `7160594413847203085` | 原生多 Pass | 通过 | 3.646 s |
+| `06-structural-food.png` | 食色 / `7131644140340776205` | 结构近似多 Pass | 通过 | 2.299 s |
+| `07-intensity-zero.png` | 逆光提亮，强度 0 | FFmpeg 旁路 LUT | 与源 RGBA 完全相同 | 2.031 s |
+| `08-backlight-video.mp4` | 逆光提亮 | FFmpeg LUT | 30 帧、音轨存在 | 2.000 s |
+| `09-native-intensity-zero.png` | 蓝调时刻，强度 0 | 原生双 LUT | 与源 RGBA 完全相同 | 3.746 s |
+
+耗时包括 CLI 启动、目录解析、渲染、FFprobe 和完整解码校验，不是单独 GPU 运算耗时。所有输出都通过 FFmpeg 完整解码。两个视频均抽查第 0/15/29 帧，三帧哈希各不相同；音频 RMS 约 0.088，不是空音轨。
+
+负例「晴空海岸」`7617814057051016484` 有缓存但不可用：CLI 返回完整 JSON 错误、退出码 1，没有生成输出文件。这是预期拒绝，不是把该卡接通了。
+
+## 桌面 UI 验证
+
+使用独立测试 profile 启动真实 Electron 窗口，执行新建项目、导入视频、加入时间线、进入滤镜实验室，再逐张搜索并点击上述三张新增卡片；没有向 store 注入预制滤镜状态。
+
+| 检查 | 结果 |
+| --- | --- |
+| 目录数量 | 887 cached / 788 available |
+| 运行库和模型来源 | `qcut-private` / `qcut-private`，`offlineReady=true` |
+| 逆光提亮 | 17 阶 LUT 已启用，预览非空 |
+| 蓝调时刻 | 64 阶双 LUT，`maskKind=skin-segmentation-v1`，正确 resourceId |
+| 奶杏 | 64 阶纹理 LUT 已启用，预览非空 |
+| A 原图按钮 | LUT enabled 切换为 false |
+| 页面异常 | `pageErrors=[]` |
+
+这次 UI 测试禁用了剪映安装/用户缓存发现，但没有加操作系统级网络隔离；不要把 UI 测试与上面的严格离线 CLI 测试混为一谈。UI 启动日志出现无音轨素材的波形提取失败及另一张卡片缩略图请求超时，未阻止三张卡应用，但不是“应用全程无告警”。
+
+## 自动化测试与证据
+
+- 43 个 Vitest 文件，258 项测试全部通过；覆盖 CLI JSON、参数、版本、渲染路由、逐帧流、原子文件保护及现有 Filter Lab/UI 回归。
+- `bunx tsc -p electron/tsconfig.json --noEmit --pretty false` 通过。
+- 15 个修改/新增 TypeScript 文件的 Biome 检查通过；`git diff --check` 通过。
+
+本机证据目录：
+
+```text
+/Users/peter/Downloads/QCut-FilterLab-2026-08-27/
+```
+
+| 文件 | 内容 |
+| --- | --- |
+| `10-still-comparison.png` | 原图与五种滤镜的对照，已人工查看 |
+| `11-video-comparison.png` | 原视频与双 LUT 视频的首/中/末帧，已人工查看 |
+| `ui-01-catalog.png` 至 `ui-05-original-toggle.png` | 真实桌面截图 |
+| `cli-real-report.json`、`*.png.json`、`*.mp4.json` | 后端、版本、SHA-256、尺寸、帧数和耗时 |
+| `pixel-verification.json` | 最终逐像素与音频检查 |
+| `pixel-verification-before-fix.json` | 零强度失败原始记录，不覆盖历史失败 |
+| `cli-real-report-before-fix.json` | 首轮真实渲染记录 |
+| `catalog-pipe-report.json` | 455,345 字节完整 JSON 管道结果 |
+| `ui-report.json`、`unsupported-report.json`、`unit-test-report.json` | UI、预期拒绝和回归测试报告 |
+
+首轮视频夹具使用 stream copy，未限制 duration 的 LUT 输出随源保留了 32 帧；最终夹具重新编码为严格 1 秒/30 帧后重测，两条视频路径均为 30 帧。对照图最初的 `%` 标签触发 drawtext 转义告警，已改为 literal expansion 并重新生成。
+
+## 尚未证明
+
+没有完成新增 67 张可用卡的逐张渲染，更没有完成全部 788 张的剪映 UI 对照。「蓝调时刻」100% 强度有明显锐化观感，仍需同素材的剪映 UI 无损参考来判断是否一致；不能因 native 调用成功就升级为 verified。
+
+99 张不可用卡的缺口仍是加载器、效果图或模型接入，不是缺缓存。HDR、长视频、不同平台、复杂旋转元数据和取消时的系统级压力测试不在本轮真实覆盖内。
+
+剪映二进制、模型、效果包、LUT、Shader 和测试媒体均留在本机私有目录，没有加入 Git。本轮只修改源码、测试与文档，没有提交、推送或发布。

--- a/qcut/docs/task/jianying-filter-runtime-research/filter-lab-cli-render-2026-08-27.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/filter-lab-cli-render-2026-08-27.zh.md
@@ -92,7 +92,7 @@ bun --silent run qcut -- filter-lab render \
 
 每次 CLI 渲染都在 macOS `sandbox-exec` 内执行：禁止联网、读取剪映安装目录、剪映用户缓存以及 QCut 下载目录。只允许使用 QCut 私有快照，并设置禁用 App bundle / 用户缓存的环境变量。
 
-使用快照 `D6342ECD-5432-33F0-A2AD-0C28F5699994-c092f19c71af1397`。这不是 Daytona/Linux 验证；原生路径依赖本机 macOS 运行库。
+使用与缓存补齐记录相同的最新私有快照（快照标识不入库）。这不是 Daytona/Linux 验证；原生路径依赖本机 macOS 运行库。
 
 图片为已有真人素材，854 x 480。视频为已有真人视频截出的 1280 x 720、1 秒、30 帧片段；原视频没有声音，测试夹具另加 440 Hz 音轨用于检查音频是否丢失。
 
@@ -134,11 +134,7 @@ bun --silent run qcut -- filter-lab render \
 - `bunx tsc -p electron/tsconfig.json --noEmit --pretty false` 通过。
 - 15 个修改/新增 TypeScript 文件的 Biome 检查通过；`git diff --check` 通过。
 
-本机证据目录：
-
-```text
-/Users/peter/Downloads/QCut-FilterLab-2026-08-27/
-```
+证据保存在本机的 `QCut-FilterLab-2026-08-27/` 目录（绝对路径不入库）：
 
 | 文件 | 内容 |
 | --- | --- |

--- a/qcut/docs/task/jianying-filter-runtime-research/jianying-person-cutout-exact-bach-v2-2026-08-28.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/jianying-person-cutout-exact-bach-v2-2026-08-28.zh.md
@@ -1,0 +1,95 @@
+# QCut 与剪映固定版人物抠像同算法验收（2026-08-28）
+
+## 结论
+
+QCut 的精细人物抠像现已接通剪映 D634 固定快照的同一条用户态数值链：
+
+```text
+源 BGRA 帧
+  -> TEBachMattingAlgorithm
+  -> ai_matting_video_object
+  -> video_saliency_seg_bce
+  -> 原始 256x256 recurrent mask
+  -> TEMattingBlendEffectV2 / FastBlend
+  -> 源尺寸 Alpha
+```
+
+产品 provider 与 pipeline 均为
+`qcut-jianying-video-object-bach-v2-exact-d634-v1`，默认后处理身份为
+`vendor-v2-exact-no-qcut-refinement-v1`，blend 身份为
+`TEMattingBlendEffectV2-vendor-exact`。默认路径不再叠加 QCut 的 Vision、形态学或
+时序补洞；只有用户显式调整高级参数时，才进入身份独立的 QCut 后处理路径。
+
+这里的“同算法”严格限定为：同一 Mac、固定 D634 私有 runtime/graph/model 与完整
+Framework 闭包上的 Bach + vendor V2 provider。它不表示复制整个剪映 App，也不保证
+跨 macOS、CoreML、Metal 驱动或 GPU 的逐字节一致。VP9 透明视频是 QCut 的交付编码，
+也不属于模型内部数值链。
+
+## 固定闭包
+
+- runtime UUID：`D6342ECD-5432-33F0-A2AD-0C28F5699994`
+- `libcccreator` SHA-256：
+  `0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9`
+- graph SHA-256：
+  `797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b`
+- model SHA-256：
+  `346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef`
+- 23 个私有 Framework 闭包：
+  `jianying-runtime-framework-closure-d634-v1-e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e`
+
+helper 在 `dlopen` 前逐文件核对大小和 SHA；缺失、混装或篡改任意依赖都会拒绝 exact
+provider。子进程环境会清除继承的 `DYLD_*`，再只设置已审计的 Framework 路径。
+剪映私有二进制、模型、graph、动态捕获和真人素材均未进入仓库。
+
+## 内部数值证据
+
+- 独立 V2 probe 与产品 helper 的真人首帧源尺寸 Alpha 逐字节相同：
+  `e8ad4c25d5d1a4dc0cc6a559686c14d98d411e43918c45d8c3249f4a56d3ba97`，
+  exact ratio `1`、MAE `0`、IoU `1`。
+- 60 帧 exact 输出 SHA-256：
+  `f1a113fc4b4330e9c405508253848376bf60b6f9b0eddcbddb712abdf0cc7b91`；
+  重复运行逐字节相同。
+- V2 接入前后 Bach 的两帧 `nn_3` 保持逐字节一致；raw 256 mask 的
+  `131072` 个像素 MAE `0`、最大误差 `0`。
+- 原生 60 帧约 `1.10 s`；完整依赖 SHA 门禁 warm-cache 约 `0.61 s`。
+- source Alpha 非全不透明时，最终 Alpha 没有越过 source Alpha 上限。
+
+## 真人桌面 E2E
+
+使用同一段 `360x640`、30 fps、2 秒、60 帧真人宽景，强制 exact
+`video-object` 路线运行完整 Electron UI 流程。结果为 `1/1 passed (22.1s)`：
+
+- 首轮真实运行 exact helper，未 fallback；
+- 生成 VP9 Alpha WebM，时长 `2.000 s`、大小 `182576 bytes`；
+- `provider/pipeline=qcut-jianying-video-object-bach-v2-exact-d634-v1`；
+- `blend=TEMattingBlendEffectV2-vendor-exact`；
+- `refinement=vendor-v2-exact-no-qcut-refinement-v1`；
+- 浏览器解码 ROI：顶部背景 `0`，人物中心 `252.9399479167`；
+- 第二轮在同一任务独立的新缓存根上观察到缓存完整，仍为 exact provider、无 fallback；
+- 完成素材入库、时间线蒙版挂载、播放器预览和三张桌面截图。
+
+白底对比固定为左剪映、右 QCut。对剪映黑白导出重建的 Alpha 代理，最终 QCut VP9
+Alpha 在阈值 128 下为 IoU `0.998339276242`、precision `0.998937929021`、
+recall `0.999400073951`、MAE `1.965280598958/255`。这些数字同时包含剪映白/黑导出
+重建误差和 QCut VP9 Alpha 量化，不能反推内部 Bach+V2 不一致；内部同帧逐字节证据
+以前一节的独立 probe 为准。
+
+证据目录：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-jianying-bach-v2-exact-2026-08-28/
+```
+
+## 产品边界
+
+- exact 不可用或运行失败时，QCut 仍按 direct CoreML、旧 Effect host、GRU + Vision
+  回退；这些 provider 有不同身份，不能称为同算法。
+- 自动模型路由仍是 QCut 的采样策略。选择 GRU + Vision 的近景不属于本页的 exact
+  object provider；若要固定同算法，应使用精细抠像的 exact `video-object` 路线并检查
+  结果 metadata。
+- seek、切镜、倒放、变速、源范围变化和剪映预览/导出模型切换仍属于宿主策略，尚未
+  宣称完整复制。
+- Alpha 仍会回读 CPU、写缓存并编码 VP9；这影响性能和最终编码字节，不改变已验证的
+  Bach + vendor V2 模型数值链。
+- 共享缓存任务的最后一个订阅者取消后，后台构建目前会继续完成；缓存提交 I/O 错误的
+  错误分类也仍可继续收紧。这两项是任务生命周期/错误策略，不是 Alpha 算法差异。

--- a/qcut/docs/task/jianying-filter-runtime-research/jianying-person-cutout-exact-bach-v2-2026-08-28.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/jianying-person-cutout-exact-bach-v2-2026-08-28.zh.md
@@ -77,7 +77,7 @@ recall `0.999400073951`、MAE `1.965280598958/255`。这些数字同时包含剪
 证据目录：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-jianying-bach-v2-exact-2026-08-28/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-jianying-bach-v2-exact-2026-08-28/
 ```
 
 ## 产品边界

--- a/qcut/docs/task/jianying-filter-runtime-research/long-tail-per-card-parity-2026-08-26.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/long-tail-per-card-parity-2026-08-26.zh.md
@@ -6,6 +6,8 @@
 执行分支：`lutv6`  
 证据目录：`~/Library/Application Support/QCut/Research/JianyingFilter/`
 
+后续缓存更新：同日 `lutv7` 已补齐 162 张缺包并修复 1 张版本不匹配，当前 887 张全部 `cached`；788 张 `available=true`，99 张已缓存但仍不可用。下文 coverage 保留补包前的历史快照，`offline-resource-missing=166` 当时归并了所有不可用卡，并非 166 张都缺包。详见 [缺包补齐与严格离线复查](cache-gap-162-2026-08-26.zh.md)；本轮补包没有增加 UI parity 证据。
+
 ## 结论
 
 本轮把“滤镜能加载”和“滤镜已与剪映一致”彻底拆开，并完成了第一轮可重复的逐卡流水线：

--- a/qcut/docs/task/jianying-filter-runtime-research/person-cutout-gap-reduction-2026-08-28.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/person-cutout-gap-reduction-2026-08-28.zh.md
@@ -337,9 +337,9 @@ frame 59 是该历史链的最弱帧，尾部差异可能同时包含错误的�
 证据目录：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-parity-gap-reduction-2026-08-28/desktop-near-route-gl-context/
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-parity-gap-reduction-2026-08-28/desktop-wide-route-final/
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-parity-gap-reduction-2026-08-28/desktop-auto-post-context-gate/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-parity-gap-reduction-2026-08-28/desktop-near-route-gl-context/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-parity-gap-reduction-2026-08-28/desktop-wide-route-final/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-parity-gap-reduction-2026-08-28/desktop-auto-post-context-gate/
 ```
 
 每个目录都包含 `desktop-person-cutout.webm`、三张桌面截图、`e2e-evidence.json` 和本地 `electron-runtime.log`；运行时日志只作为私有证据，不进入仓库。

--- a/qcut/docs/task/jianying-filter-runtime-research/person-cutout-gap-reduction-2026-08-28.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/person-cutout-gap-reduction-2026-08-28.zh.md
@@ -1,0 +1,368 @@
+# QCut 人物抠像差距收敛记录（2026-08-28）
+
+## 本轮结论
+
+QCut 的 object 路线现在分成两条身份独立的执行路径：固定 D634 runtime 的 exact Bach worker，以及不依赖剪映私有宿主的 same-model CoreML fallback。exact worker 不再经过已证伪的 Swing Effect handle；它在隔离进程内用已审计的 `TECVPixelBufferFrame` 与 `TEBachMattingAlgorithm` 具名导出执行原 Bach graph。fallback 则从已校验 SHA-256 的 `video_saliency_seg_bce` packed model 提取 `20440.3_sod_fp16.mlmodelc` 到私有缓存，直接用 CoreML 执行相同网络。模型和剪映二进制均不进入仓库。
+
+packed graph 的输入输出契约已还原并实现：RGBA 源帧直接双线性缩到 256×256，再按 BGR/NCHW 和 `/255` 生成 `data`；网络同时接收 `prev_img [1,3,256,256]` 与 `prev_mask [1,1,256,256]`，输出 `nn_3 [1,1,256,256]`。首帧两个状态为零，连续帧使用上一帧归一化图像和上一帧原始 `nn_3`。exact worker 随后把 raw 256 Mask 交给固定版 `TEMattingBlendEffectV2`，由 vendor `FastBlend` 输出源尺寸 Alpha；fallback 才使用 QCut 自有 resize。该 graph 内没有人脸节点或人脸输入。
+
+这一输入链来自 Bach 进程内的 CoreML raw capture，而不是 graph 尺寸字段推测。对同一首帧，最可信实现是源 RGBA 按 half-pixel 坐标直接双线性缩到 256，再以 `floor(value + 0.5)` 取整：归一化 MAE 为 `0.000343492`，最大误差为 `1/255`，`196608` 个元素中 `179387` 个逐灰阶相同（`91.2409%`）。旧的 `source → 288×512 → 256` 两段缩放 MAE 为 `0.005591259`、最大误差为 `96/255`，已被证据排除并从产品 fallback 删除。direct CoreML 的能力身份因此升级为 `source-rgba-direct-256-v2`，processor/cache 指纹同步换代。剩余单级 `±1` 灰阶差异仍使 fallback 不能称为 Bach bit-exact。
+
+`cacheOffset:0` 的时序语义已经由连续两帧动态 capture 最终确定，不再只依赖静态字段或输出 A/B。首帧 `prev_img`、`prev_mask` 全零；第二帧 `prev_img` 与首帧 `data` 逐字节相同，第二帧 `prev_mask` 与首帧 ByteCoreML `nn_3` 逐字节相同。该 capture 是把只读 CoreML hook 注入当前 QCut Bach bridge 的隔离 worker 后取得，不是剪映 GUI capture，也不是单帧 frame probe。此前 60 帧真人 A/B 仍作为结果侧交叉验证：上一帧语义的 MAE/IoU 为 `2.1942/255`、`0.997186`，优于错误的当前帧语义 `2.3791/255`、`0.996814`。
+
+固定版本的 native route 为 `video-object-jianying-bach-v2-exact-d634-v1`，产品 provider/pipeline 为 `qcut-jianying-video-object-bach-v2-exact-d634-v1`；它们只接受匹配的 runtime UUID/SHA、graph SHA、model SHA、V2 capability marker、config ID，以及本机 runtime manifest 全部 23 个私有 Framework dylib 的逐文件 SHA。闭包 identity 是 `jianying-runtime-framework-closure-d634-v1-e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e`。它不是跨剪映版本、macOS 或 GPU 的通用 ABI。blend identity 为 `TEMattingBlendEffectV2-vendor-exact`。默认 refinement identity 是 `vendor-v2-exact-no-qcut-refinement-v1`；只有用户显式改变高级参数时，才在 V2 源尺寸 Alpha 之后进入 `qcut-alpha-refinement-after-vendor-v2-v1`。无私有宿主的 provider 仍明确为 `qcut-video-object-same-model-coreml-v1`，能力角色记录为 `private-host-independent-fallback`。旧 Effect host interop 只保留为质量门禁候选和回退诊断。
+
+QCut 仍保留完整流 Alpha 质量门禁。旧 host interop 若再次产生 `0/1/2` 坏 Alpha，会自动回退 GRU + Vision；direct CoreML 接线曾在真实产品 render 中完成 60 帧推理、VP9 Alpha 编码，并返回：
+
+```text
+requested=video-object
+actual=video-object
+provider=qcut-video-object-same-model-coreml-v1
+pipeline=qcut-video-object-same-model-coreml-v1
+refinement=qcut-same-model-graph-output-v1
+didModelRouteFallback=false
+frames=60
+```
+
+该旧 E2E 只证明 fallback 的产品接线、时序与编码链可运行。当前 fixed Bach+V2 产品路径已另用同一段 60 帧真人宽景完成正式 Electron E2E：`1/1 passed (22.1s)`，首轮真实执行 exact helper、第二轮命中独立新缓存，两轮均返回 `provider/pipeline=qcut-jianying-video-object-bach-v2-exact-d634-v1`、`blend=TEMattingBlendEffectV2-vendor-exact`、`refinement=vendor-v2-exact-no-qcut-refinement-v1`，且 `didModelRouteFallback=false`。完整证据见 [固定版同算法验收](./jianying-person-cutout-exact-bach-v2-2026-08-28.zh.md)。
+
+## 旧 Object host interop 注册与诊断边界
+
+本轮没有把未验证的私有 ABI 接进产品。静态调用链确认 `bef_effect_init(..., modelDir, ...)` 已在内部创建普通 file resource finder；改成显式调用同一个 finder 不会改变解析语义。其他可见入口也不能直接当作缺失拼图：Bach finder 创建入口依赖 Effect/host helper，JavaScript resource finder 只是 URL 回调，assigned-model API 映射的是逻辑 key/name，而不是已证明可替代剪映宿主的 physical-model/设备注册。
+
+真实包与 QCut 生成包的 A/B 又给出更强的运行证据：真实 root `config.json` 通过 `Link: matting` 声明五个候选模型，`ai_matting_video_object` 子目录只含 graph；QCut 的 standalone 包直接声明 object graph。两条都能解析同一模型、进入同一后端，也都得到相同的零输入纹理告警和 `0/1/2` Alpha。因此当前不应继续把“模型名日志为 null”单独解释成模型未加载，更不能仅凭 Effect C API 返回 0 宣称 provider 成功。
+
+QCut 仍把旧 Effect host 路径显式标为 `output-gated-candidate`，诊断能力记录普通 file resolver、QCut standalone effect、未复现的 host Effect registry 和 C API texture 输入；该描述进入独立 capability 指纹。它与已验证的 `same-model-coreml` provider 分开，不能污染 direct CoreML 的 provider、pipeline 或缓存身份。只有同时包含质量 capability marker 与整段 hostless `0/1/2` 特征的错误才打开旧路径 circuit；其他结果提取失败、取消或瞬时错误仍逐任务 fail closed 回退 GRU + Vision。
+
+本轮继续完成了两条输入传输 A/B：
+
+- `QCUT_JIANYING_ENGINE_CONTEXT_PROBE=1` 能绑定 `HTSGLContext.sharedImageProcessingContext`，但独立进程随后报告 `RenderDeviceGLES30 createSharedContext() failed` 并停止推进。该路径只保留为显式诊断探针，生产默认不启用。
+- ARM64 真实调用点确认私有 buffer ABI 为 `algorithm_buffer(handle, width, height, data, format, timestamp)`；RGBA format `0` 与[官方 Effect SDK 像素格式](https://docs.byteplus.com/en/docs/effects/docs-c-api)一致。真实 wrapper 会先取得/刷新一对 16-byte new requirement。QCut 的 standalone Bach graph 即使在 `effectSet` 后等待并用 texture 入口激活，`get_new_requirment` 仍返回 `0/0`，直接 buffer 调用返回 `2`，没有进入模型推理。因此缺口进一步收敛为剪映宿主注入的 requirement/设备输入状态，而不是 buffer 指针、宽高或 RGBA 枚举；该 canary 也只在 `QCUT_JIANYING_BUFFER_INPUT_PROBE=1` 时运行。
+
+继续替换相同 file resolver、重复改 `model_names` 或伪造另一份 standalone `config.json`，现有证据预计不会改变结果。下一项有效实验是从剪映真实 render 调用截获这对 requirement，或在同 RLDevice 中构造 device texture；在此之前不把猜测 ABI 放进默认 provider。
+
+## 实现变化
+
+### Same-model CoreML provider
+
+- packed model 必须匹配固定 SHA-256；提取后还会验证 `data`、`prev_img`、`prev_mask`、`nn_3` 的 metadata tensor contract。
+- 缓存命中不重读 packed model；损坏缓存会原子替换，并发提取只接受最终通过 schema 验证的 bundle，不会删除另一个调用已经发布的有效缓存。
+- direct provider 不再要求 `libcccreator.dylib`、真实 effect graph 文件或私有宿主 framework 存在；这些只属于旧 host interop fallback。
+- native bridge 逐帧保存上一帧 image/mask 状态，reset 会同时清零两者；`QCUT_VIDEO_OBJECT_RESET_FRAMES` 只作为测试/seek 语义探针。
+- 精细默认参数 `0.5/0/0/0` 保持 raw graph output；额外 QCut refinement 使用不同 pipeline id，避免把自主后处理伪装成剪映原始蒙版。
+- packaged direct bridge 必须包含 `video-object-same-model-coreml-v1`；它只校验 tensor shape、finite 与 clamp，不能套用 hostless `0/1/2` 启发式。Alpha 质量 marker 只属于旧 host interop bridge。
+
+### 自动路由
+
+- `auto` 不再直接返回 GRU；它会解析 object runtime、完整检测所有抽样帧，再按实际决定选择运行时。
+- 比例严格按 `facePositiveSampleCount / validSampleCount` 计算，不再遇到第一张脸就提前结束。
+- 任一抽帧、解码或检测失败都会使整次路由 fail closed，避免用部分样本错误切换模型。
+- 路由失败和 Blend 失败分层回退；object 失败后，GRU 会重新使用自己的稳定 Blend 选择，不会继承 object 的执行状态。
+- object bridge 每帧前恢复 QCut 自有 OpenGL context，避免 vendor effect 切换 context 或残留 GL error 让第 2 帧纹理更新误失败。
+- Alpha 门禁在完整流结束后判定；合法空画面不误回退，只有完整流 `0/1/2` 量化噪声才标记 hostless。
+- 同一 bridge capability 一旦命中明确的坏 Alpha 能力标记，本次 App 会话内会打开 circuit breaker；后续自动任务直接走 GRU 缓存，不再重复付出已知无效的 object graph 成本。capability 指纹不含画幅，bridge/model/library/graph 更新才会自动重新探测；诊断环境也可显式要求重试。
+- object 子进程若连续 20 秒没有任何 stderr/progress 活动，会被终止并自动切换 GRU + Vision，避免私有 context 或设备初始化卡住整项任务。
+- engine-context 与 CPU-buffer 两条宿主输入实验均为显式 opt-in；生产默认继续使用已验证的 standalone texture、完整 Alpha 门禁和回退链。
+- 结果同时保存 `requestedModelRoute`、`modelRoute` 和 `didModelRouteFallback`。
+- 自动抽帧、face detection、ffprobe 与单个订阅者等待均支持取消；相同 Alpha 的共享构建不再被第一个调用者取消后连带中断。
+
+### 结果身份与缓存
+
+- Provider 改为真实的 `qcut-local-person-matting-v1`，不再把 GRU + Vision 标成完整剪映宿主。
+- Pipeline 明确区分 GRU + Vision、GRU-only、已验证 same-model CoreML、显式 QCut-refined CoreML、实验性 host interop 和实验性 saliency script。
+- Alpha 缓存升级到 v4；manifest 新增 `providerId`、`pipelineId`、`refinementProvider` 和整份 `alpha.gray` 的 SHA-256。
+- 缓存命中会验证 Alpha 长度和内容哈希，能拒绝“长度正确但内容损坏”的文件。
+- 源视频优先使用声明/实读帧数，缺失时才按时长与帧率估算；Alpha 帧数必须满足对应容差，成功退出但中途截断的 stream 不能写入缓存。
+- Blend 实现不再参与预合成 Alpha 缓存键。native/compatible 的语义 Alpha 相同，不再因合成诊断路径重复推理。
+- Processor 指纹加入实际 `libcccreator.dylib` 内容哈希；Vision 是否启用也进入 pipeline 与 processor 身份。
+- 透明视频 metadata 写入实际 provider、pipeline、route 和 refinement，不再只写模型名。
+
+### GPU 与 CPU 往返
+
+持久缓存保存的是合成前的语义 Alpha。旧 native 路径每帧把源图和 Alpha 上传 GPU，再回读完整 RGBA，但后续只保留回读 Alpha；这在当前 CPU VP9 Alpha 编码链中没有形成零拷贝，反而增加往返。
+
+现在的策略是：
+
+- 生产默认使用 compatible 路径生成同一语义 Alpha；
+- 私有 native Metal 只在显式诊断开关下启动，并用一帧验证私有 ABI、设备链和像素公式；
+- 首帧通过后，其余帧直接在 CPU 以已经逐字节验证的 `sourceAlpha × matte / 255` 公式写缓存；
+- 同尺寸 Alpha resize 直接复制；最大位移为 0 时跳过平移搜索；时序衰减由逐像素 `pow` 改为逐参考帧预计算；
+- bridge 输出分阶段计时 JSON，分别记录 GRU、Vision、resize、postprocess、native canary 和 cache write。
+- 静默透明 WebM 明确写入 `hasAudio=false` 后，预览不再额外启动隐藏的原视频 audio decoder；旧素材缺少 metadata 时仍保留兼容回退。
+
+这不等于端到端 GPU 零拷贝。真正的零拷贝仍需要预览直接消费设备纹理，或编码器直接接收 GPU/CVPixelBuffer，而不是把 Alpha 写成 CPU 灰度缓存后交给 `libvpx-vp9`。
+
+## Raw capture 与真人基准
+
+### Source → 256 resize 规则
+
+对 SHA-256
+`bb6ac4b70ab4ae5b683fdeb43faf082051098bc72192f1fd947806c39bb4333d`
+的首帧 360×640 RGBA，与 `coreml-0000-data.bin` 的 BGR/NCHW float32
+比较结果如下。MAE 与最大误差均以 8-bit 灰阶计：
+
+| 候选 | MAE | 最大误差 | 逐值相同 |
+| --- | ---: | ---: | ---: |
+| direct half-pixel，`floor(v + 0.5)` | **0.0875905** | **1** | **179387 / 196608（91.2409%）** |
+| direct half-pixel，banker's rounding | 0.0926208 | 1 | 178398 / 196608 |
+| direct half-pixel，floor | 0.363022 | 1 | 125235 / 196608 |
+| direct align-corners 最优 | 1.652903 | 94 | 78324 / 196608 |
+| direct asymmetric 最优 | 3.426290 | 148 | 51074 / 196608 |
+| two-stage half-pixel 最优 | 1.401647 | 96 | 88109 / 196608 |
+| 产品旧 two-stage half-pixel/round | 1.425771 | 96 | 84235 / 196608 |
+
+真实 `vImageScale_ARGB8888` direct 默认路径为 MAE `1.424276`、最大误差
+`83`；FFmpeg swscale 候选中最好的 area 为 MAE `1.116948`、最大误差
+`59`。VideoToolbox 解码出的首帧也没有缩小残差：同一 direct half-pixel/round
+变成 MAE `0.109426`、最大误差 `3`、逐值相同 `89.5218%`。因此当前最可信规则是：
+
+```text
+sx = (dx + 0.5) * sourceWidth  / 256 - 0.5
+sy = (dy + 0.5) * sourceHeight / 256 - 0.5
+u8 = floor(bilinear(source, sx, sy) + 0.5)
+tensor = BGR(u8) / 255, NCHW
+```
+
+在 360→256 与 640→256 这组比例上，6 bit 以上的 OpenCV-style 定点权重
+与 float half-pixel 得到相同候选，现有 capture 无法再区分二者。剩余 `±1`
+也不能由一个全局取整阈值解释，更可能来自剪映 frame reader 的颜色转换或内部
+整数 kernel；它不再阻塞 exact Bach worker，因为 exact worker 直接复用同一 Bach
+preprocess，只影响独立 CoreML fallback 的 bit-exact 声明。
+
+完整 resize 比较日志保存在
+`/private/tmp/qcut-resize-forensics-20260828-144456.log`，SHA-256 为
+`e37bd02ea28d138bcd26cea3aa3cfdb3c8533f5f33e469df5bdb6e73ee673316`。
+
+### 两帧 temporal capture
+
+本次 capture 目录为
+`/private/tmp/qcut-jy-coreml-capture-20260828-144456`。被测对象是从当前产品源
+`electron/jianying-person-cutout/native/video-object-bach-bridge.mm` 编译出的隔离
+Bach bridge；`coreml-feature-capture.mm` 仅作为只读 hook 注入该 worker，记录
+`MLDictionaryFeatureProvider` 输入。它不是剪映 GUI 进程，也不是早期单帧
+`qcut-jy-bach-frame-probe`。
+
+| 文件 | 字节 | SHA-256 |
+| --- | ---: | --- |
+| `capture.log` | 391 | `f3a8f1da3911e9ce4dfe9ce4e617469fa59bcf4a29b36c27e436435d8c8b23a5` |
+| `coreml-0000-data.bin` | 786432 | `209e3e1a88dc2464eee4d35575850cade736b8a916ae1125b1d7dffed77af801` |
+| `coreml-0000-prev_img.bin` | 786432 | `599c1bb5ffd4b87229a81958f33f1060821cd01cd7aa7ccafa0d862f4522f3f6` |
+| `coreml-0000-prev_mask.bin` | 262144 | `8a39d2abd3999ab73c34db2476849cddf303ce389b35826850f9a700589b4a90` |
+| `coreml-0001-data.bin` | 786432 | `cc74c2458883139c3fe54e2f8f2734e88a6bbe1d91fc1f6ada9bdaf8e1603bff` |
+| `coreml-0001-prev_img.bin` | 786432 | `209e3e1a88dc2464eee4d35575850cade736b8a916ae1125b1d7dffed77af801` |
+| `coreml-0001-prev_mask.bin` | 262144 | `18914e224988222bf3f47b1bf07ef9c71b877c278c21b8c986f751fcbba43a07` |
+
+`coreml-0000-prev_img.bin` 和 `coreml-0000-prev_mask.bin` 分别为全零
+`196608`/`65536` floats。`coreml-0001-prev_img.bin` 与
+`coreml-0000-data.bin` 不只是数值相等，而是 SHA 与所有 bytes 完全相同；
+`coreml-0001-prev_mask.bin` 也与先前首帧 ByteCoreML 输出
+`bytecoreml-nn_3.bin` 的 SHA
+`18914e224988222bf3f47b1bf07ef9c71b877c278c21b8c986f751fcbba43a07`
+完全相同。这直接证明第二帧输入的是上一帧 image 与上一帧 raw `nn_3`。
+
+输入两帧 RGBA SHA-256 为
+`aad9a96c96f2c40ba1e3f0117bcb1aa8628546cd61a8ae25438eba58fe66f38e`；
+该次历史输出仍使用 QCut 双线性放大；`/private/tmp/qcut-jy-bach-two-frame-alpha-20260828-144456.gray` 为
+`460800` bytes，SHA-256
+`092b2f8c362868a2dc6d601b6561c41e56d705069af8ae98ccf143f376a5332b`。
+完整执行日志在 `/private/tmp/qcut-jy-bach-two-frame-20260828-144456.log`
+（SHA-256
+`fc6b238de9ea5ea7f80bfcf398516a4f9e6804daf5044b9516a797476429aa16`）。
+该日志属于 V2 接入前的历史 bridge，只用于 raw Bach/temporal 证据，末尾为：
+
+```text
+progress frame=1 total=2
+progress frame=2 total=2
+ok width=360 height=640 frames=2 route=video-object-jianying-bach-d634-v1
+```
+
+### Bach raw256 → vendor V2 source Alpha
+
+当前 exact helper 已把上述 raw mask 接入同一固定版 `TEMattingBlendEffectV2`。
+同一两帧真人输入的 source-size Alpha 为 `460800` bytes，SHA-256
+`dca0f2912ba0188939737920b18c66834d7354aca7e11b8c906d4effd85f6c3e`；
+无可选参数与显式 `0.5 0 0 0` 逐字节相同。首帧 SHA-256
+`e8ad4c25d5d1a4dc0cc6a559686c14d98d411e43918c45d8c3249f4a56d3ba97`，
+与独立 V2 probe 输出完全相同。
+
+60 帧输出为 `13,824,000` bytes，SHA-256
+`f1a113fc4b4330e9c405508253848376bf60b6f9b0eddcbddb712abdf0cc7b91`；
+两次运行逐字节一致。旧 QCut resize 的 60 帧 SHA-256 为
+`589b1e55c8ec7265b3fc00ab55bb5e4d5ab3009e54602b345324f9553cdd3c8c`；
+两者 `168640/13824000` 像素不同，且全部只差 `1`，u8 MAE `0.0121991`、
+soft IoU `0.99993001`。单次同机 wall-clock 为 vendor V2 `1.07s`、旧 resize
+`0.94s`。最终升级为完整 23-dylib Framework 闭包门禁后，60 帧输出 SHA 不变，
+单次 wall-clock 为 `1.10s`；只执行所有 SHA 门禁、在 `dlopen` 前因缺失输入退出的
+warm-cache 测量为 `0.61s`。
+
+闭包按 basename 排序的 `basename=sha256\n` digest 为
+`e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e`。
+native 在 `dlopen` 前逐文件校验主 `libcccreator` 与其余 22 个 Framework；把临时
+快照中的间接依赖 `libIESAppLogger.dylib` 截断后，worker 以退出码 1 拒绝并报告
+该文件 SHA 不匹配。系统 Framework、CoreML、GPU 驱动和硬件仍是宿主环境边界。
+
+默认成功日志明确为：
+
+```text
+ok width=360 height=640 frames=60 route=video-object-jianying-bach-v2-exact-d634-v1 blend=TEMattingBlendEffectV2-vendor-exact closure=jianying-runtime-framework-closure-d634-v1-e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e refinement=vendor-v2-exact-no-qcut-refinement-v1
+```
+
+非默认 `0.6 0.2 1 2` 在 V2 后执行 refinement，2 帧输出 SHA-256 为
+`ace77edac0f73dd5415311e23b14f7f0f3d21ac5809d721946a3baa49b7e5e74`，
+并报告 `qcut-alpha-refinement-after-vendor-v2-v1`，不会冒充默认 exact。
+
+异常清理也做了真实流式故障注入：输入一帧再附加一个残缺字节，helper 先完成第一帧，
+随后以 `video-object input ended mid-frame` 返回 1，并按
+`V2 -> restore Engine context -> Bach` 顺序完整销毁。context 恢复失败会终止隔离
+进程，由 parent fallback 接管。
+
+### Bach `nn_3` 对 graph `saliency_mask`
+
+新的只读 hook 直接截获 `IESMMProcessNN::doDictPredictionWithOptions:error:`
+返回的 ByteCoreML `nn_3`，不再用 standalone CoreML replay 代替 vendor backend。
+完整两帧 capture 位于
+`/private/tmp/qcut-jy-coreml-capture-20260828-1444`：
+
+| 文件 | 字节 | SHA-256 |
+| --- | ---: | --- |
+| `bytecoreml-0000-nn_3.bin` | 262144 | `18914e224988222bf3f47b1bf07ef9c71b877c278c21b8c986f751fcbba43a07` |
+| `bytecoreml-0001-nn_3.bin` | 262144 | `a6febb781f79279295a55018a0a4882cb3c374e13169f428f9df787356da4a59` |
+| `coreml-0000-data.bin` | 786432 | `209e3e1a88dc2464eee4d35575850cade736b8a916ae1125b1d7dffed77af801` |
+| `coreml-0000-prev_img.bin` | 786432 | `599c1bb5ffd4b87229a81958f33f1060821cd01cd7aa7ccafa0d862f4522f3f6` |
+| `coreml-0000-prev_mask.bin` | 262144 | `8a39d2abd3999ab73c34db2476849cddf303ce389b35826850f9a700589b4a90` |
+| `coreml-0001-data.bin` | 786432 | `cc74c2458883139c3fe54e2f8f2734e88a6bbe1d91fc1f6ada9bdaf8e1603bff` |
+| `coreml-0001-prev_img.bin` | 786432 | `209e3e1a88dc2464eee4d35575850cade736b8a916ae1125b1d7dffed77af801` |
+| `coreml-0001-prev_mask.bin` | 262144 | `18914e224988222bf3f47b1bf07ef9c71b877c278c21b8c986f751fcbba43a07` |
+
+对应 raw graph 输出
+`/private/tmp/qcut-jy-bach-two-frame-raw-256.gray` 为 `131072` bytes，
+SHA-256
+`1e49daa89eeade3d40ece0d5ea6658bf2bbb016dfb3585a56f5b09c7af4473f0`。
+两帧都满足：
+
+```text
+saliency_mask = round(clamp(nn_3, 0, 1) * 255)
+```
+
+逐帧均为 `65536/65536` 像素相同、MAE `0`、最大误差 `0`。旧的
+`0.04414/255`、最大 `1/255` 是 standalone Apple CoreML replay 相对
+ByteCoreML 的 backend drift，不是 graph `convert_2` 的量化差异。
+
+为了排除 V2 构造时的 TERL context/ConfigID 改写 Bach 推理，最终
+full-framework-closure capture worker 在构造 V2 后再次连续处理相同两帧；capture
+目录为
+`/private/tmp/qcut-jy-bach-v2-framework-closure-capture-final-20260828-1521`。
+frame 0/1 `nn_3` SHA 仍分别为上述 `18914e...43a07` 与
+`a6febb...a4a59`，相对 V2 接入前两个文件均 `cmp=0`。按 graph 规则量化后再与
+历史 raw 256 mask 比较，`131072/131072` 像素完全相同，MAE `0`、最大误差
+`0`。V2 初始化没有改变 Bach 原始 Mask，变化只发生在 raw Mask 后的 vendor
+source-size 合成。
+
+时序也产生了可观测结果：第二帧 warm raw mask SHA-256 为
+`2ad1da78ee5ae715dd9bc803f3b433ba7b4fa07e8327bbd13adf931489f3dea4`；
+把同一个 RGBA 帧放入新 worker 冷启动，SHA-256 为
+`10da001c8db46377f21f32e39aab9393db6a45268a37b33d7203ffedc95519c9`。
+两者 `23213/65536` 像素不同，u8 MAE `0.6737823486`、最大误差 `69`。
+
+### 旧 two-stage Same-model CoreML 对重建剪映 Alpha（已废弃）
+
+以下结果来自已经被 raw capture 排除的 `source → 288×512 → 256` 两段输入缩放，只保留为历史定位证据，不再代表当前 direct fallback，也不能作为新实现的 parity 数字。输入为同一段 360×640、30 fps、60 帧真人视频，参照 Alpha 是从剪映同段黑/白背景导出重建的 8-bit 代理，不是 `MP_ProcessBorder` 前的内部原始 tensor。
+
+| 指标 | 结果 |
+| --- | ---: |
+| 全片 MAE | **2.194188 / 255** |
+| 全片二值 IoU | **0.997186** |
+| frame 0 MAE / IoU | 1.810460 / 0.999039 |
+| frame 59 MAE / IoU | 8.422977 / 0.971162 |
+| 输出 SHA-256 | `4fb1c2c6b7c81577298f724f0d2cd575cd2a7132d389ff69dd8d08dd7ff26703` |
+
+frame 59 是该历史链的最弱帧，尾部差异可能同时包含错误的两段输入缩放、参照视频编码、帧对齐或尚未截获的图内后处理影响，不能单独归因到网络推理。reset 验证仍有效：在 frame 30 清零状态后，后 30 帧与从源 frame 30 冷启动的输出逐字节相同，MAE 为 0。
+
+### 既有 GRU/Blend 性能基准
+
+输入为同一段 360×640、30 fps、60 帧真人视频。先解码为同一 RGBA 文件，再分别连续运行三次 bridge；两条路径均启用 GRU + Vision。
+
+| 路径 | 三次总耗时 | 中位数 | native canary 帧 |
+| --- | --- | ---: | ---: |
+| compatible | 6516.309 / 6570.317 / 6533.095 ms | **6533.095 ms** | 0 |
+| native canary | 6577.883 / 6526.306 / 6445.312 ms | **6526.306 ms** | 1 |
+
+修正后的 `total_us` 包含输出 flush、Vision/Metal/handle 释放与 `dlclose`，等于完整 bridge wall time。两条中位数只差 `6.789 ms`，约 `0.10%`，方向属于系统噪声，当前应表述为“性能持平”，不能宣称 native 加速。native 单帧 canary 本身三次为 `19.265 / 16.320 / 15.906 ms`。历史逐帧 native 实现的同类 60 帧结果曾慢约 `831 ms`；这足以确认逐帧 GPU 上传/回读已从当前缓存链移除。
+
+六份 13,824,000 字节 Alpha 的 SHA-256 全部相同：
+
+```text
+7f36016c92476d48e6ef50376b1ae46955feb2c0d6e7f23dfbd0d4b215b1fbe3
+```
+
+这证明本轮性能调整没有改变输出 Alpha。
+
+## Same-model 真人桌面 E2E（输入修正前的接线证据）
+
+使用同一段 360×640、60 帧真人宽景，强制 `QCUT_PERSON_CUTOUT_ROUTE=video-object` 运行完整 Electron UI 流程，实际完成素材导入、精细抠像、Alpha 缓存、VP9 透明视频、时间线蒙版挂载、浏览器解码和播放器预览，结果为 `1/1 passed (23.8s)`。该次运行使用现已废弃的两段 resize；它只证明接线完整，不代表 source→256 v2 的当前画质或缓存结果。
+
+- `requestedModelRoute=video-object`、`modelRoute=video-object`；
+- `didModelRouteFallback=false`；
+- `provider/pipeline=qcut-video-object-same-model-coreml-v1`；
+- `refinementProvider=qcut-same-model-graph-output-v1`；
+- 60 帧、2 秒、360×640、30 fps、VP9 Alpha、无音频；
+- 浏览器解码 ROI：顶部背景 `0`、中心人物 `252.8691`；
+- 第二次运行命中完整 Alpha 缓存，仍保持 same-model provider、无 route fallback，耗时 `4435 ms`（包含 VP9 重新编码）。
+
+本地证据目录：
+
+```text
+/private/tmp/qcut-same-model-desktop-e2e-20260828/
+```
+
+其中包含三张 UI 截图、`desktop-person-cutout.webm` 与 `e2e-evidence.json`。这些真人素材和运行证据不进入仓库。
+
+## 历史 host interop 真人桌面 E2E
+
+完整 Electron E2E 分别使用近景和宽景真人片段，实际完成自动路由、60 帧 object graph、坏 Alpha 拒绝、GRU + Vision 回退、VP9 Alpha 编码、素材入库、时间线蒙版挂载、播放器解码，以及同一 App 会话的 circuit/cache 二次运行。最终两次均为 `1/1 passed`。
+
+关键结果：
+
+- 输出：2 秒、360×640、30 fps、60 帧 VP9，`ALPHA_MODE=1`；
+- `requestedModelRoute=auto`；
+- `modelRoute=portrait-gru`；
+- `didModelRouteFallback=true`；
+- `provider=qcut-local-person-matting-v1`；
+- `pipelineId=qcut-gru-vision-fusion-v1`；
+- 近景浏览器解码 ROI：人物核心 `223.77934`、前景手部 `255`、右上背景 `0`；
+- 宽景浏览器解码 ROI：中心人物 `252.98184`、顶部背景 `0`；
+- 截图目检中老人脸、头发、身体和搀扶人物均被保留。
+- 同一 App 会话第二次执行中，近景耗时 `4071 ms`、宽景耗时 `5058 ms`，两者均为 `didModelRouteFallback=false`：circuit breaker 跳过已知坏 object capability，并明确观察到“人物蒙版缓存完整”后重新编码。该耗时包含 VP9 Alpha 重新编码，不等于纯缓存读取延迟。
+
+证据目录：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-parity-gap-reduction-2026-08-28/desktop-near-route-gl-context/
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-parity-gap-reduction-2026-08-28/desktop-wide-route-final/
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-parity-gap-reduction-2026-08-28/desktop-auto-post-context-gate/
+```
+
+每个目录都包含 `desktop-person-cutout.webm`、三张桌面截图、`e2e-evidence.json` 和本地 `electron-runtime.log`；运行时日志只作为私有证据，不进入仓库。
+
+## 当前剩余差距
+
+1. **exact Bach+V2 内部链已逐字节闭环，direct CoreML fallback 仍非 bit-exact。** 产品 helper 与独立 vendor V2 probe 的真人首帧源尺寸 Alpha exact ratio `1`、MAE `0`、IoU `1`；V2 前后两帧 raw `nn_3` 也逐字节不变。direct CoreML 的 source→256 输入仍有单灰阶差异，因此只能作为独立身份的 fallback。
+2. **cache cursor 提交顺序未完全静态还原。** previous-image 的选择有明确全片 A/B 支持，但仍需截获 `UpdateCacheIdx` 的真实调用顺序才能把 offset 语义完全锁死。
+3. **自动模型路由仍需更多真实片段覆盖。** object route 已是同模型链；近景选择 GRU 时，QCut 的 GRU + Vision 仍是自主补洞，不代表剪映内部调用 Vision。
+4. **还不是端到端 GPU 零拷贝。** direct CoreML 输入、Alpha 缓存和 VP9 编码仍经过 CPU；剪映可能在预览链内直接传递设备纹理/CVPixelBuffer。
+5. **剪映缓存失效与预览策略没有完全复制。** 变速、倒放、源范围、切镜、`tt_matting_video_preview.model` 和预览/导出模型切换仍需单独动态样本。
+
+## 验证门禁
+
+- packed ZIP offset、tensor schema 拒绝、完整 manifest/hash 缓存命中、损坏修复、并发发布与活 PID 锁：9/9 定向测试通过。
+- same-model/host capability 隔离、resolver fail-closed、processor/cache 身份、编译发布与 packaged marker 已进入 17 个 focused 文件、79 项测试并全部通过。
+- CoreML native preprocess 测试以 `-Wall -Wextra -Werror` 在 Vitest 中真实编译运行；覆盖 source→256、BGR/NCHW、首帧零状态、advance/reset、合法低值 Alpha 与非有限值拒绝。
+- 当前 `renderJianyingPersonCutout` 强制 exact video-object E2E 已完成 60 帧、无 fallback、VP9 Alpha 编码、桌面截图与第二轮 cache-hit；结果为 `1/1 passed (22.1s)`。
+- 路由、取消、缓存、回退、无进度保护、计时、metadata、UI、签名和打包能力门禁均已通过；完整 fixed-version 结论与证据索引见 [固定版同算法验收](./jianying-person-cutout-exact-bach-v2-2026-08-28.zh.md)。
+- 原生 Alpha resize、融合、时序、Vision、object Alpha 质量及两套 bridge 均通过编译/执行门禁，使用 `-Wall -Wextra -Werror`。
+- 全仓 TypeScript：通过。
+- Electron build：通过。
+- Web production build：通过。
+- 真人 Electron E2E：近景、宽景及最终默认 auto 回归各 1/1 通过；最终 auto 回归耗时 `28.4s`，包含 Alpha ROI、静默结果无隐藏 audio decoder、cache-hit 和第二次路由状态断言。
+
+仓库只记录 QCut 自有代码、测试和结论；剪映 dylib、模型、原始动态日志及真人素材继续保存在用户本机，不进入版本库。

--- a/qcut/docs/task/jianying-filter-runtime-research/portrait-matting-gru-parity-2026-08-27.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/portrait-matting-gru-parity-2026-08-27.zh.md
@@ -1,0 +1,580 @@
+# 剪映人物抠像 GRU 对齐记录（2026-08-27）
+
+## 结论
+
+QCut 与剪映现在使用同一份本地 `tt_matting_video_gru_v1.0.model`，并按 `TEMattingBlendEffectV2` 的透明模式语义输出可合成 Alpha。此前仍有三处可避免的链路差异：输入通道顺序、Alpha 放大方式，以及 GRU 输出后的二次时间平滑和阈值化。本次已修正这三处，并在真人运动视频上完成桌面端 E2E。
+
+本机剪映专业版 11.3.0 当前 UI 暴露的是“智能抠像”、跟踪方向，以及已完成结果的羽化、边缘硬度、描边和阴影等控制；模型类型、网络输入尺寸及原生后处理参数留在内部。QCut 的“基础 / 精细”是面向用户的能力分层，不是剪映当前界面的逐字复制。
+
+## 二进制证据
+
+- 模型 SHA-256：`101688825490be3704babc7ce49f6d002cdb4fe69e879556b4687ac9006f8596`。
+- `bef_Portrait_Matting_InitModel` 以外部类型 `4` 初始化后，`bef_Portrait_Matting_GetParam(handle, 6, ...)` 返回内部模型类型 `6`。
+- 初始化后的参数值为：`0=1`、`1=15`、`2=256`、`3=0`、`4=0`、`5=0`、`6=6`、`7=0`。
+- `MP_DoPortraitMattingRect` 对输入像素格式 `2` 走三通道直接复制路径；其他格式统一转换到格式 `2`。
+- `liblens.dylib` 的 `GetColorConvertCode` 4×4 转换表为：
+
+  ```text
+  -1  5  3  1
+   5 -1  1  3
+   2  0 -1  4
+   0  2  4 -1
+  ```
+
+  对照 OpenCV 色彩转换码可确定格式顺序为 RGBA、BGRA、BGR、RGB，因此格式 `2` 是 BGR888。旧桥把 RGB 字节标成格式 `2`，红蓝通道实际颠倒。
+- 高层运行时还包含 `TEMattingReaderUnit2::preProcessAlphaChannel`、`TEMattingBlendEffect2` 和 `TEMattingBlendEffectV2`。这证明剪映不是直接显示低分辨率网络 Alpha，而是经过独立预处理和 Blend 后处理链。
+- `TEMattingBlendEffectV2` 的透明模式片元公式为 `mix(vec4(0), source, mask.r)`，即输出预乘色和 Mask Alpha。QCut 的 WebM 采用直通 RGB + 同一 Mask Alpha，最终由 Chromium 合成器执行预乘；最终画面公式相同，同时避免在编码前预乘后被播放器再次乘 Alpha 产生黑边。
+- 原生 V2 设备纹理入口已定位并做了独立 ABI 探针。后续宿主研究已复现 Metal RLDevice 注册、三张 AGFX `DeviceTexture` 和 `FastBlend`，`TEMattingBlendEffectV2::init=1`、`v2_active=1`，真人首帧调用成功且逐通道符合预乘透明公式。产品 provider 随后已接入该路径，并以精确 dylib 指纹、config ID 校验和整段兼容回退约束私有 ABI。完整证据见 [tematting-blend-v2-native-metal-2026-08-27.zh.md](tematting-blend-v2-native-metal-2026-08-27.zh.md)。
+
+## 本次实现
+
+- RGBA 解码帧改为 BGR888 后送入原生 GRU。
+- 原生 Alpha 从 `256×448` 放大到源尺寸时，由最近邻改成半像素中心双线性采样。
+- “精细”默认值改为保留原生 GRU Alpha：不再默认叠加第二次时间平滑、羽化和阈值重映射。
+- “基础”和“精细”各自保留一套高级参数，切换质量时不互相污染。
+- 桥启动后读取并校验内部模型类型必须为 `6`，避免缓存存在但实际模型分支不一致。
+- 按反汇编校正 `MattingInput` ABI：`invertAlpha` 必须位于偏移 `0x20`，其前方保留 4 字节字段；桥内加入编译期偏移断言，避免私有结构体读取越界。
+- 原生 ByteNN/AGFX 会向进程标准输出写诊断日志。流式模式原先也用标准输出传 Alpha，日志字节因此进入灰度帧流，造成画面分块、水平接缝和后续帧错位。桥现在复制原始输出描述符专供 Alpha，并把运行库标准输出重定向到标准错误；二进制数据与日志已完全分离。
+- 输出文件写入实际 Blend 实现和 `qcut_matting_model=tt_matting_video_gru_v1.0` 元数据；当前受支持版本为 `qcut_matting_blend=TEMattingBlendEffectV2-native-metal`，自动回退时则标记 `compatible`，E2E 不再只依赖 UI 文案。
+- 新增只读参数探针 `portrait-matting-param-probe.cpp`。
+- 新增 V2 设备纹理 ABI 探针 `portrait-matting-blend-v2-probe.cpp`；该探针现在同时校验 RLDevice 所有权、Metal renderer、执行计划、原生返回值和像素公式。
+
+## 真人视频验证
+
+输入：2 秒、360×640、30 fps、60 帧真人运动片段。
+
+| 指标 | 旧链路 | 对齐后 |
+| --- | ---: | ---: |
+| Alpha 均值 | 76.631 | 159.537 |
+| `alpha > 127` 覆盖率 | 30.138% | 65.686% |
+| 半透明像素占比 | 3.327% | 41.242% |
+| 相邻帧 Alpha MAE | 3.6544 | 12.0044 |
+
+旧链路的默认阈值和平滑把手、猫和大量软边缘误删，只剩上半部人物硬蒙版。对齐后恢复了手、猫、衣服和软边缘。较高的相邻帧 MAE 主要来自取消额外的 0.65 时间低通；GRU 本身已经保留跨帧状态，旧值不能直接解释为更接近剪映。
+
+桌面 E2E 状态：精细模式完成，耗时 5 秒，界面显示“人物蒙版已应用到所选片段”。输出为 2 秒 VP9 WebM，360×640，`ALPHA_MODE=1`。
+
+新增 `TEMattingBlendEffectV2-compatible` 输出与上一版 GRU 对齐输出逐帧完全一致：SSIM `1.000000`，PSNR `inf`。变化只在合成职责封装和可核验元数据，不改变已验证的 Alpha 结果。
+
+状态重置验证：同一真人首帧分别交给两个全新桥进程，两个 `256×448` Alpha 输出均为 230400 字节，SHA-256 同为 `ef731a1767e2c4f345d1afa0cf2cc7fced96a8983433a42e5a6820dfa6c08d0b`，字节比较相同。这证明新任务会从干净的 GRU 状态开始，不会继承上一个片段的时序状态。
+
+本机证据目录：`/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/`
+
+- `real-person-cutout-gru-parity-v2-2s.webm`
+- `alpha-old-vs-parity-v2-2s.mp4`
+- `alpha-old-frame0.png`
+- `alpha-parity-v2-frame0.png`
+- `qcut-gru-fine-e2e-after.png`
+- `jianying-smart-cutout-ui.jpeg`
+- `real-person-cutout-tematting-v2-compatible-2s.webm`
+- `tematting-v2-compatible-runtime.log`
+- `tematting-v2-compatible-checkerboard-1s.png`
+
+## 仍有差距
+
+1. QCut 人物抠像 provider 已执行 `TEMattingBlendEffectV2` 原生 Metal `FastBlend`，并跨帧复用 input、Mask、output 三张纹理；Alpha 仍需回读编码，因此还不是最终零拷贝加速形态。
+2. 当前剪映对照 Alpha 来自黑底/白底两次 H.264 导出的反推值，不是剪映直接导出的无损 Alpha；编码色差会进入误差，因此数值只能作为高可信代理，不能称为逐字节真值。
+3. 羽化和边缘硬度的数值映射仍是 QCut 参数语义，不应宣称与剪映滑杆一一对应。
+4. 有效宽景样本的后 30 帧差距显著大于前 30 帧。后续反汇编没有发现宿主执行固定的“前后帧 Alpha 融合”；更可靠的候选是 GRU recurrent state 的重置时机、片段级模型路由、边缘处理入口差异，以及黑白底 H.264 反推 Alpha 自身的误差，而不是给默认蒙版统一加腐蚀或阈值。
+
+## 流式管线与取消（2026-08-27 下午）
+
+原来的产品链先把整段视频解码为 `frames.rgba`，再把整段 Alpha 写为 `alpha.gray`，最后第三次启动 FFmpeg 编码。渲染期间的进度只有固定的 `8 -> 94`，AbortSignal 也只能在本机调用前后检查，不能终止已运行的桥。
+
+现已改为带背压的连续管线：
+
+```text
+FFmpeg RGBA stdout -> GRU/TEMatting stdin
+GRU Alpha stdout   -> FFmpeg alpha stdin -> VP9 WebM
+```
+
+- 不再创建整段 RGBA 或 Alpha 临时文件；临时目录只保留最终 WebM。
+- 桥逐帧向 stderr 报告 `frame/total`，IPC 以任务 ID 回传真实进度。
+- Renderer 取消会通过独立 IPC 触发 AbortController，同时终止解码器、原生桥和编码器；一秒后仍未退出的子进程会被强制结束。
+- Native Metal 的 input、Alpha、output 三张纹理均已改为跨帧复用；逐帧通过已验证的 `RendererDevice::updateTexture` 更新内容。
+- AbortError 不再触发 native -> compatible 自动重跑。
+
+同一 2 秒、360×640、60 帧真人视频验证：
+
+| 项目 | 结果 |
+| --- | --- |
+| Node 产品运行时 native Metal | 成功，60/60 帧，4.91 秒 |
+| Node 产品运行时 compatible | 成功，60/60 帧，4.11 秒 |
+| 取消 | 第 9 帧触发，0.90 秒返回 `AbortError`，进程正常退出 |
+| Electron 桌面 E2E | 1/1 通过，16.0 秒 |
+| 输出元数据 | `ALPHA_MODE=1`、`TEMattingBlendEffectV2-native-metal`、GRU v1.0 |
+| 播放器 | `readyState >= 2`、360×640，截图已保存 |
+
+桌面证据目录：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-streaming-native-metal/
+```
+
+### 剪映黑/白底 Alpha 反推（2026-08-27）
+
+最初的蓝背景近景不适合作为差距基准：在真正的 `/Applications/VideoFusion-macOS.app` 中启用“智能抠像”后，剪映也几乎保留了整幅画面。该素材上的蓝色残留不是 QCut 独有问题，不能据此调高默认阈值或腐蚀半径。
+
+随后从用户真人素材中截取 2 秒宽景，保持 360×640、30 fps、60 帧，在剪映中以同一抠像片段分别叠加纯黑和纯白底并导出。对齐两段画面后按 `alpha = 255 - (white - black)` 逐像素反推剪映 Alpha。该方法经过 H.264 输出，存在压缩和色彩转换误差，但真实经过剪映 UI、智能抠像和导出链，适合作为参数选择代理。
+
+与剪映反推 Alpha 对齐 60 帧后：
+
+| QCut 后处理 | 全帧 MAE | 二值 IoU | 结论 |
+| --- | ---: | ---: | --- |
+| 原始精细 Alpha | 17.1302 | **0.9383** | IoU 与边界误差均为本轮最佳 |
+| 腐蚀 1 px | 17.8327 | 0.9344 | 边缘被进一步吃掉 |
+| 腐蚀 2 px | 19.1778 | 0.9266 | 明显漏抠 |
+| 阈值 0.55 | 16.3605 | 0.9282 | 平均灰度接近，但软边界变差 |
+| 腐蚀 1 px + 羽化 1 | **15.0963** | 0.9344 | MAE 较低，但轮廓准确度仍低于原始 Alpha |
+
+因此没有把腐蚀、硬阈值或内容拟合 LUT 写进“精细”默认值。它们能让个别截图显得更干净，却会系统性损失衣物、头发和手部边缘。
+
+分段指标暴露出下一层差距：原始精细 Alpha 在前 30 帧的 IoU 为 `0.9890`、MAE 为 `8.04`，后 30 帧降到 IoU `0.8909`、MAE `26.22`。这说明静态模型输出已经很接近，主要剩余差距与跨帧状态、镜头内容变化、片段级模型选择和对照 Alpha 的压缩误差有关。静态分析尚未证明剪映在 GRU 后额外执行固定的多帧 Alpha 融合。针对这个样本拟合单调 LUT 虽能改善后半段，却会恶化前半段边界，因而没有作为产品修复。
+
+有效对照证据目录：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/
+```
+
+- `jianying-wide-cutout-black-ui.png`、`jianying-wide-cutout-white-ui.png`：真实剪映 UI 状态。
+- `jianying-wide-cutout-black.mkv`、`jianying-wide-cutout-white.mkv`：两次剪映导出的同帧底色对照。
+- `jianying-wide-reconstructed-alpha.mkv`：反推 Alpha。
+- `alpha-parameter-sweep-frame15.png`：QCut 参数扫描。
+- `source-jianying-qcut-diff-frame15.png`：源帧、剪映 Alpha、QCut Alpha、绝对差异（从左到右）。
+- `qcut-wide-native-metal-stream-clean.webm`：隔离日志后由产品流式运行时生成的 60 帧 Native Metal 输出。
+- `qcut-wide-native-metal-stream-corrupt-before-fix.webm`：修复前的分块错误样本，仅用于回归对照。
+
+流式管线同时在该无音轨真人片段上通过 60/60 帧。修复前虽然文件存在且播放器 `readyState >= 2`，但解出的 Alpha 有明显分块错位，说明“能播放”不等于画面正确。修复后从 VP9 重新解出的第 15 帧 Alpha 轮廓连续，黑底合成不再露出矩形原背景。管线还会忽略中间 pipe 的裸 `EPIPE`，改由三个子进程的退出码和 stderr 给出具体失败环节，避免正常收尾竞态掩盖诊断信息。
+
+最新真人桌面 E2E：1/1 通过，精细模式生成并挂载全帧 `1×1` Alpha 蒙版，预览播放器成功解码 360×640 VP9 Alpha；自动生成完成后不再默认进入几何蒙版编辑态，结果截图不再覆盖 80% 尺寸的误导性编辑框。证据目录：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-wide-native-metal/
+```
+
+## 老人脸部闪烁修复：QCut 双向窗口与人物内部保持
+
+逐帧检查发现，旧 QCut 结果在第 5–6、30–31 帧会把老人脸部从前景降为半透明；例如第 5 帧脸部区域 Alpha 均值由剪映代理值 `252.14` 降至 `150.29`。异常已经存在于原始 Alpha，不是白底合成或 VP9 编码造成。
+
+对 `/Applications/VideoFusion-macOS.app/Contents/Frameworks/libcccreator.dylib` 的第一轮只读符号审计发现，剪映宿主在模型外还包含：
+
+- `TEMattingFaceDetectBin` / `handleFaceDetect`；
+- `getPreviousFrame`；
+- `getMaskInfoFromExtendFrames`；
+- `scheduleMaskInfoPrefetch` / `takePrefetchedMaskInfo`。
+
+后续逐函数反汇编修正了对这些名称的过度解释：`handleFaceDetect` 是片段级模型路由，`getPreviousFrame` 只返回宿主缓存的 `ITEVideoFrame`，`getMaskInfoFromExtendFrames` 只复制上游已经附着的一张蒙版，prefetch 则只调度未来帧的蒙版计算。它们证明剪映的“智能抠像”不只是单独调用一份 GRU 模型，但不能证明剪映宿主在 GRU 后执行了双向 Alpha 融合。系统 Vision 人脸检测也在老人倾斜、遮挡的脸上实测无结果，因此没有把它作为错误兜底。
+
+QCut 新增的是不依赖私有宿主的自主修复，不再称为剪映 `extendFrames` 的等价复刻：
+
+1. 保留前后各 5 帧，输出增加最多 5 帧延迟，不缓存整段视频；
+2. 只在当前 Alpha 仍有前景证据时，从前后帧寻找颜色一致的高置信度前景；
+3. 用当前帧 RGB 校验相邻帧候选，只保留颜色稳定的同位置前景，避免人物离开后产生残影；
+4. 对低阈值前景内部做 3 px 安全腐蚀后再实心化，外轮廓与头发软边缘不参与填充；
+5. 用户选择基础模式并已有显式时间平滑时，不重复叠加该精细模式修复。
+
+同一 360×640、60 帧真人视频，与剪映黑/白底反推 Alpha 对比：
+
+| 指标 | 修复前 | 修复后 |
+| --- | ---: | ---: |
+| 全片 MAE | 17.1302 | **8.8952** |
+| 全片二值 IoU | 0.9383 | **0.9777** |
+| 前 30 帧 MAE | 8.0426 | **5.6900** |
+| 后 30 帧 MAE | 26.2178 | **12.1004** |
+| 第 5 帧老人脸 Alpha | 150.29 | **约 242** |
+| 第 30 帧老人脸 Alpha | 180.49 | **约 241** |
+
+桌面 Electron E2E 重新运行并通过 `1/1`：输出为 2 秒、360×640、30 fps 的 Native Metal VP9 透明视频；浏览器实际解码得到中心 Alpha 均值 `245.90`、顶部背景 `0`，并成功挂载人物蒙版及在预览播放器中播放。
+
+最终证据：
+
+- `/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-wide-temporal-window/e2e-evidence.json`
+- `/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/qcut-temporal-window-e2e-parity-metrics.json`
+- `/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/same-video-white-bg-jianying-left-qcut-right-temporal-window-2s.mp4`
+- `/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/same-video-white-bg-jianying-left-qcut-right-temporal-window-slow-4s.mp4`
+
+## 六项宿主问题的追踪结论（2026-08-27）
+
+研究对象固定为中文剪映专业版 `/Applications/VideoFusion-macOS.app` 11.3.0，不是 CapCut。以下结论来自对本机 arm64 `libcccreator.dylib` 的只读符号、字符串和窄范围反汇编；对象偏移和地址只适用于该版本。第三方二进制、模型和原始日志不进入仓库。
+
+核验时还发现同一 `11.3.0` 版本号下存在两个不同的运行时 build：
+
+| 位置 | universal dylib SHA-256 | arm64 UUID | 用途 |
+| --- | --- | --- | --- |
+| 当前 `/Applications/VideoFusion-macOS.app` | `b09c395d934169cb20ec865dd1d4032ca68023b287a7264e1b06ff4d71fd1be4` | `100726E3-FCB0-31BC-98EE-1B196A1714A3` | 本节六项宿主问题的静态分析对象 |
+| QCut 私有运行时备份 | `0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9` | `D6342ECD-5432-33F0-A2AD-0C28F5699994` | 之前 Native Metal 探针和产品 E2E 的已验证对象 |
+
+两个位置的 GRU 模型 SHA-256 都是 `101688825490be3704babc7ce49f6d002cdb4fe69e879556b4687ac9006f8596`，但 dylib UUID 已变化，说明不是 universal/thin 切片或签名显示差异。QCut 产品运行时读取自己的私有备份，并只对白名单中的旧 build 开启 Native Metal；它不会把当前新 build 误当成已验证 ABI。下面记录的宿主职责在新 build 中仍可见，但不能据此宣称两个 build 的所有私有偏移和调用参数兼容。
+
+| 问题 | 当前结论 | 置信边界 |
+| --- | --- | --- |
+| GRU 状态如何重置 | 已确认 `matting_reset_optical_flow != 0` 时直接调用 `MP_IgnorePrevious`；单帧 cache miss、普通 seek 和含 frame 47 视觉切点的 60 帧无缓存任务都没有设置它 | 速度曲线中的非连续时间跳变是否设置该键仍需单独样本；普通素材硬切已排除 |
+| 人脸检测做什么 | 动静态均确认是片段级模型路由；低于阈值切到 model type `3` 的 video saliency | 人脸检测器自身的具体模型文件尚未唯一定位 |
+| `extendFrames` / prefetch 做什么 | 已确认是上游蒙版复用与未来帧计算缓存，不是宿主双向 Alpha 融合 | 缓存淘汰指标的字段名只能部分恢复，但不影响语义判断 |
+| 边缘如何处理 | `MP_ProcessBorder(256,448)` 对 GRU Alpha 应用中心 `0.65`、斜率 `8` 的 256 项正弦 LUT；同尺寸输入没有额外空间腐蚀/膨胀 | 当前结论已在安装版与 QCut 私有备份两个 dylib 上逐字节验证；UI 羽化/边缘硬度仍是缓存后的 Blend 控制 |
+| 预览和导出是否同一路径 | 完整缓存时两者都读 mask 后 Blend；单帧缺失时预览不补，导出即时 `doMattingRender -> MP_ProcessBorder` | 源范围、模型路由或效果包变化时怎样使 complete range 失效仍未知 |
+| GPU fast path 是否零拷贝 | 已确认 V2 Blend 可走同设备 Metal 纹理；QCut 当前不是端到端零拷贝 | GRU 推理、纹理上传、Alpha 回读和编码仍是独立成本 |
+
+### 1. GRU recurrent state 生命周期
+
+模型字符串包含 `input_recur_feat`、`output_recur_feat` 和 `reset recur_feat`，低层还导出 `MP_IgnorePrevious`。该函数在当前版本中把 matting handle `+0x2cc` 的“先前状态有效”标志清零；Bach 路径在收到 `matting_reset_optical_flow` 时调用它。因此可以确认：宿主有显式的不连续点信号，让下一帧不再沿用前一帧的 recurrent/previous 状态。函数名里的 optical flow 不代表这里只重置光流；它最终作用在同一个 portrait-matting handle 的 previous-state 门禁上。
+
+QCut 每个抠像任务启动一个新 bridge、创建一个新 handle，任务起点已验证为干净状态；同一任务内按时间顺序连续处理，不会跨任务泄漏。早期版本曾用稀疏画面差异猜测硬切并调用 `MP_IgnorePrevious`，但最新剪映无缓存实测已否定这一宿主假设，产品 bridge 已删除该检测和主动 reset。
+
+### 2. 人脸检测不是“脸部补洞”
+
+`TEMattingFaceDetectBin::configExtractFrame` 不逐帧追踪脸，而是按任务给定的采样间隔抽取有限数量的帧；当片长会导致样本过多时，宿主会增大间隔，使样本均匀覆盖片段。送检图像最长边限制为 480。
+
+`TEMattingFaceDetectSinkUnit` 分别累计抽样总数与“检测到脸”的样本数。`TEMattingDriveUnit::handleFaceDetect` 计算二者比例：当有脸比例低于任务阈值时，日志为 `change model to video saliency`，并把模型类型切为 `3`、改用任务携带的 saliency 模型路径；否则保留 portrait matting 路径。应用包也同时带有 `saliency_matting_v1.0.model`、`tt_matting_video_v1.0.model` 和 `tt_matting_video_gru_v1.0.model`。
+
+因此老人脸偶发变透明不能解释为“剪映检测到脸后把脸区域强行填满”。该 detector 的已确认作用是整段内容分类和模型选择。最新注入运行已把 `TE_MATTING_FACE_DETECT_PARAM` 唯一映射到两份实际加载文件：base 为 `tt_fsnew_base_jianying_v2.0`（1,299,522 字节，SHA-256 `89e4cf058aa4ec0eceda3ecffe6b5b599b718f58aaadac5e03e5c2c1b2d66227`），extra 为 `tt_face_extra_v15.0`（691,859 字节，SHA-256 `23f548af90179d43d89931ab7d579af6b0972cb382cac379b10b8b421053a44e`）。运行日志还确认 base 版本 `2025011603`、extra 版本 `2025010812`，检测器类型为 SSD，两者均由 ByteNN CPU backend 初始化。
+
+### 3. `getPreviousFrame`、`extendFrames` 与 prefetch 的真实语义
+
+- `getPreviousFrame` 的实现只从 `TEMattingUnit2` 缓存成员复制一份 `shared_ptr<ITEVideoFrame>` 给调用方；它不读取两张 Alpha、不计算光流，也不做融合。
+- `getMaskInfoFromExtendFrames` 要求 pipeline 已带可用的扩展帧数据，然后把该帧中 `width × height` 的单通道字节复制进新的 `TEMattingMaskInfo`。函数自身不遍历前后帧，也不生成候选蒙版。
+- `scheduleMaskInfoPrefetch` 以当前 PTS 加 `n × frameDuration` 生成任务，`n` 从 `1` 开始，因此是向未来预计算。frame duration 优先由 clip FPS 得到 `1,000,000 / fps`，无有效 FPS 时回退到 pipeline duration。
+- 初始 lookahead 为 3 帧，运行时每累计约 60 次观测再调参，并把窗口限制在 3–5 帧。命中、过期和耗时统计改变的是预取深度，目标是减少预览等待与 cache miss，不是改变同一帧蒙版的像素公式。
+
+`doProcess` 还会在不同状态分支中尝试持久化 mask、上游扩展帧 mask、prefetch 结果和按需 matting，最后再进入 Blend；分支并非所有帧都按一条固定直线执行。可确定的是“获取/缓存蒙版”和“改变蒙版像素”是两个不同职责。QCut 当前 ±5 帧颜色一致性修复是针对真人回归指标设计的独立算法，虽然把全片 MAE 从 `17.1302` 降到 `8.8952`，也不能据此反推剪映内部使用相同窗口或参数。
+
+### 4. 边缘与人物内部后处理
+
+低层存在 `PortraitMatting::ProcessBorder` / `MP_ProcessBorder`。`bef_MP_DoPortraitMattingRect` 这条包装入口会先执行 matting，再取得 Alpha 尺寸、分配暂存蒙版、调用 `MP_ProcessBorder` 并复制处理后结果。当前下载的智能抠像效果包进一步给出了真实图配置：
+
+| 子图 | `model_name` | `matting_mp_modeltype` | `forwardtype` | `frashevery` | `edgemode` | `proc_border` |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `ai_matting` | `tt_matting_video` | 4 | -1 | 15 | 1 | 1 |
+| `ai_matting_gru` | `tt_matting_video_gru` | 4 | -1 | 15 | 1 | 1 |
+
+非 GRU 图还显式给出 `matting_mp_imagemode=0`。这里的 `frashevery` 是包内原字段拼写。最初动态无缓存后台生成没有命中 `MP_ProcessBorder`，不是隐藏的另一路 Border：最新任务路由证实它已经从 GRU type `1` 切到不含 `matting_proc_border` 的 `ai_matting_video_object` type `3`。在同一素材上只把路由阈值临时降为 0、强制保留 GRU 后，导出的 `MP_ProcessBorder` 和图内 `PortraitMatting::ProcessBorder` 都严格命中 120 次。
+
+单帧 cache-miss 导出则走另一条按需路径：10 次 `doMattingRender` 都紧接 10 次 `MP_ProcessBorder`，尺寸固定为 `256×448`、输入 Mat 类型字段为 `5`，返回值均为 0。首次创建 processor 时还观察到 `PortraitMattingIF::SetParam` 序列 `5=1, 6=-1, 7=1, 8=1, 1=15, 0=1, 5=1`，与效果包中的 `proc_border/forward/edge/refresh` 开关相互印证。早期 4096 点抽样哈希恰好漏掉变化区域，因此不能再作为“边界步骤可能恒等”的证据。
+
+新探针 [portrait-matting-border-oracle.cpp](probes/portrait-matting-border-oracle.cpp) 直接创建 GRU handle、完成一次真实模型初始化，再把灰阶 ramp、带边界/矩形的空间图案和宿主同尺寸 `256×448` 合成 Alpha 送入原始 `MP_ProcessBorder`。反汇编与 oracle 共同确认构造函数调用 `UpdatePostprocessLutEff(8, 0.65)`，生成如下 256 项逐像素 LUT：
+
+```text
+x = input / 255
+h = (π / 2) / 8
+x < 0.65 - h  -> 0
+x > 0.65 + h  -> 255
+otherwise      -> floor(255 * (0.5 + 0.5 * sin(8 * (x - 0.65))))
+```
+
+安装版 `b09c...` 与 QCut 私有备份 `0c393...` 的三组测试均为 `mismatch=0, max_difference=0`。空间图案逐像素等于 LUT 结果，证明这条默认 GRU 边界步骤不是形态学腐蚀、膨胀或模糊；它把低置信度 Alpha 压向 0、高置信度 Alpha 推向 255。QCut 已在 GRU 原生 `256×448` Alpha 上先应用同一 LUT，再做双线性放大和自有高级控制。Saliency ScriptInfo Mask 不重复套用，因为其 Bach graph 已经消费 `matting_proc_border=1`。
+
+UI 羽化从 0 改到 50、边缘硬度从 0 改到 19 时，没有调用推理、`MP_ProcessBorder` 或 SetParam，也没有改写任何 `mask/<PTS>` 的时间戳，只触发已有 mask/previous frame 的预览读取。两项值随后恢复为 0。它们属于缓存后的显示/合成控制，不是人物模型或磁盘 mask 的失效键。QCut 应复现这些图参数的语义，不能为了“调用同名函数”再重复执行第二次边界处理。
+
+另一组 `PortraitMattingV2MorphH/V`、`PortraitMattingV2BlurH/V`、`PortraitMattingV2StrokeMask` 属于 `TEMattingBlendEffectV2` 的描边/feature 计划。当前真人透明抠像探针关闭 feature path 后命中 `FastBlend`，不能把描边用的 morphology/blur 当成默认透明蒙版清理。QCut 因此只复现已证实的正弦 LUT，没有再叠加猜测性的默认腐蚀或模糊。
+
+接入后使用全新缓存根完成真人 Electron E2E，`1/1` 通过，用时 23.3 秒。旧软 Alpha 与新剪映 LUT Alpha 的 60 帧 PSNR 为 `9.447 dB`；零值比例从 `24.82%` 提升到 `37.28%`，255 比例从 `20.65%` 提升到 `35.37%`。白底图显示灰边明显减少，但模型原本低置信度的手臂/衣物也会被压掉；这说明剩余主观画质问题已从“边缘公式未知”收窄为“GRU 原始置信度不足”，不能再靠猜测腐蚀半径解决。证据保存在：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-border-lut-e2e-2026-08-27/
+```
+
+### 5. 预览、缓存与导出
+
+`TEMattingUnit2::setPreviewModel` 在模型类型不是 saliency `3` 且 processor 已创建时，把资源名切为 `tt_matting_video_preview.model` 并调用 processor 的模型设置入口。调用条件现已收窄为：刚成功创建 matting processor、内部 `+0x78a` 预览模型标志为真、当前处理模式等于 fourcc `0x53544245`，并且最终模型类型不是 `3`。`doProcess` 与 `doMattingRender` 各有一个相同门禁的直接调用点。
+
+`+0x78a` 构造时为 false；正常路径只在 type param 为 `1` 且 `(modelType & ~2) == 1` 时置真，也就是 model type `1` 或 `3` 的特定预览任务。随后宿主会读取 context property `36` 覆盖它；二进制属性名正是 `forceMattingDetectModelInPreview`。但 type `3` 到达 `setPreviewModel` 后仍立即返回，因此实际可切换的是满足上述预览任务条件的 portrait 路径。三次新任务动态运行均没有命中 `setPreviewModel`，证明后台完整蒙版生成不使用该模型。本机应用 Resources、用户 model cache 和效果包中仍没有同名独立文件，实际资源解析来源尚未定位，不能把字符串本身当成已缓存模型。
+
+宿主同时有 `TEMattingFileHelper`、`insertMaskPTS`、`insertCompleteSegment`、`saveCatchToMANEFile` 和 `getMaskFile`。动态运行已经确认缓存命中分支：工程重开、顺序播放、反向/正向 seek、从当前时间向右跟踪和切分后的预览，都只执行 `getMaskFile -> TEMattingBlendEffectV2::doBlendRender`；切分没有创建新 cache ID，也没有调用推理或 `MP_IgnorePrevious`。这不能证明切分时永远不重置推理状态，而是证明完整 mask 存在时根本没有推理状态需要重置。
+
+真实 7 秒导出阶段记录到 125 次 `getMaskFile`、125 次 Blend enter/exit，模型初始化、`doMattingRender`、prefetch、face detect、`MP_ProcessBorder` 和 `MP_IgnorePrevious` 都是 0 次。导出的 H.264 MOV 为 360×640、30 fps、7.000 秒。这直接排除了“有缓存也会在导出时强制用完整模型重算”的假设。
+
+随后从两个 cache ID 各可逆地移走 PTS `1,000,000` 的 `mask` 和 `maskinfo`。停在 `00:00:01:00` 的编辑器预览只调用 `getMaskFile`，没有补算，该帧临时显示未抠像原画；同一工程导出时则出现 125 次 lookup、120 次正常 Blend，以及 10 次 `doMattingRender -> MP_ProcessBorder`。补算期间没有 face detect、preview model、prefetch、`MP_IgnorePrevious`、`insertMaskPTS` 或 `saveCatchToMANEFile`，导出后两个缺失文件仍未重新生成。也就是说，导出会为缺失 payload 尝试临时按需补算，但不会把结果写回已标记 complete 的磁盘段。
+
+恢复原文件后，在完全相同的草稿状态下再次导出并做逐帧对齐。片段内 PTS 1 秒对应 timeline frame 90：完整缓存版本是白底抠像，缺帧版本却漏出整张原背景，PSNR 只有 `9.46 dB`；frame 91 立即恢复正常。由此可见，`doMattingRender -> MP_ProcessBorder` 的结果没有赶上同一输出帧，当前帧仍走降级结果，且没有持久化供下一次使用。证据图 `restored-vs-cache-miss-frame90.png` 左侧为完整缓存、右侧为缺帧导出。实验后两个原始 mask/maskinfo 已逐文件恢复。
+
+### 6. 原生 GPU fast path 与 QCut 差距
+
+剪映原生快路径要求 source、mask、output 三张 AGFX `DeviceTexture` 处于同一 Metal renderer、同一 GPDevice，并由当前 context 对应的 `TERLDeviceManager` / RLDevice 管理。它加速的是 morphology、stroke 和 blend 等合成阶段；没有证据表明这一个入口同时把 GRU/ByteNN 推理也变成零拷贝。
+
+QCut 已实际调用相同 `TEMattingBlendEffectV2` 并命中 `FastBlend`。本轮进一步定位并调用 `RendererDevice::updateTexture(DeviceTexture, const void *)`：input、mask、output 三张 `DeviceTexture` 现在都在整段视频内复用，逐帧只更新 input/mask 内容。60 帧真人回归中 native 与 compatible Alpha 逐字节相同，桌面冷 E2E 也完整输出 60 帧。
+
+这仍不是端到端零拷贝。GRU 输入来自 CPU BGR，V2 输出 Alpha 仍回读 CPU 后交给 VP9 编码；三次冷启动中 compatible 中位数为 `2510 ms`，native 为 `3341 ms`，native 仍慢约 `831 ms`。当前价值是减少私有纹理生命周期差异并锁定相同 Blend 语义，不是宣称性能领先。下一步性能收益必须来自减少 Alpha 回读或让预览/编码留在同一 GPU device chain，详见 [tematting-blend-v2-native-metal-2026-08-27.zh.md](tematting-blend-v2-native-metal-2026-08-27.zh.md)。
+
+## 当前应用动态追踪（2026-08-27）
+
+新增自有探针 [jianying-matting-runtime-trace.mm](probes/jianying-matting-runtime-trace.mm)，在只匹配当前 arm64 UUID/函数序言的前提下挂载 21 个窄入口，并额外记录 matting/model 文件的 `open`。探针以 `-Wall -Wextra -Werror` 编译；日志写在仓库外，第三方二进制、效果包、模型、配置和原始日志都不提交。
+
+`open` 事件只用于定位资源活动：剪映启动时会扫描多份 model catalog，因此“某个模型文件被打开”不能单独证明当前片段使用了它。模型选择结论来自 `handleFaceDetect` 的动态命中、该函数的控制流和实际效果包图三者交叉验证。
+
+### 模型自动切换
+
+无缓存打开真人草稿时，两个任务都动态命中 `handleFaceDetect`。该函数读取 face sink 在 `+0x35c` 返回的“抽样总数/有脸样本数”，当总数至少为 1 且 `有脸数 / 总数 < MattingTaskParam(+0x180)` 时：
+
+1. 把任务携带的 saliency 路径复制到输出任务；
+2. 把输出 model type 写为 `3`；
+3. 打印 `change model to video saliency`。
+
+否则不改写人物模型。效果包同时提供 `ai_matting`、`ai_matting_gru`、`saliency_matting` 和 `ai_matting_video_object` 子图，因此这里是片段级内容路由，不是一个 UI 质量开关，也不是逐帧给脸补洞。
+
+### 显著性 provider 的真实层级
+
+效果包 `saliency_matting/algorithmConfig.json` 已确认不是 Portrait Matting C API 配置，而是一张 `640×640` Bach 图：`texture_blit -> script`，脚本节点写入 `model_name=saliency_script_for_cc`、`packed_model_group_key=script`、`return_mask=1`。但最新默认自动路由没有选择这张图，而是选择 `ai_matting_video_object/algorithmConfig.json`：`texture_blit -> general_seg(model_name=video_saliency_seg_bce)`。这两张显著性图不能再合并称作同一个 type `3` provider。实际模型目录同时存在并在应用运行时被解析：
+
+- `saliency_matting_v1.0`，SHA-256 `ac2ae6badafc6a94641dc59b5844762676eee71b218785bfad37169eea380341`；
+- `saliency_script_for_cc_v1.2`，SHA-256 `4d7fbc2ec820f28f3d0c8531a63d53a338d091a989109f20ee67377c4f594c01`；
+- `video_saliency_seg_bce_v1.0`，SHA-256 `346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef`。
+
+新增只读探针 [saliency-seg-abi-probe.cpp](probes/saliency-seg-abi-probe.cpp) 还原了独立 `Bingo_SaliencySeg_*` 的 handle、input、result ABI。它可以用应用 Resources 中另一份 `bingo_saliency_seg_v1.0.model` 成功输出 `360×640` Mask，但上述三份智能抠像模型分别初始化失败 `-109`，而把 `saliency_matting` 直接传给 Portrait Matting type 3 则返回 `-2010`。这两组结果仍能排除 Bingo SaliencySeg 和 Portrait API 直接换模型；它们不能证明自动 fallback 使用 `saliency_matting` script。最新任务已经动态证明自动 fallback 使用的是另一张 Bach `ai_matting_video_object` general-seg graph。Bingo 输出在真人样本上只保留局部手臂或产生错误条纹，因此没有接进 QCut 产品冒充剪映 fallback。
+
+### Bach ScriptInfo 蒙版 ABI 与 QCut provider
+
+[effect-cgl-render-probe.cpp](probes/effect-cgl-render-probe.cpp) 已在剪映专业版 11.3.0 的真实 `saliency_matting` 图上得到可用 `Bach::ScriptInfo`：`bef_effect_get_bach_result(..., type=141)` 返回的 wrapper 在 `+0x18` 保存结果 vector，第一项是 ScriptInfo。剪映自身 `TEBachMattingAlgorithm::getMaskAndBoundingBox` 的反汇编进一步确认：
+
+- ScriptInfo 的键值 map 位于 `+0x10`；
+- 宿主分别查询 `mask` 与 `ltwh`；
+- `mask` 条目的 CPU image payload 指针位于 `+0x88`，payload vector 的 begin/end 位于 `+0x10/+0x18`；
+- `ltwh` 通过导出的 `BachObject -> Vector4f` 转换得到目标矩形；
+- 当前 360×640 真人帧返回 `ltwh=0,0,360,640` 与严格 230,400 字节 L8 Alpha。
+
+研究探针输出的 PGM payload 与产品桥 [saliency-script-bridge.cpp](../../../electron/jianying-person-cutout/native/saliency-script-bridge.cpp) 输出的 raw Gray **逐字节相同**，SHA-256 均为 `1e75bc207638afe66056b613d5ca26a7b12a8fb8ded733dc3ba478a3d20954d6`。这证明产品不是从输出纹理猜 Alpha，也不是换用近似模型，而是读取剪映宿主同一 ScriptInfo 结果。
+
+该 ABI 只对已验证的 VideoFusion 11.3.0 `libcccreator.dylib` 开放，库 SHA-256 必须为 `b09c395d934169cb20ec865dd1d4032ca68023b287a7264e1b06ff4d71fd1be4`。QCut 同时校验三份模型和两份 graph 配置的 SHA-256；任一不匹配都不进入该路径。模型和 graph 只缓存在用户本机 `~/Library/Application Support/QCut/PrivateRuntimes/JianyingSaliency/current/`，不提交、不打包、不重新分发。桥二进制由 QCut 自有源码构建，并已进入 staging、签名 entitlement 和打包一致性检查。
+
+整段 60 帧真人调用成功，输出 cache key 为 `b46c0dd4b05a75294bfb66af7e4da30e0d858aa1d42258e762b9d8f618642de1`，Alpha 严格为 `13,824,000 = 360×640×60` 字节。冷运行约 4.1 秒，缓存命中复跑约 2.2 秒；透明输出 metadata 为 `saliency_script_for_cc_v1.2`、`saliency-script` 和 `TEMattingBlendEffectV2-compatible`。完整证据在：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-saliency-provider-e2e-2026-08-27/
+```
+
+这次真人反例也明确了 provider 的适用范围：强制把整段有脸镜头交给 saliency 时，它会优先保留手、衣服、地图等显著物，而不是完整两个人；因此不能取代 GRU。后续无缓存动态任务已直接读取 `MattingTaskParam(+0x180)`：两次 `handleFaceDetect` 的原始位模式都是 `0x3f000000`，即阈值 **0.5**。QCut 的实验性自动路由因此也改成“有脸样本数 / 有效样本数低于 50% 才切 saliency”。
+
+但 QCut 当前本地 face graph 在这段真人素材的 3 个采样帧上全部漏检；若默认启用自动路由，会把人物抠像误送到 saliency。实测整段二值 IoU 会从强制 GRU 的 `0.9285` 降到 `0.5791`。因此面向用户的“人物抠像”现在默认固定为 `portrait-gru`；`saliency-script` 只接受显式高级选择，精确 0.5 阈值只在 `QCUT_ENABLE_PERSON_CUTOUT_AUTO_ROUTE=1` 的实验模式使用。最新动态结果还表明，QCut 实验模式当前选择的 `saliency-script` 并不是剪映这段素材实际选择的 `ai_matting_video_object`，所以它只能称为安全关闭的实验路由，不能称为自动 fallback 对齐。
+
+GRU 与 saliency 现在共用同一套 Alpha 后处理实现：阈值、时序平滑、边缘移动和羽化不会因模型切换而失效。默认参数下 saliency 输出仍与原始 ScriptInfo Mask 逐字节一致；改变高级参数后输出 SHA-256 变为 `235aefc846d5ecb10ebaafb39fd61959f2e0e9532edbdf75698876bdd5359eb5`，证明控制项确实进入实际 provider，而不是只停留在 UI。两条路径不再根据像素差异自行猜测“硬切”并清空状态；重置边界改为任务生命周期。
+
+两条自动路由均在共享后处理接入后通过真实 Electron E2E：有脸 2 秒素材走 GRU + native Metal，23.5 秒完成；无脸 0.5 秒素材自动走 saliency + compatible Blend，14.9 秒完成。两次均完成导入、属性面板、任务进度、添加透明媒体、绑定人物蒙版与播放器解码，截图和输出分别位于：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-auto-route-refined-e2e-2026-08-27/
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-auto-saliency-refined-e2e-2026-08-27/
+```
+
+### Mask 缓存格式与完成协议
+
+这次无缓存运行产生两个 cache ID。每个 2 秒、30 fps 任务都有：
+
+- `2/mask/<PTS>`：60 个文件，PTS 从 `0` 到 `1,966,667`，单文件固定 65,536 字节；该尺寸与 256×256 单通道 payload 一致，但本轮没有把它宣称为已完整解码的格式；
+- `2/maskinfo/<PTS>`：60 个文件，当前样本每个 110 字节；
+- `2/matting_result.json`：`{"result_time_range":[{"start":0,"end":2000000}]}`；
+- `2/mocf`：485 字节。
+
+运行事件严格对应为每任务 60 次 `insertMaskPTS`，然后 `insertCompleteSegment` 和 `saveCatchToMANEFile` 各一次。再次打开工程会直接命中 `getMaskFile`。这说明有效性单位至少包含 cache ID、matting type 目录 `2`、逐帧 PTS 和 complete time range；UI 的跟踪方向决定从当前时间向右、向左或双向补齐哪一段，而不是改变模型质量。
+
+### Seek、跟踪、切分与状态重置
+
+完整缓存下执行顺序播放、反向 seek、正向 seek、从当前时间向右跟踪和一次可撤销切分：
+
+- 都只读取已有 mask 并 Blend；
+- 切分前后仍为原来的两个 cache ID，各 122 个文件，没有产生新 ID；
+- 没有调用 `MP_IgnorePrevious`、`doMattingRender`、prefetch 或模型初始化。
+
+低层唯一直接调用 `MP_IgnorePrevious` 的配置分支读取键 `matting_reset_optical_flow`，值非零才清除 previous-state 标志。默认 `ai_matting` / `ai_matting_gru` 图没有写死这个键。因此 reset 是宿主在真正发生非连续推理时按任务注入的事件，不是每次 UI seek 都无条件调用；缓存命中的 seek/切分不能观察到它。
+
+单帧 cache miss 导出虽然实际执行了 10 次按需 matting，也仍然 0 次命中 `MP_IgnorePrevious`。这进一步说明“缺一帧”本身不等于时序重置事件。它更可能使用导出任务的新 processor/当前顺序上下文，并从已存在的 previous frame 入口获取邻接输入；本轮确实观察到 5 次 `getPreviousFrame`，但不能仅凭指针返回证明 GRU recurrent feature 怎样初始化。
+
+最新无缓存运行又给出了更强的反例：真人源视频在 frame 47 有全画面切镜，剪映仍连续生成 60 个 `mask/<PTS>`，期间 `MP_IgnorePrevious` 命中 **0 次**。因此剪映 11.3.0 的这条标准智能抠像任务不存在可观察到的“按像素硬切阈值”；`matting_reset_optical_flow` 是上游任务明确传入的离散事件，不应由 QCut 用画面差异自行猜测。
+
+### 预览与导出策略
+
+动态结果把策略收窄为：
+
+```text
+有效逐帧 mask
+  -> 预览 / seek / 跟踪 / 切分后预览：getMaskFile -> Blend
+  -> 导出：getMaskFile -> Blend
+
+完整段中的单帧 payload 缺失
+  -> 交互预览：不补算，临时显示原画
+  -> 导出：尝试 doMattingRender -> MP_ProcessBorder，但当前帧仍漏出原画
+  -> 不写回 mask/MANE
+
+新任务或失效区间
+  -> face sampling -> 片段级模型路由
+  -> 算法图生成 mask -> insertMaskPTS
+  -> complete segment + MANE/磁盘缓存
+```
+
+`setPreviewModel(tt_matting_video_preview.model)` 仍存在，但这轮完整缓存运行没有动态命中；不能把它描述成每次预览必走的固定模型。导出 E2E 及原始动态证据保存在：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/dynamic-host-trace-2026-08-27/
+```
+
+其中 `jianying-host-trace-export.mov` 的 SHA-256 为 `5f2a3e083309f56ec3835b99f9995938d8b000b368b9e8b8f6c548704dd73a4c`；同状态的缺帧/恢复缓存导出分别为 `af000972d99fb1a8f5dcae674490a3b89abfb0ef8e106a0af16db7b79e9ed30e` 和 `f0be9c58505e380e2029c5c567a4906fb5fcbf8098caf236314ab864d9b4b814`。实验结束后已经把草稿恢复为原来的未抠像顶层片段、撤销测试切分、把羽化和边缘硬度恢复为 0，并恢复实验前的 `matting/` 缓存。
+
+## QCut 缓存完整性与连续时序实现（2026-08-27）
+
+QCut 的精细人物抠像已从“推理 Alpha 直接流入编码器”改为两阶段：先完整生成并验证单通道 Alpha 缓存，再启动透明视频编码。缓存 manifest 记录实际帧数、宽高、Alpha 字节数、内容抽样指纹、模型名及 SHA-256、native processor SHA-256、片段级模型路由、抠像参数和 Blend 实现。缓存键不包含编辑器临时复制路径或文件 mtime，因此同一素材被复制到新的临时目录后仍可复用；模型、processor、路由、内容、尺寸、帧率、参数或 Blend 实现变化都会产生新键。这样边缘处理、时序策略或 Blend bridge 更新后不会继续复用旧算法生成的 Alpha。
+
+未完成构建写在独立 `.building-*` 目录，只有 bridge 正常退出且 `alpha.gray` 严格满足 `frameCount × width × height` 时才写 manifest 并原子提交。导出只读取通过同一检查的完整缓存；少一个字节都会判定失效并重建，不再出现剪映当前 cache-miss 导出中“当前帧先漏出原背景、补算结果又不持久化”的降级分支。
+
+GRU bridge 现在按已动态确认的效果包序列设置 `5=1, 6=-1, 7=1, 8=1, 1=15, 0=1, 5=1`，并在设置前验证加载后的内部模型类型仍为 6。每个抠像任务创建独立 handle，从天然干净的 recurrent state 开始；同一任务内按解码顺序连续处理，不再使用 32×18 像素差异猜测硬切，也不再主动调用 `MP_IgnorePrevious`。Saliency 的自有时间平滑同样保持连续。该策略与本轮剪映 60 帧无缓存动态结果一致。
+
+曾尝试把首帧重复送入 GRU 5 次作为“预热”，但 frame 47–52 相对剪映缓存的 MAE 从 `49.373` 恶化到 `63.039`，IoU 从 `0.7854` 降到 `0.7045`，因此已删除。视觉切点 reset 与连续运行的原始 GRU Alpha 则逐字节相同；连续后处理只把全片 IoU 从 `0.928456` 微升到 `0.928508`。这些反证说明老人脸缺口不是简单的首帧预热或 `MP_IgnorePrevious` 时机问题。
+
+真人桌面 E2E 连续运行两次均通过。第二次运行前后同一缓存的 manifest 与 Alpha mtime 完全不变，证明导出命中缓存而非重新推理；缓存 manifest 为 60 帧、13,824,000 字节，模型路由为 `portrait-gru`，Blend 为 `TEMattingBlendEffectV2-native-metal`。QCut UI 完成态、时间线蒙版和实际播放器截图保存在：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-cache-integrity-e2e-2026-08-27/
+```
+
+剪映应用内的 `saliency_matting.v1.0`、`saliency_script_for_cc.v1.2` 和 `video_saliency_seg_bce.v1.0` 已完成分层资源验证；`saliency_matting` Bach script graph 已接入 QCut 并通过强制 route、缓存命中、无脸实验 route 和真实 Electron E2E。`modelRoute`、模型/graph/processor 哈希均进入缓存身份，透明视频 metadata 会按实际路径写 `portrait-gru` 或 `saliency-script`。剪映自动选择的 `ai_matting_video_object -> video_saliency_seg_bce` 尚未作为独立 QCut provider 接入。
+
+最新真人桌面 E2E 在删除硬切 reset、启动 `MP_IgnorePrevious` 和默认自动路由后，使用全新缓存根冷运行 `1/1` 通过。生成 60 帧、`13,824,000` 字节 Alpha；输出为 2 秒、360×640、30 fps VP9 Alpha，metadata 同时包含 `TEMattingBlendEffectV2-native-metal`、GRU v1.0 和 `portrait-gru`。浏览器实际解码中心 Alpha 均值 `248.72`、顶部背景 `0`。证据目录：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/qcut-default-gru-e2e/
+```
+
+## 老人近景的最终模型路由与 Border 前 Alpha
+
+本轮把测试草稿原来的 244 个 matting 文件可逆移出，使用注入探针重新生成两次，每次都处理两个 2 秒任务、各写入 60 帧。默认运行得到完全一致的路由：
+
+```text
+初始 model type 1
+  -> ai_matting_gru/algorithmConfig.json
+  -> face detector 抽样 2 帧，检测到脸 0 帧
+  -> 0 / 2 < 0.5
+  -> model type 3
+  -> ai_matting_video_object/algorithmConfig.json
+  -> video_saliency_seg_bce
+```
+
+这张近景实际没有进入 GRU。最终 object graph 的 SHA-256 为 `797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b`，唯一模型节点是 `general_seg(model_name=video_saliency_seg_bce)`；模型文件为 6,292,096 字节，SHA-256 `346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef`。该图没有 `matting_proc_border`，默认运行也确实 0 次命中 `MP_ProcessBorder`。因此“老人近景漏抠的首要来源”已经确定为片段级人脸漏检导致的模型选择，不是 GRU 后的 Border 参数。
+
+为了把剩余两层拆开，受控运行只把 `MattingTaskParam(+0x180)` 从 `0.5` 临时改为 `0`，函数返回后立即恢复原值，使同一素材保留 `ai_matting_gru`。GRU graph SHA-256 为 `57a8edbedcb0701ca67b5106c7521b681ddba9c1618df1351c29ee22cdd8c270`，实际模型仍是 3,601,895 字节的 `tt_matting_video_gru_v1.0`，SHA-256 `101688825490be3704babc7ce49f6d002cdb4fe69e879556b4687ac9006f8596`。
+
+强制 GRU 时，探针在导出 `MP_ProcessBorder` 入口和图内 `PortraitMatting::ProcessBorder` 各命中 120 次，并保存全部 `256×448` 输入/输出 Alpha。首个任务按 frame 47–59 汇总：
+
+| 阶段 | Alpha 均值 | 0 值占比 | 255 值占比 |
+| --- | ---: | ---: | ---: |
+| `MP_ProcessBorder` 前 | 70.1207 | 45.0099% | 1.3926% |
+| `MP_ProcessBorder` 后 | 45.8083 | 71.4176% | 8.1040% |
+
+对照 frame 0–46，Border 前 Alpha 均值为 `162.1330`。也就是说，若强行使用 GRU，近景漏抠在 Border 前已经明显存在；已验证的正弦 LUT 又把大量低置信度像素压到 0，使缺口进一步扩大。三层责任现在可以分开陈述：
+
+1. **默认剪映结果**：人脸检测 `0/2`，整段切到 object saliency，这是主路由差异；
+2. **强制 GRU 原始推理**：frame 47–59 的上游 Alpha 自身已经大幅下降；
+3. **图内 Border**：不制造第一次置信度下降，但会把已有低置信度区域进一步硬化为背景。
+
+原始 trace、两次新生成的缓存和 480 份 Border Alpha 均保存在仓库外：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/closeup-model-route-preborder-2026-08-27/
+```
+
+实验结束后，测试草稿原来的 244 个 `matting/` 文件已按两个原 cache ID 完整恢复。
+
+## 当前最小剩余未知项
+
+本轮已经动态回答老人近景的模型图、人脸检测输出和 `MP_ProcessBorder` 前后 Alpha，也恢复了实验前缓存。现在真正剩下的是：
+
+1. 改变源时间范围、模型路由结果和效果包版本时，剪映 cache ID 与 complete range 怎样失效；QCut 自有缓存已把实际路由和全部处理器哈希纳入内容身份；
+2. `tt_matting_video_preview.model` 的调用门禁已经确定，但同名资源最终由哪个 catalog/resolver 映射或下载仍未知；
+3. 剪映自动 fallback 的 `ai_matting_video_object -> video_saliency_seg_bce` graph 尚未接入 QCut；当前 `saliency-script` 是另一张已验证但语义不同的显著性图；
+4. 剪映宿主是否避免 Alpha 回读，以及推理、写缓存、Blend、编码各阶段的真实耗时；QCut 已完成三张 device texture 跨帧复用，但仍有 CPU Alpha 回读。Saliency provider 为规避子进程管道的分片差异，当前还会先落一份临时 RGBA。
+
+因此 QCut 当前可以称为“同 GRU 模型、同 BGR 输入、同正弦边界 LUT、同 Metal Blend、已接入一张可用的 Bach saliency script graph、同 0.5 判定阈值，并有严格缓存完整性和按任务隔离的连续时序”。不能称为完整复刻剪映私有宿主或同自动 fallback；当前最值得修改的是 QCut 的自动路由防误判策略和 `ai_matting_video_object` provider，而不是继续猜老人近景的腐蚀或羽化参数。
+
+本轮阈值与 reset 原始证据：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/jianying-threshold-reset-trace/
+```
+
+本轮 QCut 真人桌面 E2E、量化与左剪映/右 QCut 白底对比：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/qcut-default-gru-e2e/
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/jianying-left-qcut-right-white.mp4
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/jianying-left-qcut-right-frame-55-white.png
+```
+
+## 2026-08-28：object graph 宿主边界与精细模式最终补洞
+
+### 剪映 object graph 实际输出链
+
+再次清空测试草稿的可恢复 matting 缓存并动态生成后，默认近景任务仍稳定走
+`ai_matting_video_object -> video_saliency_seg_bce`。360×640 源帧进入图前缩放为
+288×512；`TEBachMattingAlgorithm::getMaskAndBoundingBox` 直接读取键
+`saliency_mask`，随后写入逐帧缓存。该默认 object 路径中：
+
+- `MP_ProcessBorder` 为 0 次；
+- `TEBachMaskPostProcessAlgorithm::processFrame` 为 0 次；
+- 缓存内容是 general-seg 图返回的 soft Alpha，不是另一次全局 mask post-process 的结果。
+
+这进一步确认近景主差距发生在模型路由和图输出，不应继续猜测一个 object 路径并未调用的
+Border 参数。
+
+剪映宿主为这张图构造 `RendererMetalV2`、RLDevice/Effect 注册和同设备纹理。对
+`bef_effect_set_render_api` 的直接入口挂载在真实任务中没有命中，说明该 renderer 不是通过公开
+Effect C handle 的 render-api setter 注入，而是由宿主私有对象图创建。QCut 独立 C handle 即使尝试
+CGL、EGL/GLES、Metal DeviceTexture 和相关 Effect AB 开关，输入仍呈现零纹理特征，输出只包含
+`0/1/2`。因此不能把“函数返回成功”当成 object provider 成功。
+
+QCut 现在对 `video-object` Alpha 做写缓存前质量门禁：最大值不超过 2 时立即拒绝，并自动回退
+`portrait-gru`；AbortError 和 GRU 自身失败不会被错误吞掉。生成图的 texture-blit 尺寸按源画幅动态
+计算，最长边为 512，360×640 对应 288×512。该路由仍是高级实验能力，不再冒充已复刻的剪映宿主。
+
+### 精细模式采用 GRU + 系统人物蒙版融合
+
+单纯对 GRU Alpha 做大半径形态学 closing 虽把近景 IoU 提高到 `0.9117`，白底逐帧却出现明显的
+轴对齐蓝背景矩形，已从产品路径删除。最终方案保留同一份剪映 GRU、BGR 输入、双向安全窗口、
+正弦 Border LUT 和 TEMatting Blend，只在“精细”模式增加 macOS Vision 的本机人物蒙版：
+
+```text
+source RGBA
+  -> Jianying GRU -> temporal interior hold
+  -> macOS Vision accurate person mask
+  -> max(GRU, saturate(Vision * 2))
+  -> Jianying portrait Border LUT
+  -> advanced controls -> TEMattingBlendEffectV2
+```
+
+融合只提高 Vision 已识别为人物的置信度，不用方形结构元素扩张轮廓。系统 Vision 模型由 macOS
+管理，QCut 不复制或重新分发它；QCut 本机缓存仍保存用户已有的 GRU 资源和最终 Alpha。输出模型标识为
+`tt_matting_video_gru_v1.0+vision-person-v1`，processor 指纹包含 bridge 内容与 Darwin 系统版本，系统
+分割实现升级后不会误命中旧 Alpha 缓存。打包门禁同时要求 bridge 含有
+`Vision-person-fusion-v1` 能力标记。
+
+同一真人 60 帧、同一剪映黑白底反推 Alpha 的最终结果如下。MAE 已除以 255：
+
+| 区间 | 实现 | IoU | Recall | Precision | MAE |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 全片 | 旧 GRU 精细结果 | 0.961935 | 0.977215 | **0.984005** | 0.042211 |
+| 全片 | **GRU + Vision** | **0.980103** | **0.998120** | 0.981916 | **0.031194** |
+| frame 47–59 | 旧 GRU 精细结果 | 0.879071 | 0.910478 | **0.962241** | 0.139292 |
+| frame 47–59 | **GRU + Vision** | **0.957343** | **0.995049** | 0.961924 | **0.086022** |
+
+排除 frame 46→47 的整画面切镜后，相邻帧 Alpha MAE 从旧结果 `1.7415` 降为 `0.6683`；近景
+前景面积标准差从 `0.03612` 降为 `0.00298`，没有用补洞换来闪烁。白底检查还显示 frame 50 中
+剪映参考保留了一块蓝背景，而 QCut 将其正确移除，所以剩余 IoU 并不全部代表 QCut 主观画质更差。
+
+原生 Metal 与 compatible 两次 60 帧输出逐字节相同。桌面冷启动、强制 object 后安全回退、以及
+缓存命中三次 E2E 均通过；缓存命中前后 13,824,000 字节 Alpha 和 manifest 的 mtime/size 不变。
+最终证据位于：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-motion-reset-parity-2026-08-28/
+```
+
+重点文件为 `findings.md`、`vision-fusion-final-metrics.json`、
+`jianying-left-qcut-right-vision-fusion-white-1x.mp4`、
+`jianying-left-qcut-right-vision-fusion-white-0.5x.mp4` 和
+`vision-fusion-final-keyframes-contact-sheet.png`。
+
+### 仍然存在的真实边界
+
+1. QCut 没有也不应宣称可从独立 C handle 完整复制剪映宿主的 RLDevice/Effect 注册；高级 object
+   路由当前靠输出质量门禁安全回退。
+2. Vision 融合是 QCut 自主的本机精细化实现，不是证明剪映内部也调用 Apple Vision。
+3. 剪映对照 Alpha 来自黑/白底 H.264 反推，仍不是无损内部真值。
+4. QCut 仍把 Alpha 回读 CPU 后写缓存和编码，不是端到端 GPU 零拷贝。
+5. 变速曲线、倒放和源范围变化的剪映缓存失效协议仍没有全部动态覆盖；QCut 自有缓存已把内容、
+   路由、模型、处理器、系统版本、画幅、帧率、Blend 和参数纳入身份。

--- a/qcut/docs/task/jianying-filter-runtime-research/portrait-matting-gru-parity-2026-08-27.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/portrait-matting-gru-parity-2026-08-27.zh.md
@@ -518,8 +518,10 @@ Effect C handle 的 render-api setter 注入，而是由宿主私有对象图创
 CGL、EGL/GLES、Metal DeviceTexture 和相关 Effect AB 开关，输入仍呈现零纹理特征，输出只包含
 `0/1/2`。因此不能把“函数返回成功”当成 object provider 成功。
 
-QCut 现在对 `video-object` Alpha 做写缓存前质量门禁：最大值不超过 2 时立即拒绝，并自动回退
-`portrait-gru`；AbortError 和 GRU 自身失败不会被错误吞掉。生成图的 texture-blit 尺寸按源画幅动态
+QCut 现在对 `video-object` Alpha 做写缓存前质量门禁：完整视频流中任意长度的全零片头都允许，
+整段全零也视为合法空蒙版；仅当整段从未观察到大于 `2` 的有效 Alpha、同时确实出现 `1/2`
+量化噪声时，才确认 `0/1/2` hostless 特征并自动回退 `portrait-gru`。一旦观察到有效 Alpha，
+前后合法空背景帧都不会触发误回退；AbortError 和 GRU 自身失败不会被错误吞掉。生成图的 texture-blit 尺寸按源画幅动态
 计算，最长边为 512，360×640 对应 288×512。该路由仍是高级实验能力，不再冒充已复刻的剪映宿主。
 
 ### 精细模式采用 GRU + 系统人物蒙版融合
@@ -578,3 +580,10 @@ source RGBA
 4. QCut 仍把 Alpha 回读 CPU 后写缓存和编码，不是端到端 GPU 零拷贝。
 5. 变速曲线、倒放和源范围变化的剪映缓存失效协议仍没有全部动态覆盖；QCut 自有缓存已把内容、
    路由、模型、处理器、系统版本、画幅、帧率、Blend 和参数纳入身份。
+
+## 2026-08-28：自动路由、缓存身份与 GPU 往返收敛
+
+本节之后的最新产品状态单独记录在
+[QCut 人物抠像差距收敛记录](person-cutout-gap-reduction-2026-08-28.zh.md)。它取代本文较早章节中“自动路由仍直接保留 GRU”“Blend 实现参与 Alpha 缓存键”以及“native 每帧回读完整 RGBA”的当前状态描述；早期数字保留为历史证据。
+
+最新真人桌面 E2E 已实际走通 `auto -> video-object -> Alpha 质量门禁 -> portrait-gru + Vision`，并明确返回请求路线、实际路线和回退状态。native Metal 现在只做单帧 ABI/公式校验，生产缓存默认不再为相同语义 Alpha 执行逐帧 GPU 往返。

--- a/qcut/docs/task/jianying-filter-runtime-research/portrait-matting-gru-parity-2026-08-27.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/portrait-matting-gru-parity-2026-08-27.zh.md
@@ -58,7 +58,7 @@ QCut 与剪映现在使用同一份本地 `tt_matting_video_gru_v1.0.model`，�
 
 状态重置验证：同一真人首帧分别交给两个全新桥进程，两个 `256×448` Alpha 输出均为 230400 字节，SHA-256 同为 `ef731a1767e2c4f345d1afa0cf2cc7fced96a8983433a42e5a6820dfa6c08d0b`，字节比较相同。这证明新任务会从干净的 GRU 状态开始，不会继承上一个片段的时序状态。
 
-本机证据目录：`/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/`
+本机证据目录：`<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/`
 
 - `real-person-cutout-gru-parity-v2-2s.webm`
 - `alpha-old-vs-parity-v2-2s.mp4`
@@ -108,7 +108,7 @@ GRU Alpha stdout   -> FFmpeg alpha stdin -> VP9 WebM
 桌面证据目录：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-streaming-native-metal/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-streaming-native-metal/
 ```
 
 ### 剪映黑/白底 Alpha 反推（2026-08-27）
@@ -134,7 +134,7 @@ GRU Alpha stdout   -> FFmpeg alpha stdin -> VP9 WebM
 有效对照证据目录：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/
 ```
 
 - `jianying-wide-cutout-black-ui.png`、`jianying-wide-cutout-white-ui.png`：真实剪映 UI 状态。
@@ -150,7 +150,7 @@ GRU Alpha stdout   -> FFmpeg alpha stdin -> VP9 WebM
 最新真人桌面 E2E：1/1 通过，精细模式生成并挂载全帧 `1×1` Alpha 蒙版，预览播放器成功解码 360×640 VP9 Alpha；自动生成完成后不再默认进入几何蒙版编辑态，结果截图不再覆盖 80% 尺寸的误导性编辑框。证据目录：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-wide-native-metal/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-wide-native-metal/
 ```
 
 ## 老人脸部闪烁修复：QCut 双向窗口与人物内部保持
@@ -189,10 +189,10 @@ QCut 新增的是不依赖私有宿主的自主修复，不再称为剪映 `exte
 
 最终证据：
 
-- `/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-wide-temporal-window/e2e-evidence.json`
-- `/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/qcut-temporal-window-e2e-parity-metrics.json`
-- `/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/same-video-white-bg-jianying-left-qcut-right-temporal-window-2s.mp4`
-- `/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/same-video-white-bg-jianying-left-qcut-right-temporal-window-slow-4s.mp4`
+- `<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-desktop-e2e-wide-temporal-window/e2e-evidence.json`
+- `<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/qcut-temporal-window-e2e-parity-metrics.json`
+- `<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/same-video-white-bg-jianying-left-qcut-right-temporal-window-2s.mp4`
+- `<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/jianying-alpha-reconstruction-2026-08-27/same-video-white-bg-jianying-left-qcut-right-temporal-window-slow-4s.mp4`
 
 ## 六项宿主问题的追踪结论（2026-08-27）
 
@@ -271,7 +271,7 @@ UI 羽化从 0 改到 50、边缘硬度从 0 改到 19 时，没有调用推理�
 接入后使用全新缓存根完成真人 Electron E2E，`1/1` 通过，用时 23.3 秒。旧软 Alpha 与新剪映 LUT Alpha 的 60 帧 PSNR 为 `9.447 dB`；零值比例从 `24.82%` 提升到 `37.28%`，255 比例从 `20.65%` 提升到 `35.37%`。白底图显示灰边明显减少，但模型原本低置信度的手臂/衣物也会被压掉；这说明剩余主观画质问题已从“边缘公式未知”收窄为“GRU 原始置信度不足”，不能再靠猜测腐蚀半径解决。证据保存在：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-border-lut-e2e-2026-08-27/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-border-lut-e2e-2026-08-27/
 ```
 
 ### 5. 预览、缓存与导出
@@ -339,7 +339,7 @@ QCut 已实际调用相同 `TEMattingBlendEffectV2` 并命中 `FastBlend`。本�
 整段 60 帧真人调用成功，输出 cache key 为 `b46c0dd4b05a75294bfb66af7e4da30e0d858aa1d42258e762b9d8f618642de1`，Alpha 严格为 `13,824,000 = 360×640×60` 字节。冷运行约 4.1 秒，缓存命中复跑约 2.2 秒；透明输出 metadata 为 `saliency_script_for_cc_v1.2`、`saliency-script` 和 `TEMattingBlendEffectV2-compatible`。完整证据在：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-saliency-provider-e2e-2026-08-27/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-saliency-provider-e2e-2026-08-27/
 ```
 
 这次真人反例也明确了 provider 的适用范围：强制把整段有脸镜头交给 saliency 时，它会优先保留手、衣服、地图等显著物，而不是完整两个人；因此不能取代 GRU。后续无缓存动态任务已直接读取 `MattingTaskParam(+0x180)`：两次 `handleFaceDetect` 的原始位模式都是 `0x3f000000`，即阈值 **0.5**。QCut 的实验性自动路由因此也改成“有脸样本数 / 有效样本数低于 50% 才切 saliency”。
@@ -351,8 +351,8 @@ GRU 与 saliency 现在共用同一套 Alpha 后处理实现：阈值、时序�
 两条自动路由均在共享后处理接入后通过真实 Electron E2E：有脸 2 秒素材走 GRU + native Metal，23.5 秒完成；无脸 0.5 秒素材自动走 saliency + compatible Blend，14.9 秒完成。两次均完成导入、属性面板、任务进度、添加透明媒体、绑定人物蒙版与播放器解码，截图和输出分别位于：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-auto-route-refined-e2e-2026-08-27/
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-auto-saliency-refined-e2e-2026-08-27/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-auto-route-refined-e2e-2026-08-27/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-auto-saliency-refined-e2e-2026-08-27/
 ```
 
 ### Mask 缓存格式与完成协议
@@ -403,7 +403,7 @@ GRU 与 saliency 现在共用同一套 Alpha 后处理实现：阈值、时序�
 `setPreviewModel(tt_matting_video_preview.model)` 仍存在，但这轮完整缓存运行没有动态命中；不能把它描述成每次预览必走的固定模型。导出 E2E 及原始动态证据保存在：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/dynamic-host-trace-2026-08-27/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/dynamic-host-trace-2026-08-27/
 ```
 
 其中 `jianying-host-trace-export.mov` 的 SHA-256 为 `5f2a3e083309f56ec3835b99f9995938d8b000b368b9e8b8f6c548704dd73a4c`；同状态的缺帧/恢复缓存导出分别为 `af000972d99fb1a8f5dcae674490a3b89abfb0ef8e106a0af16db7b79e9ed30e` 和 `f0be9c58505e380e2029c5c567a4906fb5fcbf8098caf236314ab864d9b4b814`。实验结束后已经把草稿恢复为原来的未抠像顶层片段、撤销测试切分、把羽化和边缘硬度恢复为 0，并恢复实验前的 `matting/` 缓存。
@@ -421,7 +421,7 @@ GRU bridge 现在按已动态确认的效果包序列设置 `5=1, 6=-1, 7=1, 8=1
 真人桌面 E2E 连续运行两次均通过。第二次运行前后同一缓存的 manifest 与 Alpha mtime 完全不变，证明导出命中缓存而非重新推理；缓存 manifest 为 60 帧、13,824,000 字节，模型路由为 `portrait-gru`，Blend 为 `TEMattingBlendEffectV2-native-metal`。QCut UI 完成态、时间线蒙版和实际播放器截图保存在：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-cache-integrity-e2e-2026-08-27/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-cache-integrity-e2e-2026-08-27/
 ```
 
 剪映应用内的 `saliency_matting.v1.0`、`saliency_script_for_cc.v1.2` 和 `video_saliency_seg_bce.v1.0` 已完成分层资源验证；`saliency_matting` Bach script graph 已接入 QCut 并通过强制 route、缓存命中、无脸实验 route 和真实 Electron E2E。`modelRoute`、模型/graph/processor 哈希均进入缓存身份，透明视频 metadata 会按实际路径写 `portrait-gru` 或 `saliency-script`。剪映自动选择的 `ai_matting_video_object -> video_saliency_seg_bce` 尚未作为独立 QCut provider 接入。
@@ -429,7 +429,7 @@ GRU bridge 现在按已动态确认的效果包序列设置 `5=1, 6=-1, 7=1, 8=1
 最新真人桌面 E2E 在删除硬切 reset、启动 `MP_IgnorePrevious` 和默认自动路由后，使用全新缓存根冷运行 `1/1` 通过。生成 60 帧、`13,824,000` 字节 Alpha；输出为 2 秒、360×640、30 fps VP9 Alpha，metadata 同时包含 `TEMattingBlendEffectV2-native-metal`、GRU v1.0 和 `portrait-gru`。浏览器实际解码中心 Alpha 均值 `248.72`、顶部背景 `0`。证据目录：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/qcut-default-gru-e2e/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/qcut-default-gru-e2e/
 ```
 
 ## 老人近景的最终模型路由与 Border 前 Alpha
@@ -466,7 +466,7 @@ GRU bridge 现在按已动态确认的效果包序列设置 `5=1, 6=-1, 7=1, 8=1
 原始 trace、两次新生成的缓存和 480 份 Border Alpha 均保存在仓库外：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/closeup-model-route-preborder-2026-08-27/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/closeup-model-route-preborder-2026-08-27/
 ```
 
 实验结束后，测试草稿原来的 244 个 `matting/` 文件已按两个原 cache ID 完整恢复。
@@ -485,15 +485,15 @@ GRU bridge 现在按已动态确认的效果包序列设置 `5=1, 6=-1, 7=1, 8=1
 本轮阈值与 reset 原始证据：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/jianying-threshold-reset-trace/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/jianying-threshold-reset-trace/
 ```
 
 本轮 QCut 真人桌面 E2E、量化与左剪映/右 QCut 白底对比：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/qcut-default-gru-e2e/
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/jianying-left-qcut-right-white.mp4
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/jianying-left-qcut-right-frame-55-white.png
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/qcut-default-gru-e2e/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/jianying-left-qcut-right-white.mp4
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/raw-alpha-context-parity-2026-08-27/jianying-left-qcut-right-frame-55-white.png
 ```
 
 ## 2026-08-28：object graph 宿主边界与精细模式最终补洞
@@ -563,7 +563,7 @@ source RGBA
 最终证据位于：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/qcut-motion-reset-parity-2026-08-28/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/qcut-motion-reset-parity-2026-08-28/
 ```
 
 重点文件为 `findings.md`、`vision-fusion-final-metrics.json`、

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/bytecoreml-nn3-capture.mm
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/bytecoreml-nn3-capture.mm
@@ -1,0 +1,93 @@
+#import <CoreML/CoreML.h>
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using ProcessPrediction = id (*)(id, SEL, id, id);
+
+ProcessPrediction originalProcessPrediction = nullptr;
+std::filesystem::path captureDirectory;
+std::atomic<unsigned int> captureIndex = 0;
+
+void captureNn3(id prediction) noexcept {
+  try {
+    MLMultiArray *array = nil;
+    if ([prediction respondsToSelector:@selector(featureValueForName:)]) {
+      MLFeatureValue *value =
+          [static_cast<id<MLFeatureProvider>>(prediction)
+              featureValueForName:@"nn_3"];
+      array = value.multiArrayValue;
+    }
+    if (array == nil && [prediction isKindOfClass:NSDictionary.class]) {
+      id value = static_cast<NSDictionary *>(prediction)[@"nn_3"];
+      if ([value isKindOfClass:MLFeatureValue.class]) {
+        array = static_cast<MLFeatureValue *>(value).multiArrayValue;
+      }
+    }
+    if (array == nil || array.dataType != MLMultiArrayDataTypeFloat32 ||
+        array.count != 256 * 256 || array.dataPointer == nullptr) {
+      std::cerr << "[nn3-capture] incompatible ByteCoreML output\n";
+      return;
+    }
+    char filename[128];
+    const unsigned int index = captureIndex.fetch_add(1);
+    std::snprintf(filename, sizeof(filename),
+                  "bytecoreml-%04u-nn_3.bin", index);
+    std::error_code error;
+    std::filesystem::create_directories(captureDirectory, error);
+    if (error) {
+      std::cerr << "[nn3-capture] cannot create output directory\n";
+      return;
+    }
+    std::ofstream output(captureDirectory / filename,
+                         std::ios::binary | std::ios::trunc);
+    output.write(static_cast<const char *>(array.dataPointer),
+                 static_cast<std::streamsize>(array.count * sizeof(float)));
+    if (!output.good()) {
+      std::cerr << "[nn3-capture] cannot write output\n";
+      return;
+    }
+    std::cerr << "[nn3-capture] frame=" << index
+              << " floats=" << array.count << '\n';
+  } catch (...) {
+    std::cerr << "[nn3-capture] unexpected capture failure\n";
+  }
+}
+
+id captureProcessPrediction(id object, SEL selector, id options, id error) {
+  id prediction =
+      originalProcessPrediction(object, selector, options, error);
+  captureNn3(prediction);
+  return prediction;
+}
+
+} // namespace
+
+extern "C" void installByteCoreMLNn3Capture() {
+  const char *configured = std::getenv("JY_BACH_NN3_CAPTURE_DIR");
+  if (configured == nullptr || *configured == '\0') {
+    throw std::runtime_error("JY_BACH_NN3_CAPTURE_DIR is required");
+  }
+  captureDirectory = configured;
+  Class processClass = NSClassFromString(@"IESMMProcessNN");
+  const SEL selector = @selector(doDictPredictionWithOptions:error:);
+  Method method = class_getInstanceMethod(processClass, selector);
+  if (processClass == Nil || method == nullptr) {
+    throw std::runtime_error(
+        "IESMMProcessNN prediction selector is unavailable");
+  }
+  originalProcessPrediction = reinterpret_cast<ProcessPrediction>(
+      method_getImplementation(method));
+  method_setImplementation(method,
+                           reinterpret_cast<IMP>(captureProcessPrediction));
+}

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/coreml-feature-capture.mm
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/coreml-feature-capture.mm
@@ -1,0 +1,141 @@
+#import <CoreML/CoreML.h>
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <string>
+
+namespace {
+
+using Prediction = id<MLFeatureProvider> (*)(
+    id, SEL, id<MLFeatureProvider>, MLPredictionOptions *, NSError **);
+using DictionaryInitializer = id (*)(id, SEL, NSDictionary *, NSError **);
+
+Prediction originalPrediction = nullptr;
+DictionaryInitializer originalDictionaryInitializer = nullptr;
+std::atomic<unsigned int> captureIndex = 0;
+std::mutex outputMutex;
+
+std::filesystem::path captureDirectory() {
+  const char *configured = std::getenv("JY_COREML_CAPTURE_DIR");
+  return configured == nullptr
+             ? std::filesystem::path("/tmp/jy-coreml-capture")
+             : std::filesystem::path(configured);
+}
+
+void appendLog(const std::string &line) {
+  std::lock_guard lock(outputMutex);
+  std::error_code error;
+  const auto directory = captureDirectory();
+  std::filesystem::create_directories(directory, error);
+  if (error) {
+    return;
+  }
+  std::ofstream output(directory / "capture.log", std::ios::app);
+  output << line << '\n';
+}
+
+bool isTargetModelInput(id<MLFeatureProvider> features) {
+  const NSSet<NSString *> *names = features.featureNames;
+  return [names containsObject:@"data"] && [names containsObject:@"prev_img"] &&
+         [names containsObject:@"prev_mask"];
+}
+
+void writeArray(MLMultiArray *array, unsigned int index, NSString *name) {
+  if (array == nil) {
+    appendLog("missing tensor " + std::string(name.UTF8String));
+    return;
+  }
+  std::string shape;
+  for (NSNumber *dimension in array.shape) {
+    if (!shape.empty()) {
+      shape += 'x';
+    }
+    shape += std::to_string(dimension.longLongValue);
+  }
+  appendLog("coreml[" + std::to_string(index) + "] " +
+            std::string(name.UTF8String) + " type=" +
+            std::to_string(array.dataType) + " shape=" + shape +
+            " count=" + std::to_string(array.count));
+  if (array.dataType != MLMultiArrayDataTypeFloat32 || array.dataPointer == nullptr) {
+    return;
+  }
+  char filename[128];
+  std::snprintf(filename, sizeof(filename), "coreml-%04u-%s.bin", index,
+                name.UTF8String);
+  const std::filesystem::path outputPath = captureDirectory() / filename;
+  std::ofstream output(outputPath, std::ios::binary);
+  output.write(static_cast<const char *>(array.dataPointer),
+               static_cast<std::streamsize>(array.count * sizeof(float)));
+  if (!output.good()) {
+    appendLog("failed to write " + outputPath.string());
+  }
+}
+
+void writeFeature(id<MLFeatureProvider> features, unsigned int index,
+                  NSString *name) {
+  writeArray([features featureValueForName:name].multiArrayValue, index, name);
+}
+
+id captureDictionaryInitializer(id object, SEL selector,
+                                NSDictionary *features, NSError **error) {
+  id result = originalDictionaryInitializer(object, selector, features, error);
+  if (features[@"data"] == nil || features[@"prev_img"] == nil ||
+      features[@"prev_mask"] == nil) {
+    return result;
+  }
+  const unsigned int index = captureIndex.fetch_add(1);
+  for (NSString *name in @[@"data", @"prev_img", @"prev_mask"]) {
+    MLFeatureValue *value = features[name];
+    writeArray(value.multiArrayValue, index, name);
+  }
+  return result;
+}
+
+id<MLFeatureProvider> capturePrediction(id model, SEL selector,
+                                        id<MLFeatureProvider> features,
+                                        MLPredictionOptions *options,
+                                        NSError **error) {
+  if (!isTargetModelInput(features)) {
+    return originalPrediction(model, selector, features, options, error);
+  }
+  const unsigned int index = captureIndex.fetch_add(1);
+  writeFeature(features, index, @"data");
+  writeFeature(features, index, @"prev_img");
+  writeFeature(features, index, @"prev_mask");
+  id<MLFeatureProvider> result =
+      originalPrediction(model, selector, features, options, error);
+  if (result != nil) {
+    writeFeature(result, index, @"nn_3");
+  }
+  return result;
+}
+
+__attribute__((constructor)) void installCapture() {
+  const SEL predictionSelector =
+      @selector(predictionFromFeatures:options:error:);
+  Method predictionMethod =
+      class_getInstanceMethod(MLModel.class, predictionSelector);
+  const SEL dictionarySelector = @selector(initWithDictionary:error:);
+  Method dictionaryMethod = class_getInstanceMethod(
+      MLDictionaryFeatureProvider.class, dictionarySelector);
+  if (predictionMethod == nullptr || dictionaryMethod == nullptr) {
+    appendLog("MLModel prediction selector is unavailable");
+    return;
+  }
+  originalPrediction = reinterpret_cast<Prediction>(
+      method_getImplementation(predictionMethod));
+  originalDictionaryInitializer = reinterpret_cast<DictionaryInitializer>(
+      method_getImplementation(dictionaryMethod));
+  method_setImplementation(predictionMethod,
+                           reinterpret_cast<IMP>(capturePrediction));
+  method_setImplementation(dictionaryMethod,
+                           reinterpret_cast<IMP>(captureDictionaryInitializer));
+  appendLog("CoreML feature capture installed");
+}
+
+} // namespace

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/coreml-feature-capture.mm
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/coreml-feature-capture.mm
@@ -4,6 +4,8 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <mutex>

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/effect-cgl-render-probe.cpp
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/effect-cgl-render-probe.cpp
@@ -3,6 +3,7 @@
 #include <objc/message.h>
 #include <objc/runtime.h>
 #include <OpenGL/gl.h>
+#include <mach/mach.h>
 
 #include <dlfcn.h>
 
@@ -18,6 +19,7 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -61,6 +63,27 @@ using EffectGetBachResultByGraphAndNodeName =
     Result (*)(EffectHandle, const char*, const char*, void**);
 using EffectConfigAbValue = Result (*)(const char*, const void*, std::int32_t);
 using SkinSegTextureId = GLuint (*)(void*);
+using MattingTextureId = GLuint (*)(void*);
+
+struct Vector4f {
+    float x;
+    float y;
+    float z;
+    float w;
+};
+
+struct ReturnedPrimitiveVector {
+    void* value = nullptr;
+    ~ReturnedPrimitiveVector() {}
+};
+
+using BachObjectToVector4f = Vector4f (*)(const void*);
+using FindScriptValue = void* (*)(
+    void*,
+    const std::string*,
+    const void*,
+    const std::string**,
+    bool*);
 
 template <typename Function>
 Function loadSymbol(const struct SymbolOptions& options);
@@ -450,6 +473,401 @@ struct InspectFaceResultOptions {
     const char* coordinateSpace;
 };
 
+struct InspectMattingResultOptions {
+    EffectHandle handle;
+    void* library;
+    EffectGetBachResult getResultByType;
+    EffectGetBachResultByNodeName getResult;
+    EffectGetBachResultByGraphAndNodeName getResultByGraphAndNode;
+    MattingTextureId getTextureId;
+    BachObjectToVector4f toVector4f;
+    const char* graphName;
+    const char* nodeName;
+    const char* maskOutputPath;
+};
+
+[[maybe_unused]] void inspectTextureInfoMap(void* library, const void* map) {
+    using Constructor = void (*)(void*);
+    using Destructor = void (*)(void*);
+    using CastTo = void (*)(void*, void*);
+    using IntegerGetter = std::int32_t (*)(void*);
+    using PointerGetter = void* (*)(void*);
+    using TextureGetter = GLuint (*)(void*);
+    const auto constructor = reinterpret_cast<Constructor>(
+        dlsym(library, "_ZN4Bach15BachTextureInfoC1Ev"));
+    const auto destructor = reinterpret_cast<Destructor>(
+        dlsym(library, "_ZN4Bach15BachTextureInfoD1Ev"));
+    const auto castTo = reinterpret_cast<CastTo>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo6castToEPNS_7BachMapE"));
+    const auto width = reinterpret_cast<IntegerGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo5widthEv"));
+    const auto height = reinterpret_cast<IntegerGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo6heightEv"));
+    const auto dataPtr = reinterpret_cast<PointerGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo7dataPtrEv"));
+    const auto textureId = reinterpret_cast<TextureGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo9textureIdEv"));
+    const bool hasVector4Conversion = dlsym(
+        library, "_ZNK4Bach10BachObjectcvN13AmazingEngine8Vector4fEEv") != nullptr;
+    if (!constructor || !destructor || !castTo || !width || !height ||
+        !dataPtr || !textureId) {
+        std::cout << "texture_info_symbols=missing constructor="
+                  << static_cast<bool>(constructor)
+                  << " destructor=" << static_cast<bool>(destructor)
+                  << " cast=" << static_cast<bool>(castTo)
+                  << " width=" << static_cast<bool>(width)
+                  << " height=" << static_cast<bool>(height)
+                  << " data=" << static_cast<bool>(dataPtr)
+                  << " texture=" << static_cast<bool>(textureId)
+                  << " vector4=" << hasVector4Conversion
+                  << " library=" << library << '\n';
+        return;
+    }
+    alignas(std::max_align_t) std::array<std::uint8_t, 1024> storage{};
+    constructor(storage.data());
+    castTo(storage.data(), const_cast<void*>(map));
+    std::cout << "texture_info_map width=" << width(storage.data())
+              << " height=" << height(storage.data())
+              << " data=" << dataPtr(storage.data())
+              << " texture=" << textureId(storage.data()) << '\n';
+    destructor(storage.data());
+}
+
+[[maybe_unused]] void inspectTextureInfo(void* library, void* textureInfo) {
+    using IntegerGetter = std::int32_t (*)(void*);
+    using SizeGetter = std::size_t (*)(void*);
+    const auto width = reinterpret_cast<IntegerGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo5widthEv"));
+    const auto height = reinterpret_cast<IntegerGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo6heightEv"));
+    const auto imageWidth = reinterpret_cast<IntegerGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo10imageWidthEv"));
+    const auto imageHeight = reinterpret_cast<IntegerGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo11imageHeightEv"));
+    const auto byteSize = reinterpret_cast<SizeGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo11GetByteSizeEv"));
+    const auto dataCount = reinterpret_cast<SizeGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo12GetDataCountEv"));
+    const auto dataFormat = reinterpret_cast<IntegerGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo10dataFormatEv"));
+    const auto dataType = reinterpret_cast<IntegerGetter>(
+        dlsym(library, "_ZN4Bach15BachTextureInfo8dataTypeEv"));
+    if (!width || !height || !imageWidth || !imageHeight || !byteSize ||
+        !dataCount || !dataFormat || !dataType ||
+        textureInfo == nullptr) {
+        return;
+    }
+    std::cout << "texture_info_direct width=" << width(textureInfo)
+              << " height=" << height(textureInfo)
+              << " image_width=" << imageWidth(textureInfo)
+              << " image_height=" << imageHeight(textureInfo)
+              << " byte_size=" << byteSize(textureInfo)
+              << " data_count=" << dataCount(textureInfo)
+              << " data_format=" << dataFormat(textureInfo)
+              << " data_type=" << dataType(textureInfo) << '\n';
+}
+
+struct ReadProcessMemoryOptions {
+    const void* address;
+    void* output;
+    std::size_t size;
+};
+
+bool readProcessMemory(const ReadProcessMemoryOptions& options) {
+    vm_size_t bytesRead = 0;
+    const kern_return_t result = vm_read_overwrite(
+        mach_task_self(),
+        reinterpret_cast<vm_address_t>(options.address),
+        static_cast<vm_size_t>(options.size),
+        reinterpret_cast<vm_address_t>(options.output),
+        &bytesRead);
+    return result == KERN_SUCCESS && bytesRead == options.size;
+}
+
+void inspectVtable(const void* object, const char* label) {
+    const void* vtable = nullptr;
+    if (!readProcessMemory({
+            .address = object,
+            .output = &vtable,
+            .size = sizeof(vtable),
+        }) || vtable == nullptr) {
+        return;
+    }
+    for (std::size_t index = 0; index < 32; ++index) {
+        const void* function = nullptr;
+        if (!readProcessMemory({
+                .address = static_cast<const std::uint8_t*>(vtable) +
+                    index * sizeof(function),
+                .output = &function,
+                .size = sizeof(function),
+            }) || function == nullptr) {
+            continue;
+        }
+        Dl_info info{};
+        std::cout << label << "_vtable[" << index << "]=" << function;
+        if (dladdr(function, &info) != 0 && info.dli_sname != nullptr) {
+            std::cout << " symbol=" << info.dli_sname;
+        }
+        std::cout << '\n';
+    }
+}
+
+void inspectAsciiMemory(const void* address, const char* label) {
+    std::array<std::uint8_t, 512> bytes{};
+    if (!readProcessMemory({
+            .address = address,
+            .output = bytes.data(),
+            .size = bytes.size(),
+        })) {
+        return;
+    }
+    for (std::size_t start = 0; start < bytes.size();) {
+        if (bytes[start] < 0x20 || bytes[start] > 0x7e) {
+            start += 1;
+            continue;
+        }
+        std::size_t end = start;
+        while (end < bytes.size() && bytes[end] >= 0x20 && bytes[end] <= 0x7e) {
+            end += 1;
+        }
+        if (end - start >= 3) {
+            std::cout << label << "_ascii[0x" << std::hex << start << std::dec
+                      << "]="
+                      << std::string(reinterpret_cast<const char*>(bytes.data() + start),
+                                     end - start)
+                      << '\n';
+        }
+        start = end;
+    }
+}
+
+std::string readRttiName(const void* object) {
+    std::uintptr_t vtable = 0;
+    if (!readProcessMemory({
+            .address = object,
+            .output = &vtable,
+            .size = sizeof(vtable),
+        }) || vtable < sizeof(std::uintptr_t)) {
+        return {};
+    }
+
+    std::uintptr_t typeInfo = 0;
+    if (!readProcessMemory({
+            .address = reinterpret_cast<const void*>(vtable - sizeof(std::uintptr_t)),
+            .output = &typeInfo,
+            .size = sizeof(typeInfo),
+        }) || typeInfo == 0) {
+        return {};
+    }
+
+    std::uintptr_t name = 0;
+    if (!readProcessMemory({
+            .address = reinterpret_cast<const std::uint8_t*>(
+                reinterpret_cast<const void*>(typeInfo)) + sizeof(std::uintptr_t),
+            .output = &name,
+            .size = sizeof(name),
+        }) || name == 0) {
+        return {};
+    }
+    name &= 0x0000ffffffffffffULL;
+
+    std::string result;
+    result.reserve(160);
+    for (std::size_t index = 0; index < 160; ++index) {
+        char character = '\0';
+        if (!readProcessMemory({
+                .address = reinterpret_cast<const char*>(
+                    reinterpret_cast<const void*>(name)) + index,
+                .output = &character,
+                .size = sizeof(character),
+            })) {
+            return {};
+        }
+        if (character == '\0') {
+            return result;
+        }
+        result.push_back(character);
+    }
+    return {};
+}
+
+void inspectResultPointers(const void* resultObject) {
+    constexpr std::size_t wordCount = 32;
+    std::array<std::uintptr_t, wordCount> words{};
+    if (!readProcessMemory({
+            .address = resultObject,
+            .output = words.data(),
+            .size = sizeof(words),
+        })) {
+        std::cout << "matting_result_pointer_scan=unreadable\n";
+        return;
+    }
+
+    for (std::size_t index = 0; index < words.size(); ++index) {
+        const std::uintptr_t value = words[index];
+        Dl_info directSymbol{};
+        const bool hasDirectSymbol =
+            dladdr(reinterpret_cast<const void*>(value), &directSymbol) != 0 &&
+            directSymbol.dli_sname != nullptr;
+
+        std::uintptr_t nestedValue = 0;
+        const bool hasNestedValue = value != 0 && readProcessMemory({
+            .address = reinterpret_cast<const void*>(value),
+            .output = &nestedValue,
+            .size = sizeof(nestedValue),
+        });
+        Dl_info nestedSymbol{};
+        const bool hasNestedSymbol = hasNestedValue &&
+            dladdr(reinterpret_cast<const void*>(nestedValue), &nestedSymbol) != 0 &&
+            nestedSymbol.dli_sname != nullptr;
+        if (value == 0) {
+            continue;
+        }
+
+        std::cout << "matting_result_word[0x" << std::hex << index * sizeof(value)
+                  << "]=0x" << value << std::dec;
+        if (hasDirectSymbol) {
+            std::cout << " symbol=" << directSymbol.dli_sname;
+        }
+        if (hasNestedSymbol) {
+            std::cout << " nested_symbol=" << nestedSymbol.dli_sname;
+        } else if (hasNestedValue) {
+            std::cout << " nested=0x" << std::hex << nestedValue << std::dec;
+            const std::string nestedRtti =
+                readRttiName(reinterpret_cast<const void*>(nestedValue));
+            if (!nestedRtti.empty()) {
+                std::cout << " nested_rtti=" << nestedRtti;
+            }
+            std::uintptr_t secondNestedValue = 0;
+            const bool hasSecondNestedValue = nestedValue != 0 && readProcessMemory({
+                .address = reinterpret_cast<const void*>(nestedValue),
+                .output = &secondNestedValue,
+                .size = sizeof(secondNestedValue),
+            });
+            Dl_info secondNestedSymbol{};
+            const bool hasSecondNestedSymbol = hasSecondNestedValue &&
+                dladdr(reinterpret_cast<const void*>(secondNestedValue), &secondNestedSymbol) != 0 &&
+                secondNestedSymbol.dli_sname != nullptr;
+            if (hasSecondNestedSymbol) {
+                std::cout << " second_nested_symbol=" << secondNestedSymbol.dli_sname;
+            } else if (hasSecondNestedValue) {
+                std::cout << " second_nested=0x" << std::hex << secondNestedValue << std::dec;
+                std::uintptr_t typeInfo = 0;
+                std::uintptr_t typeName = 0;
+                const bool hasTypeInfo = secondNestedValue >= sizeof(std::uintptr_t) &&
+                    readProcessMemory({
+                        .address = reinterpret_cast<const void*>(
+                            secondNestedValue - sizeof(std::uintptr_t)),
+                        .output = &typeInfo,
+                        .size = sizeof(typeInfo),
+                    });
+                const bool hasTypeName = hasTypeInfo && typeInfo != 0 && readProcessMemory({
+                    .address = reinterpret_cast<const std::uint8_t*>(
+                        reinterpret_cast<const void*>(typeInfo)) + sizeof(std::uintptr_t),
+                    .output = &typeName,
+                    .size = sizeof(typeName),
+                });
+                if (hasTypeName) {
+                    std::cout << " type_info=0x" << std::hex << typeInfo
+                              << " type_name=0x" << typeName << std::dec;
+                }
+            }
+        }
+        std::cout << '\n';
+    }
+}
+
+struct FindScriptValueOptions {
+    const void* scriptInfo;
+    const char* key;
+    const void* libraryBase;
+};
+
+void* findScriptValue(const FindScriptValueOptions& options) {
+    // Pinned to VideoFusion 11.3.0. These are the same map lookup and static
+    // comparator addresses used by TEBachMattingAlgorithm::getMaskAndBoundingBox.
+    constexpr std::uintptr_t findValueOffset = 0x0b86aa4;
+    constexpr std::uintptr_t comparatorOffset = 0x2d03ee0;
+    const auto base = reinterpret_cast<std::uintptr_t>(options.libraryBase);
+    const auto findValue = reinterpret_cast<FindScriptValue>(base + findValueOffset);
+    const auto* comparator = reinterpret_cast<const void*>(base + comparatorOffset);
+    const std::string key(options.key);
+    const std::string* matchedKey = &key;
+    bool didInsert = false;
+    auto* map = const_cast<std::uint8_t*>(
+        static_cast<const std::uint8_t*>(options.scriptInfo)) + 0x10;
+    return findValue(map, &key, comparator, &matchedKey, &didInsert);
+}
+
+struct WriteScriptMaskOptions {
+    const void* scriptInfo;
+    BachObjectToVector4f toVector4f;
+    const void* libraryBase;
+    const char* outputPath;
+};
+
+bool writePgmMask(
+    const char* outputPath,
+    const std::uint8_t* pixels,
+    std::int32_t width,
+    std::int32_t height);
+
+bool writeScriptMask(const WriteScriptMaskOptions& options) {
+    const void* maskEntry = findScriptValue({
+        .scriptInfo = options.scriptInfo,
+        .key = "mask",
+        .libraryBase = options.libraryBase,
+    });
+    const void* boundsEntry = findScriptValue({
+        .scriptInfo = options.scriptInfo,
+        .key = "ltwh",
+        .libraryBase = options.libraryBase,
+    });
+    std::cout << "script_mask_entry=" << maskEntry
+              << " bounds_entry=" << boundsEntry << '\n';
+    if (maskEntry == nullptr || boundsEntry == nullptr) {
+        return false;
+    }
+
+    const Vector4f bounds = options.toVector4f(
+        static_cast<const std::uint8_t*>(boundsEntry) + 0x28);
+    const auto width = static_cast<std::int32_t>(std::lround(bounds.z));
+    const auto height = static_cast<std::int32_t>(std::lround(bounds.w));
+    const void* textureInfo = nullptr;
+    if (!readProcessMemory({
+            .address = static_cast<const std::uint8_t*>(maskEntry) + 0x88,
+            .output = &textureInfo,
+            .size = sizeof(textureInfo),
+        }) || textureInfo == nullptr) {
+        return false;
+    }
+
+    const std::uint8_t* begin = nullptr;
+    const std::uint8_t* end = nullptr;
+    if (!readProcessMemory({
+            .address = static_cast<const std::uint8_t*>(textureInfo) + 0x10,
+            .output = &begin,
+            .size = sizeof(begin),
+        }) || !readProcessMemory({
+            .address = static_cast<const std::uint8_t*>(textureInfo) + 0x18,
+            .output = &end,
+            .size = sizeof(end),
+        }) || begin == nullptr || end < begin) {
+        return false;
+    }
+
+    const std::size_t byteCount = static_cast<std::size_t>(end - begin);
+    const std::size_t expectedByteCount =
+        static_cast<std::size_t>(width) * static_cast<std::size_t>(height);
+    std::cout << "script_mask_bounds=" << bounds.x << ',' << bounds.y << ','
+              << bounds.z << ',' << bounds.w << " bytes=" << byteCount << '\n';
+    if (width <= 0 || height <= 0 || width > 4096 || height > 4096 ||
+        byteCount != expectedByteCount) {
+        return false;
+    }
+    return writePgmMask(options.outputPath, begin, width, height);
+}
+
 struct InspectTextureOptions {
     GLint expectedWidth;
     GLint expectedHeight;
@@ -570,6 +988,322 @@ bool writePgmMask(
     std::cout << "skin_mask_output=" << outputPath << " size=" << width << 'x'
               << height << '\n';
     return true;
+}
+
+bool inspectMattingResult(const InspectMattingResultOptions& options) {
+    void* resultObject = nullptr;
+    Result result = options.getResult(options.handle, options.nodeName, &resultObject);
+    std::cout << "matting_result_by_node_status=" << result
+              << " node=" << options.nodeName << " object=" << resultObject << '\n';
+    if (result != 0 || resultObject == nullptr) {
+        resultObject = nullptr;
+        result = options.getResultByGraphAndNode(
+            options.handle, options.graphName, options.nodeName, &resultObject);
+        std::cout << "matting_result_by_graph_status=" << result
+                  << " graph=" << options.graphName << " node=" << options.nodeName
+                  << " object=" << resultObject << '\n';
+    }
+    if (result != 0 || resultObject == nullptr) {
+        resultObject = nullptr;
+        constexpr std::int32_t scriptAlgorithmType = 141;
+        result = options.getResultByType(
+            options.handle, &resultObject, scriptAlgorithmType);
+        std::cout << "matting_result_by_type_status=" << result
+                  << " type=" << scriptAlgorithmType << " object=" << resultObject << '\n';
+    }
+    if (result != 0 || resultObject == nullptr) {
+        resultObject = nullptr;
+        constexpr std::int32_t generalSegAlgorithmType = 198;
+        result = options.getResultByType(
+            options.handle, &resultObject, generalSegAlgorithmType);
+        std::cout << "matting_result_by_type_status=" << result
+                  << " type=" << generalSegAlgorithmType
+                  << " object=" << resultObject << '\n';
+    }
+    if (result != 0 || resultObject == nullptr) {
+        for (std::int32_t algorithmType = 0; algorithmType <= 255; ++algorithmType) {
+            void* candidate = nullptr;
+            const Result candidateResult = options.getResultByType(
+                options.handle, &candidate, algorithmType);
+            if (candidateResult != 0 || candidate == nullptr) {
+                continue;
+            }
+            const auto* candidateBytes = static_cast<const std::uint8_t*>(candidate);
+            const void* infoVector = nullptr;
+            const void* algorithmInfo = nullptr;
+            if (readProcessMemory({
+                    .address = candidateBytes + 0x18,
+                    .output = &infoVector,
+                    .size = sizeof(infoVector),
+                }) && infoVector != nullptr) {
+                readProcessMemory({
+                    .address = infoVector,
+                    .output = &algorithmInfo,
+                    .size = sizeof(algorithmInfo),
+                });
+            }
+            std::cout << "matting_result_scan type=" << algorithmType
+                      << " object=" << candidate
+                      << " wrapper_rtti=" << readRttiName(candidate)
+                      << " info=" << algorithmInfo
+                      << " info_rtti=" << readRttiName(algorithmInfo) << '\n';
+        }
+    }
+    if (result != 0 || resultObject == nullptr) {
+        return false;
+    }
+
+    void* const vtable = *static_cast<void**>(resultObject);
+    Dl_info symbolInfo{};
+    const bool hasSymbol = dladdr(vtable, &symbolInfo) != 0 && symbolInfo.dli_sname != nullptr;
+    const std::string_view symbolName = hasSymbol ? symbolInfo.dli_sname : "<unknown>";
+    std::cout << "matting_result_vtable=" << vtable << " symbol=" << symbolName << '\n';
+    inspectResultPointers(resultObject);
+    const auto* resultBytes = static_cast<const std::uint8_t*>(resultObject);
+    const void* infoVector = nullptr;
+    if (readProcessMemory({
+            .address = resultBytes + 0x18,
+            .output = &infoVector,
+            .size = sizeof(infoVector),
+        }) && infoVector != nullptr) {
+        const void* algorithmInfo = nullptr;
+        if (readProcessMemory({
+                .address = infoVector,
+                .output = &algorithmInfo,
+                .size = sizeof(algorithmInfo),
+            }) && algorithmInfo != nullptr) {
+            std::cout << "matting_result_algorithm_info=" << algorithmInfo
+                      << " rtti=" << readRttiName(algorithmInfo) << '\n';
+            inspectResultPointers(algorithmInfo);
+            if (readRttiName(algorithmInfo) == "N4Bach7BachMapE") {
+                inspectVtable(algorithmInfo, "bach_map");
+                const void* firstNode = nullptr;
+                readProcessMemory({
+                    .address = static_cast<const std::uint8_t*>(algorithmInfo) + 0x20,
+                    .output = &firstNode,
+                    .size = sizeof(firstNode),
+                });
+                inspectAsciiMemory(firstNode, "bach_map_node");
+                if (firstNode != nullptr) {
+                    using BachObjectToMap = void* (*)(const void*);
+                    const auto toMap = reinterpret_cast<BachObjectToMap>(dlsym(
+                        options.library,
+                        "_ZNK4Bach10BachObjectcvPNS_7BachMapEEv"));
+                    constexpr std::size_t valueOffset = 0x28;
+                    constexpr std::size_t typeOffset = 0x80;
+                    const auto* value = static_cast<const std::uint8_t*>(firstNode) +
+                        valueOffset;
+                    std::uint32_t valueType = 0;
+                    if (toMap != nullptr && readProcessMemory({
+                            .address = value + typeOffset,
+                            .output = &valueType,
+                            .size = sizeof(valueType),
+                        }) && valueType == 0x1d) {
+                        void* nestedMap = toMap(value);
+                        std::cout << "bach_map_entry_type=0x" << std::hex
+                                  << valueType << std::dec
+                                  << " nested_map=" << nestedMap
+                                  << " rtti=" << readRttiName(nestedMap) << '\n';
+                        inspectResultPointers(nestedMap);
+                        void* implementation = nullptr;
+                        void* textureWrapper = nullptr;
+                        void* dataObject = nullptr;
+                        const bool readImplementation = readProcessMemory({
+                            .address = static_cast<const std::uint8_t*>(nestedMap) + 0x38,
+                            .output = &implementation,
+                            .size = sizeof(implementation),
+                        });
+                        bool readTextureWrapper = false;
+                        if (implementation != nullptr) {
+                            readTextureWrapper = readProcessMemory({
+                                .address = static_cast<const std::uint8_t*>(implementation) + 0x8,
+                                .output = &textureWrapper,
+                                .size = sizeof(textureWrapper),
+                            });
+                        }
+                        std::cout << "general_seg_layout implementation="
+                                  << implementation
+                                  << " read_implementation=" << readImplementation
+                                  << " texture_wrapper=" << textureWrapper
+                                  << " read_texture_wrapper=" << readTextureWrapper << '\n';
+                        if (implementation != nullptr) {
+                            for (const std::size_t offset : {0x8U, 0x10U, 0x18U, 0x28U,
+                                                             0x38U, 0x40U, 0x50U}) {
+                                void* candidate = nullptr;
+                                const bool didRead = readProcessMemory({
+                                    .address = static_cast<const std::uint8_t*>(
+                                        implementation) + offset,
+                                    .output = &candidate,
+                                    .size = sizeof(candidate),
+                                });
+                                std::cout << "general_seg_impl[0x" << std::hex
+                                          << offset << std::dec << "]=" << candidate
+                                          << " read=" << didRead
+                                          << " rtti=" << readRttiName(candidate) << '\n';
+                            }
+                        }
+                        if (textureWrapper != nullptr) {
+                            std::int32_t textureWidth = 0;
+                            std::int32_t textureHeight = 0;
+                            std::int32_t textureFormat = 0;
+                            GLuint texture = 0;
+                            readProcessMemory({
+                                .address = static_cast<const std::uint8_t*>(textureWrapper) + 0x14,
+                                .output = &textureWidth,
+                                .size = sizeof(textureWidth),
+                            });
+                            readProcessMemory({
+                                .address = static_cast<const std::uint8_t*>(textureWrapper) + 0x18,
+                                .output = &textureHeight,
+                                .size = sizeof(textureHeight),
+                            });
+                            readProcessMemory({
+                                .address = static_cast<const std::uint8_t*>(textureWrapper) + 0x60,
+                                .output = &dataObject,
+                                .size = sizeof(dataObject),
+                            });
+                            readProcessMemory({
+                                .address = static_cast<const std::uint8_t*>(textureWrapper) + 0x68,
+                                .output = &textureFormat,
+                                .size = sizeof(textureFormat),
+                            });
+                            readProcessMemory({
+                                .address = static_cast<const std::uint8_t*>(textureWrapper) + 0x70,
+                                .output = &texture,
+                                .size = sizeof(texture),
+                            });
+                            std::cout << "general_seg_texture_wrapper=" << textureWrapper
+                                      << " rtti=" << readRttiName(textureWrapper)
+                                      << " size=" << textureWidth << 'x' << textureHeight
+                                      << " format=" << textureFormat
+                                      << " texture=" << texture
+                                      << " valid=" << static_cast<int>(glIsTexture(texture))
+                                      << " data=" << dataObject
+                                      << " data_rtti=" << readRttiName(dataObject) << '\n';
+                        }
+                        if (dataObject == nullptr && implementation != nullptr) {
+                            readProcessMemory({
+                                .address = static_cast<const std::uint8_t*>(implementation) + 0x50,
+                                .output = &dataObject,
+                                .size = sizeof(dataObject),
+                            });
+                        }
+                        using BachTextureInfoData = ReturnedPrimitiveVector (*)(void*);
+                        const auto getData = reinterpret_cast<BachTextureInfoData>(dlsym(
+                            options.library,
+                            "_ZN4Bach15BachTextureInfo4dataEv"));
+                        const auto release = reinterpret_cast<void (*)(const void*)>(dlsym(
+                            options.library,
+                            "_ZNK13AmazingEngine7RefBase7releaseEv"));
+                        ReturnedPrimitiveVector returnedData;
+                        if (getData != nullptr) {
+                            returnedData = getData(nestedMap);
+                            dataObject = returnedData.value;
+                            std::cout << "general_seg_materialized_data=" << dataObject
+                                      << " rtti=" << readRttiName(dataObject) << '\n';
+                        }
+                        if (dataObject != nullptr) {
+                            inspectResultPointers(dataObject);
+                            const std::uint8_t* begin = nullptr;
+                            const std::uint8_t* end = nullptr;
+                            readProcessMemory({
+                                .address = static_cast<const std::uint8_t*>(dataObject) + 0x10,
+                                .output = &begin,
+                                .size = sizeof(begin),
+                            });
+                            readProcessMemory({
+                                .address = static_cast<const std::uint8_t*>(dataObject) + 0x18,
+                                .output = &end,
+                                .size = sizeof(end),
+                            });
+                            const auto byteCount = begin != nullptr && end >= begin
+                                ? static_cast<std::size_t>(end - begin)
+                                : 0;
+                            std::cout << "general_seg_data begin="
+                                      << static_cast<const void*>(begin)
+                                      << " end=" << static_cast<const void*>(end)
+                                      << " bytes=" << byteCount << '\n';
+                            if (options.maskOutputPath != nullptr &&
+                                byteCount == 256U * 256U) {
+                                std::cout << "general_seg_mask_written="
+                                          << writePgmMask(
+                                                 options.maskOutputPath,
+                                                 begin,
+                                                 256,
+                                                 256)
+                                          << '\n';
+                            }
+                        }
+                        if (returnedData.value != nullptr && release != nullptr) {
+                            release(returnedData.value);
+                            returnedData.value = nullptr;
+                        }
+                    } else {
+                        std::cout << "bach_map_entry_type=0x" << std::hex
+                                  << valueType << std::dec
+                                  << " to_map=" << static_cast<bool>(toMap) << '\n';
+                    }
+                }
+            }
+            Dl_info libraryInfo{};
+            const bool hasLibraryInfo = dladdr(
+                reinterpret_cast<const void*>(options.getTextureId), &libraryInfo) != 0 &&
+                libraryInfo.dli_fbase != nullptr;
+            if (readRttiName(algorithmInfo) == "N4Bach10ScriptInfoE" && hasLibraryInfo) {
+                return writeScriptMask({
+                    .scriptInfo = algorithmInfo,
+                    .toVector4f = options.toVector4f,
+                    .libraryBase = libraryInfo.dli_fbase,
+                    .outputPath = options.maskOutputPath,
+                });
+            }
+        }
+    }
+    if (symbolName.find("MattingResult") == std::string_view::npos) {
+        return false;
+    }
+
+    const GLuint texture = options.getTextureId(resultObject);
+    std::cout << "matting_result_texture=" << texture
+              << " valid=" << static_cast<int>(glIsTexture(texture)) << '\n';
+    if (texture == 0 || glIsTexture(texture) == GL_FALSE) {
+        return false;
+    }
+
+    GLint previousTexture = 0;
+    GLint width = 0;
+    GLint height = 0;
+    GLint internalFormat = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &previousTexture);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &width);
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &height);
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internalFormat);
+    if (width <= 0 || height <= 0 || width > 4096 || height > 4096) {
+        glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(previousTexture));
+        return false;
+    }
+
+    const std::size_t pixelCount = static_cast<std::size_t>(width) * height;
+    std::vector<std::uint8_t> mask(pixelCount);
+    glGetTexImage(GL_TEXTURE_2D, 0, GL_RED, GL_UNSIGNED_BYTE, mask.data());
+    const GLenum readError = glGetError();
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(previousTexture));
+    if (readError != GL_NO_ERROR) {
+        std::cout << "matting_result_texture_size=" << width << 'x' << height
+                  << " internal_format=0x" << std::hex << internalFormat
+                  << " read_error=0x" << readError << std::dec << '\n';
+        return false;
+    }
+
+    const auto [minimum, maximum] = std::minmax_element(mask.begin(), mask.end());
+    const std::uint64_t sum = std::accumulate(mask.begin(), mask.end(), std::uint64_t{0});
+    std::cout << "matting_result_texture_size=" << width << 'x' << height
+              << " internal_format=0x" << std::hex << internalFormat << std::dec
+              << " min=" << static_cast<int>(*minimum)
+              << " max=" << static_cast<int>(*maximum)
+              << " mean=" << static_cast<double>(sum) / pixelCount << '\n';
+    return writePgmMask(options.maskOutputPath, mask.data(), width, height);
 }
 
 struct WriteSkinSegInfoCpuMaskOptions {
@@ -953,6 +1687,8 @@ struct ProbeOptions {
     bool skipAlgorithm = false;
     bool inspectSkinResult = false;
     bool inspectFaceResult = false;
+    const char* mattingResultNode = nullptr;
+    const char* mattingResultGraph = "ai_matting_saliency";
     bool forceSkinSegPictureMode = false;
     bool enableComposerNodeEvent = false;
     std::int32_t skinSegVideoMode = -1;
@@ -1017,6 +1753,14 @@ ProbeOptions parseProbeOptions(int argc, char** argv) {
             options.inspectFaceResult = true;
             continue;
         }
+        if (argument == "--inspect-matting-result" && index + 1 < argc) {
+            options.mattingResultNode = argv[++index];
+            continue;
+        }
+        if (argument == "--matting-graph" && index + 1 < argc) {
+            options.mattingResultGraph = argv[++index];
+            continue;
+        }
         if (argument == "--force-skin-seg-picture-mode") {
             options.forceSkinSegPictureMode = true;
             continue;
@@ -1039,7 +1783,6 @@ ProbeOptions parseProbeOptions(int argc, char** argv) {
         }
         if (argument == "--mask-output" && index + 1 < argc) {
             options.maskOutputPath = argv[++index];
-            options.inspectSkinResult = true;
             continue;
         }
         if (argument == "--orientation" && index + 1 < argc) {
@@ -1189,6 +1932,9 @@ ProbeOptions parseProbeOptions(int argc, char** argv) {
         throw std::runtime_error(
             "--composer-key requires either --composer-value or --composer-json");
     }
+    if (options.maskOutputPath != nullptr && options.mattingResultNode == nullptr) {
+        options.inspectSkinResult = true;
+    }
     return options;
 }
 
@@ -1279,6 +2025,7 @@ int main(int argc, char** argv) {
                "[--intensity-type type --intensity value] "
                "[--reshape-face-intensity eye cheek] "
                "[--skip-algorithm] [--inspect-skin-result] [--inspect-face-result] "
+               "[--inspect-matting-result node-name] [--matting-graph graph-name] "
                "[--mask-output output.pgm] "
                "[--face-output output.json] "
                "[--orientation 0|90|180|270] "
@@ -1431,7 +2178,10 @@ int main(int argc, char** argv) {
     EffectGetBachResult effectGetBachResult = nullptr;
     EffectGetBachResultByGraphAndNodeName effectGetBachResultByGraphAndNodeName = nullptr;
     SkinSegTextureId skinSegTextureId = nullptr;
-    if (probeOptions.inspectSkinResult || probeOptions.inspectFaceResult) {
+    MattingTextureId mattingTextureId = nullptr;
+    BachObjectToVector4f bachObjectToVector4f = nullptr;
+    if (probeOptions.inspectSkinResult || probeOptions.inspectFaceResult ||
+        probeOptions.mattingResultNode != nullptr) {
         effectGetBachResult = loadSymbol<EffectGetBachResult>(
             {effectLibrary, "bef_effect_get_bach_result"});
         effectGetBachResultByNodeName = loadSymbol<EffectGetBachResultByNodeName>(
@@ -1442,6 +2192,14 @@ int main(int argc, char** argv) {
         if (probeOptions.inspectSkinResult) {
             skinSegTextureId = loadSymbol<SkinSegTextureId>(
                 {effectLibrary, "_ZN4Bach11SkinSegInfo9textureIdEv"});
+        }
+        if (probeOptions.mattingResultNode != nullptr) {
+            mattingTextureId = loadSymbol<MattingTextureId>(
+                {effectLibrary, "_ZN4Bach13MattingResult9textureIDEv"});
+            bachObjectToVector4f = loadSymbol<BachObjectToVector4f>({
+                effectLibrary,
+                "_ZNK4Bach10BachObjectcvN13AmazingEngine8Vector4fEEv",
+            });
         }
     }
     if (probeOptions.skinSegVideoMode >= 0) {
@@ -1861,6 +2619,20 @@ int main(int argc, char** argv) {
                 .coordinateSpace = "algorithm-input",
             }) && processingSucceeded;
         }
+        if (probeOptions.mattingResultNode != nullptr) {
+            processingSucceeded = inspectMattingResult({
+                .handle = handle,
+                .library = effectLibrary,
+                .getResultByType = effectGetBachResult,
+                .getResult = effectGetBachResultByNodeName,
+                .getResultByGraphAndNode = effectGetBachResultByGraphAndNodeName,
+                .getTextureId = mattingTextureId,
+                .toVector4f = bachObjectToVector4f,
+                .graphName = probeOptions.mattingResultGraph,
+                .nodeName = probeOptions.mattingResultNode,
+                .maskOutputPath = probeOptions.maskOutputPath,
+            }) && processingSucceeded;
+        }
 
         const std::filesystem::path outputDirectory(argv[4]);
         for (std::size_t frameIndex = 0; frameIndex < inputPaths.size(); ++frameIndex) {
@@ -1979,6 +2751,20 @@ int main(int argc, char** argv) {
                 .getResult = effectGetBachResultByNodeName,
                 .outputPath = probeOptions.faceOutputPath,
                 .coordinateSpace = "algorithm-input",
+            }) && processingSucceeded;
+        }
+        if (probeOptions.mattingResultNode != nullptr) {
+            processingSucceeded = inspectMattingResult({
+                .handle = handle,
+                .library = effectLibrary,
+                .getResultByType = effectGetBachResult,
+                .getResult = effectGetBachResultByNodeName,
+                .getResultByGraphAndNode = effectGetBachResultByGraphAndNodeName,
+                .getTextureId = mattingTextureId,
+                .toVector4f = bachObjectToVector4f,
+                .graphName = probeOptions.mattingResultGraph,
+                .nodeName = probeOptions.mattingResultNode,
+                .maskOutputPath = probeOptions.maskOutputPath,
             }) && processingSucceeded;
         }
         glFinish();

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/jianying-matting-runtime-trace.mm
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/jianying-matting-runtime-trace.mm
@@ -1,0 +1,823 @@
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libkern/OSCacheControl.h>
+#include <mach-o/dyld.h>
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <string>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+namespace {
+
+constexpr uint64_t kExpectedArm64UuidBuildMarker = 0x1a96fb8;
+constexpr size_t kJumpSize = 16;
+
+int traceFile = -1;
+atomic_flag traceLock = ATOMIC_FLAG_INIT;
+intptr_t creatorSlide = 0;
+atomic_uint_fast64_t borderDumpSequence = 0;
+const char *borderDumpDirectory = nullptr;
+bool forceGruRoute = false;
+
+extern "C" int __open(const char *, int, int);
+
+void writeTraceLine(const char *line) {
+  if (traceFile < 0) {
+    return;
+  }
+  while (atomic_flag_test_and_set_explicit(&traceLock, memory_order_acquire)) {
+  }
+  write(traceFile, line, strlen(line));
+  atomic_flag_clear_explicit(&traceLock, memory_order_release);
+}
+
+uint64_t monotonicNanoseconds() {
+  timespec value{};
+  clock_gettime(CLOCK_MONOTONIC_RAW, &value);
+  return static_cast<uint64_t>(value.tv_sec) * 1'000'000'000ULL + value.tv_nsec;
+}
+
+void traceEvent(const char *event, uint64_t a0 = 0, uint64_t a1 = 0,
+                uint64_t a2 = 0, uint64_t a3 = 0, int64_t result = 0) {
+  uint64_t threadId = 0;
+  pthread_threadid_np(nullptr, &threadId);
+  char line[640];
+  snprintf(line, sizeof(line),
+           "{\"t_ns\":%llu,\"pid\":%d,\"tid\":%llu,\"event\":\"%s\","
+           "\"a0\":%llu,\"a1\":%llu,\"a2\":%llu,\"a3\":%llu,"
+           "\"result\":%lld}\n",
+           monotonicNanoseconds(), getpid(), threadId, event, a0, a1, a2, a3,
+           result);
+  writeTraceLine(line);
+}
+
+void sanitizePath(const char *path, char *output, size_t outputSize) {
+  if (!path || outputSize == 0) {
+    return;
+  }
+  size_t index = 0;
+  for (; path[index] && index + 1 < outputSize; ++index) {
+    const unsigned char value = static_cast<unsigned char>(path[index]);
+    output[index] = value < 0x20 || value == '\\' || value == '"' ? '_' : value;
+  }
+  output[index] = '\0';
+}
+
+bool shouldTracePath(const char *path) {
+  if (!path) {
+    return false;
+  }
+  return strstr(path, "matting") || strstr(path, "maskinfo") ||
+         strstr(path, ".MANE") || strstr(path, ".mane") ||
+         strstr(path, ".model");
+}
+
+void tracePath(const char *operation, const char *path, int64_t result) {
+  if (!shouldTracePath(path) || traceFile < 0) {
+    return;
+  }
+  char safePath[384]{};
+  sanitizePath(path, safePath, sizeof(safePath));
+  uint64_t threadId = 0;
+  pthread_threadid_np(nullptr, &threadId);
+  char line[768];
+  snprintf(line, sizeof(line),
+           "{\"t_ns\":%llu,\"pid\":%d,\"tid\":%llu,\"event\":\"%s\","
+           "\"path\":\"%s\",\"result\":%lld}\n",
+           monotonicNanoseconds(), getpid(), threadId, operation, safePath,
+           result);
+  writeTraceLine(line);
+}
+
+void writeAbsoluteJump(uint8_t *destination, const void *target) {
+  const uint32_t instructions[] = {0x58000050, 0xd61f0200};
+  memcpy(destination, instructions, sizeof(instructions));
+  const auto address = reinterpret_cast<uint64_t>(target);
+  memcpy(destination + sizeof(instructions), &address, sizeof(address));
+}
+
+bool makeWritable(void *address) {
+  const vm_size_t pageSize = static_cast<vm_size_t>(getpagesize());
+  const auto start = reinterpret_cast<mach_vm_address_t>(address) &
+                     ~(static_cast<mach_vm_address_t>(pageSize) - 1);
+  return mach_vm_protect(mach_task_self(), start, pageSize, false,
+                         VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY) ==
+         KERN_SUCCESS;
+}
+
+void *installHook(const char *name, uintptr_t offset, uint32_t expectedFirst,
+                  void *replacement) {
+  auto *target = reinterpret_cast<uint8_t *>(creatorSlide + offset);
+  uint32_t actualFirst = 0;
+  memcpy(&actualFirst, target, sizeof(actualFirst));
+  if (actualFirst != expectedFirst) {
+    traceEvent("hook_rejected", offset, expectedFirst, actualFirst);
+    return nullptr;
+  }
+
+  auto *trampoline = static_cast<uint8_t *>(
+      mmap(nullptr, getpagesize(), PROT_READ | PROT_WRITE,
+           MAP_PRIVATE | MAP_ANON, -1, 0));
+  if (trampoline == MAP_FAILED) {
+    traceEvent("hook_mmap_failed", offset);
+    return nullptr;
+  }
+  memcpy(trampoline, target, kJumpSize);
+  writeAbsoluteJump(trampoline + kJumpSize, target + kJumpSize);
+  mprotect(trampoline, getpagesize(), PROT_READ | PROT_EXEC);
+  sys_icache_invalidate(trampoline, kJumpSize * 2);
+
+  if (!makeWritable(target)) {
+    traceEvent("hook_protect_failed", offset);
+    munmap(trampoline, getpagesize());
+    return nullptr;
+  }
+  writeAbsoluteJump(target, replacement);
+  sys_icache_invalidate(target, kJumpSize);
+  mach_vm_protect(mach_task_self(), reinterpret_cast<mach_vm_address_t>(target) &
+                                        ~(static_cast<mach_vm_address_t>(
+                                              getpagesize()) -
+                                          1),
+                  getpagesize(), false, VM_PROT_READ | VM_PROT_EXECUTE);
+  traceEvent(name, offset, reinterpret_cast<uint64_t>(target));
+  return trampoline;
+}
+
+using Function2 = uintptr_t (*)(uintptr_t, uintptr_t);
+using Function3 = uintptr_t (*)(uintptr_t, uintptr_t, uintptr_t);
+using Function5 = uintptr_t (*)(uintptr_t, uintptr_t, uintptr_t, uintptr_t,
+                                uintptr_t);
+using Function7 = uintptr_t (*)(uintptr_t, uintptr_t, uintptr_t, uintptr_t,
+                                uintptr_t, uintptr_t, uintptr_t);
+using Function8 = uintptr_t (*)(uintptr_t, uintptr_t, uintptr_t, uintptr_t,
+                                uintptr_t, uintptr_t, uintptr_t, uintptr_t);
+using Function12 = uintptr_t (*)(uintptr_t, uintptr_t, uintptr_t, uintptr_t,
+                                 uintptr_t, uintptr_t, uintptr_t, uintptr_t,
+                                 uintptr_t, uintptr_t, uintptr_t, uintptr_t);
+
+Function2 originalHandleFaceDetect = nullptr;
+Function2 originalSetPreviewModel = nullptr;
+Function7 originalGetMaskFile = nullptr;
+Function5 originalGetMaskVideo = nullptr;
+Function8 originalBlendRender = nullptr;
+Function7 originalPreviousFrame = nullptr;
+Function5 originalTakePrefetch = nullptr;
+Function8 originalSchedulePrefetch = nullptr;
+Function12 originalMattingRender = nullptr;
+Function7 originalExtendFrames = nullptr;
+Function8 originalBlendForContext = nullptr;
+Function2 originalSaveMane = nullptr;
+Function3 originalCompleteSegment = nullptr;
+Function2 originalInsertMaskPts = nullptr;
+Function3 originalPortraitSetParam = nullptr;
+Function5 originalSetStrokeParam = nullptr;
+Function2 originalBachInitAlgorithm = nullptr;
+Function3 originalFaceSinkProcess = nullptr;
+Function2 originalSetRenderApi = nullptr;
+
+using MaskPostProcessFrame = int (*)(uintptr_t, uintptr_t, uintptr_t, int,
+                                     int, double, uintptr_t);
+MaskPostProcessFrame originalMaskPostProcessFrame = nullptr;
+
+void traceTaskModel(const char *event, uintptr_t task) {
+  if (!task) {
+    traceEvent(event);
+    return;
+  }
+  uint32_t modelType = 0;
+  memcpy(&modelType, reinterpret_cast<const void *>(task + 0x150),
+         sizeof(modelType));
+  traceEvent(event, task, modelType);
+
+  const auto *modelPath =
+      reinterpret_cast<const std::string *>(task + 0x108);
+  tracePath("task_model_path", modelPath->c_str(), modelType);
+}
+
+uintptr_t hookHandleFaceDetect(uintptr_t a0, uintptr_t a1) {
+  uintptr_t task = 0;
+  uint32_t thresholdBits = 0;
+  if (a1 != 0) {
+    memcpy(&task, reinterpret_cast<const void *>(a1), sizeof(task));
+  }
+  if (task != 0) {
+    memcpy(&thresholdBits, reinterpret_cast<const void *>(task + 0x180),
+           sizeof(thresholdBits));
+  }
+  traceTaskModel("face_detect_route_before", task);
+  traceEvent("face_detect_enter", a0, task, thresholdBits);
+  if (forceGruRoute && task != 0) {
+    const uint32_t zeroThreshold = 0;
+    memcpy(reinterpret_cast<void *>(task + 0x180), &zeroThreshold,
+           sizeof(zeroThreshold));
+    traceEvent("force_gru_threshold", task, thresholdBits);
+  }
+  const auto result = originalHandleFaceDetect(a0, a1);
+  if (forceGruRoute && task != 0) {
+    memcpy(reinterpret_cast<void *>(task + 0x180), &thresholdBits,
+           sizeof(thresholdBits));
+  }
+  uintptr_t faceSink = 0;
+  uint64_t sampleCounts = 0;
+  if (a0 != 0) {
+    memcpy(&faceSink, reinterpret_cast<const void *>(a0 + 0x440),
+           sizeof(faceSink));
+  }
+  if (faceSink != 0) {
+    memcpy(&sampleCounts, reinterpret_cast<const void *>(faceSink + 0x35c),
+           sizeof(sampleCounts));
+  }
+  traceEvent("face_detect_summary", sampleCounts & 0xffffffffULL,
+             sampleCounts >> 32, faceSink);
+  traceEvent("face_detect_exit", a0, task, thresholdBits, 0, result);
+  traceTaskModel("face_detect_route_after", task);
+  return result;
+}
+
+uintptr_t hookSetRenderApi(uintptr_t handle, uintptr_t renderApi) {
+  const auto result = originalSetRenderApi(handle, renderApi);
+  traceEvent("effect_set_render_api", handle, renderApi, 0, 0, result);
+  return result;
+}
+
+uintptr_t hookFaceSinkProcess(uintptr_t unit, uintptr_t inputIndex,
+                              uintptr_t pipelineSharedPointer) {
+  const auto result =
+      originalFaceSinkProcess(unit, inputIndex, pipelineSharedPointer);
+  const uintptr_t pipeline = pipelineSharedPointer
+                                 ? *reinterpret_cast<const uintptr_t *>(
+                                       pipelineSharedPointer)
+                                 : 0;
+  uint32_t pipelineState = 0;
+  uintptr_t faceBegin = 0;
+  uintptr_t faceEnd = 0;
+  if (pipeline) {
+    memcpy(&pipelineState, reinterpret_cast<const void *>(pipeline + 0x5b4),
+           sizeof(pipelineState));
+    memcpy(&faceBegin, reinterpret_cast<const void *>(pipeline + 0x478),
+           sizeof(faceBegin));
+    memcpy(&faceEnd, reinterpret_cast<const void *>(pipeline + 0x480),
+           sizeof(faceEnd));
+  }
+  uint32_t totalSamples = 0;
+  uint32_t faceSamples = 0;
+  memcpy(&totalSamples, reinterpret_cast<const void *>(unit + 0x35c),
+         sizeof(totalSamples));
+  memcpy(&faceSamples, reinterpret_cast<const void *>(unit + 0x360),
+         sizeof(faceSamples));
+
+  const bool hasPlausibleFaceVector =
+      faceBegin != 0 && faceEnd >= faceBegin && faceEnd - faceBegin <= 4096;
+  const uint64_t faceRectCount = hasPlausibleFaceVector
+                                     ? (faceEnd - faceBegin) / (sizeof(float) * 4)
+                                     : 0;
+  traceEvent("face_detect_sample", pipelineState, totalSamples, faceSamples,
+             faceRectCount, result);
+  if (faceRectCount > 0) {
+    float rectangle[4]{};
+    memcpy(rectangle, reinterpret_cast<const void *>(faceBegin),
+           sizeof(rectangle));
+    traceEvent("face_detect_first_rect",
+               static_cast<int64_t>(rectangle[0] * 1'000'000.0F),
+               static_cast<int64_t>(rectangle[1] * 1'000'000.0F),
+               static_cast<int64_t>(rectangle[2] * 1'000'000.0F),
+               static_cast<int64_t>(rectangle[3] * 1'000'000.0F));
+  }
+  return result;
+}
+
+void *installFaceSinkHook(void *replacement) {
+  constexpr uintptr_t offset = 0x1a8fb1c;
+  const uint32_t expected[] = {0xf9400048, 0xb945b509, 0x7100093f,
+                               0x54000201};
+  auto *target = reinterpret_cast<uint8_t *>(creatorSlide + offset);
+  if (memcmp(target, expected, sizeof(expected)) != 0) {
+    traceEvent("hook_face_sink_rejected", offset);
+    return nullptr;
+  }
+
+  auto *trampoline = static_cast<uint8_t *>(
+      mmap(nullptr, getpagesize(), PROT_READ | PROT_WRITE,
+           MAP_PRIVATE | MAP_ANON, -1, 0));
+  if (trampoline == MAP_FAILED) {
+    traceEvent("hook_face_sink_mmap_failed", offset);
+    return nullptr;
+  }
+  memcpy(trampoline, target, 12);
+  const uint32_t branchEqualToOriginal = 0x540000a0;
+  memcpy(trampoline + 12, &branchEqualToOriginal,
+         sizeof(branchEqualToOriginal));
+  writeAbsoluteJump(trampoline + 16, target + 0x4c);
+  writeAbsoluteJump(trampoline + 32, target + 0x10);
+  mprotect(trampoline, getpagesize(), PROT_READ | PROT_EXEC);
+  sys_icache_invalidate(trampoline, 48);
+
+  if (!makeWritable(target)) {
+    traceEvent("hook_face_sink_protect_failed", offset);
+    munmap(trampoline, getpagesize());
+    return nullptr;
+  }
+  writeAbsoluteJump(target, replacement);
+  sys_icache_invalidate(target, kJumpSize);
+  mach_vm_protect(mach_task_self(), reinterpret_cast<mach_vm_address_t>(target) &
+                                        ~(static_cast<mach_vm_address_t>(
+                                              getpagesize()) -
+                                          1),
+                  getpagesize(), false, VM_PROT_READ | VM_PROT_EXECUTE);
+  traceEvent("hook_face_sink_process", offset,
+             reinterpret_cast<uint64_t>(target));
+  return trampoline;
+}
+
+uintptr_t hookBachInitAlgorithm(uintptr_t unit, uintptr_t taskSharedPointer) {
+  const uintptr_t task = taskSharedPointer
+                             ? *reinterpret_cast<const uintptr_t *>(
+                                   taskSharedPointer)
+                             : 0;
+  traceTaskModel("bach_init_algorithm_before", task);
+  const auto result = originalBachInitAlgorithm(unit, taskSharedPointer);
+  traceTaskModel("bach_init_algorithm_after", task);
+  return result;
+}
+
+uintptr_t hookSetPreviewModel(uintptr_t a0, uintptr_t modelType) {
+  traceEvent("set_preview_model", a0, modelType);
+  return originalSetPreviewModel(a0, modelType);
+}
+
+uintptr_t hookGetMaskFile(uintptr_t a0, uintptr_t a1, uintptr_t a2,
+                          uintptr_t a3, uintptr_t a4, uintptr_t a5,
+                          uintptr_t a6) {
+  const auto result = originalGetMaskFile(a0, a1, a2, a3, a4, a5, a6);
+  traceEvent("get_mask_file", a0, a3, a6, 0, result);
+  return result;
+}
+
+uintptr_t hookGetMaskVideo(uintptr_t a0, uintptr_t a1, uintptr_t a2,
+                           uintptr_t a3, uintptr_t a4) {
+  const auto result = originalGetMaskVideo(a0, a1, a2, a3, a4);
+  traceEvent("get_mask_video", a0, a2, a3, a4, result);
+  return result;
+}
+
+uintptr_t hookBlendRender(uintptr_t a0, uintptr_t a1, uintptr_t a2,
+                          uintptr_t a3, uintptr_t blendMode,
+                          uintptr_t mattingType, uintptr_t a6, uintptr_t a7) {
+  traceEvent("blend_render_enter", blendMode, mattingType, a3);
+  const auto result = originalBlendRender(a0, a1, a2, a3, blendMode,
+                                          mattingType, a6, a7);
+  traceEvent("blend_render_exit", blendMode, mattingType, 0, 0, result);
+  return result;
+}
+
+uintptr_t hookPreviousFrame(uintptr_t a0, uintptr_t a1, uintptr_t pts,
+                            uintptr_t a3, uintptr_t mattingType, uintptr_t a5,
+                            uintptr_t a6) {
+  const auto result =
+      originalPreviousFrame(a0, a1, pts, a3, mattingType, a5, a6);
+  traceEvent("get_previous_frame", pts, mattingType, 0, 0, result);
+  return result;
+}
+
+uintptr_t hookTakePrefetch(uintptr_t a0, uintptr_t a1, uintptr_t a2,
+                           uintptr_t pts, uintptr_t a4) {
+  const auto result = originalTakePrefetch(a0, a1, a2, pts, a4);
+  traceEvent("take_prefetch", pts, a1, a4, 0, result);
+  return result;
+}
+
+uintptr_t hookSchedulePrefetch(uintptr_t a0, uintptr_t a1, uintptr_t a2,
+                               uintptr_t a3, uintptr_t a4, uintptr_t pts,
+                               uintptr_t frameDuration, uintptr_t reset) {
+  traceEvent("schedule_prefetch_enter", pts, frameDuration, reset);
+  const auto result = originalSchedulePrefetch(a0, a1, a2, a3, a4, pts,
+                                               frameDuration, reset);
+  traceEvent("schedule_prefetch_exit", pts, frameDuration, reset, 0, result);
+  return result;
+}
+
+uintptr_t hookMattingRender(uintptr_t a0, uintptr_t a1, uintptr_t a2,
+                            uintptr_t a3, uintptr_t a4, uintptr_t a5,
+                            uintptr_t a6, uintptr_t a7, uintptr_t a8,
+                            uintptr_t a9, uintptr_t a10, uintptr_t a11) {
+  traceEvent("matting_render_enter", a3, a7, a8, a9);
+  const auto result = originalMattingRender(a0, a1, a2, a3, a4, a5, a6, a7,
+                                            a8, a9, a10, a11);
+  traceEvent("matting_render_exit", a3, a7, a8, a9, result);
+  return result;
+}
+
+uintptr_t hookExtendFrames(uintptr_t a0, uintptr_t a1, uintptr_t a2,
+                           uintptr_t a3, uintptr_t a4, uintptr_t a5,
+                           uintptr_t a6) {
+  const auto result = originalExtendFrames(a0, a1, a2, a3, a4, a5, a6);
+  traceEvent("get_extend_frames", a0, a3, a6, 0, result);
+  return result;
+}
+
+uintptr_t hookBlendForContext(uintptr_t a0, uintptr_t a1, uintptr_t a2,
+                              uintptr_t a3, uintptr_t blendMode, uintptr_t a5,
+                              uintptr_t a6, uintptr_t a7) {
+  const auto result = originalBlendForContext(a0, a1, a2, a3, blendMode, a5,
+                                              a6, a7);
+  traceEvent("blend_for_context", blendMode, a3, a7, 0, result);
+  return result;
+}
+
+uintptr_t hookSaveMane(uintptr_t a0, uintptr_t a1) {
+  traceEvent("save_mane_enter", a0);
+  const auto result = originalSaveMane(a0, a1);
+  traceEvent("save_mane_exit", a0, 0, 0, 0, result);
+  return result;
+}
+
+uintptr_t hookCompleteSegment(uintptr_t a0, uintptr_t start, uintptr_t end) {
+  const auto result = originalCompleteSegment(a0, start, end);
+  traceEvent("insert_complete_segment", start, end, 0, 0, result);
+  return result;
+}
+
+uintptr_t hookInsertMaskPts(uintptr_t a0, uintptr_t pts) {
+  const auto result = originalInsertMaskPts(a0, pts);
+  traceEvent("insert_mask_pts", pts, 0, 0, 0, result);
+  return result;
+}
+
+uintptr_t hookPortraitSetParam(uintptr_t a0, uintptr_t parameter,
+                               uintptr_t value) {
+  traceEvent("portrait_set_param", parameter, value);
+  return originalPortraitSetParam(a0, parameter, value);
+}
+
+uintptr_t hookSetStrokeParam(uintptr_t a0, uintptr_t a1, uintptr_t a2,
+                             uintptr_t a3, uintptr_t a4) {
+  traceEvent("set_stroke_param", a1, a2, a3, a4);
+  return originalSetStrokeParam(a0, a1, a2, a3, a4);
+}
+
+using ProcessBorderFunction = int (*)(void *, const void *, int, int, void *);
+using InternalProcessBorderFunction = int (*)(void *, const void *, int, int,
+                                              uint8_t *);
+ProcessBorderFunction originalProcessBorder = nullptr;
+InternalProcessBorderFunction originalInternalProcessBorder = nullptr;
+
+uint64_t sampledHash(const uint8_t *data, size_t size) {
+  if (!data || size == 0 || size > 64 * 1024 * 1024) {
+    return 0;
+  }
+  uint64_t hash = 1469598103934665603ULL;
+  const size_t step = size > 4096 ? size / 4096 : 1;
+  for (size_t index = 0; index < size; index += step) {
+    hash ^= data[index];
+    hash *= 1099511628211ULL;
+  }
+  return hash;
+}
+
+void dumpBorderAlpha(const char *stage, const uint8_t *data, int width,
+                     int height, uint64_t sequence) {
+  if (!borderDumpDirectory || !data || width <= 0 || height <= 0) {
+    return;
+  }
+  const size_t size = static_cast<size_t>(width) * static_cast<size_t>(height);
+  if (size > 64 * 1024 * 1024) {
+    return;
+  }
+  char path[1024];
+  const int pathLength = snprintf(
+      path, sizeof(path), "%s/%06llu-%s-%dx%d.gray", borderDumpDirectory,
+      sequence, stage, width, height);
+  if (pathLength <= 0 || static_cast<size_t>(pathLength) >= sizeof(path)) {
+    traceEvent("border_dump_path_rejected", sequence, width, height);
+    return;
+  }
+  const int output = __open(path, O_CREAT | O_WRONLY | O_TRUNC, 0600);
+  if (output < 0) {
+    traceEvent("border_dump_open_failed", sequence, width, height, errno);
+    return;
+  }
+  size_t written = 0;
+  while (written < size) {
+    const ssize_t result = write(output, data + written, size - written);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    if (result <= 0) {
+      traceEvent("border_dump_write_failed", sequence, width, height, errno);
+      break;
+    }
+    written += static_cast<size_t>(result);
+  }
+  close(output);
+  traceEvent("border_dump", sequence, width, height, written);
+}
+
+int traceProcessBorder(const char *source, ProcessBorderFunction original,
+                       void *handle, const void *inputMat, int width,
+                       int height, void *outputMat) {
+  const uint64_t sequence = atomic_fetch_add_explicit(
+      &borderDumpSequence, 1, memory_order_relaxed);
+  const auto *inputBytes =
+      inputMat ? *reinterpret_cast<uint8_t *const *>(inputMat) : nullptr;
+  const uint64_t before = sampledHash(
+      inputBytes, static_cast<size_t>(width) * static_cast<size_t>(height));
+  traceEvent(source, width, height, before,
+             inputMat ? *reinterpret_cast<const uint32_t *>(
+                            static_cast<const uint8_t *>(inputMat) + 8)
+                      : 0);
+  dumpBorderAlpha("input", inputBytes, width, height, sequence);
+  const int result = original(handle, inputMat, width, height, outputMat);
+  const auto *outputBytes =
+      outputMat ? *reinterpret_cast<uint8_t *const *>(outputMat) : nullptr;
+  dumpBorderAlpha("output", outputBytes, width, height, sequence);
+  const uint64_t after = sampledHash(
+      outputBytes, static_cast<size_t>(width) * static_cast<size_t>(height));
+  traceEvent("process_border_exit", width, height, before, after, result);
+  return result;
+}
+
+int hookProcessBorder(void *handle, const void *inputMat, int width, int height,
+                      void *outputMat) {
+  return traceProcessBorder("process_border_export_enter", originalProcessBorder,
+                            handle, inputMat, width, height, outputMat);
+}
+
+int hookInternalProcessBorder(void *handle, const void *inputMat, int width,
+                              int height, uint8_t *outputBytes) {
+  const uint64_t sequence = atomic_fetch_add_explicit(
+      &borderDumpSequence, 1, memory_order_relaxed);
+  const auto *inputBytes =
+      inputMat ? *reinterpret_cast<uint8_t *const *>(inputMat) : nullptr;
+  const size_t size = static_cast<size_t>(width) * static_cast<size_t>(height);
+  const uint64_t before = sampledHash(inputBytes, size);
+  traceEvent("process_border_graph_enter", width, height, before,
+             reinterpret_cast<uint64_t>(outputBytes));
+  dumpBorderAlpha("input", inputBytes, width, height, sequence);
+  const int result =
+      originalInternalProcessBorder(handle, inputMat, width, height, outputBytes);
+  dumpBorderAlpha("output", outputBytes, width, height, sequence);
+  const uint64_t after = sampledHash(outputBytes, size);
+  traceEvent("process_border_graph_exit", width, height, before, after, result);
+  return result;
+}
+
+int hookIgnorePrevious(void *handle) {
+  traceEvent("ignore_previous", reinterpret_cast<uint64_t>(handle));
+  if (!handle) {
+    return -1;
+  }
+  *(static_cast<uint8_t *>(handle) + 0x2cc) = 0;
+  return 0;
+}
+
+using ContourParamFunction = int (*)(void *, int, float);
+ContourParamFunction contourParamBody = nullptr;
+
+int hookContourParamF(void *handle, int parameter, float value) {
+  traceEvent("contour_param_f", parameter, 0, 0, 0,
+             static_cast<int64_t>(value * 1'000'000.0F));
+  if (!handle) {
+    return -108;
+  }
+  return contourParamBody(handle, parameter, value);
+}
+
+int hookContourParam(void *handle, int parameter, float value) {
+  traceEvent("contour_param", parameter, 0, 0, 0,
+             static_cast<int64_t>(value * 1'000'000.0F));
+  if (!handle) {
+    return -108;
+  }
+  return contourParamBody(handle, parameter, value);
+}
+
+using InitModelFunction = int (*)(void *, int, const char *);
+InitModelFunction originalInitModel = nullptr;
+
+int hookInitModel(void *handle, int modelType, const char *path) {
+  tracePath("init_model_path", path, modelType);
+  traceEvent("init_model_enter", modelType, reinterpret_cast<uint64_t>(handle));
+  const int result = originalInitModel(handle, modelType, path);
+  traceEvent("init_model_exit", modelType, 0, 0, 0, result);
+  return result;
+}
+
+int hookMaskPostProcessFrame(uintptr_t algorithm,
+                             uintptr_t maskSharedPointer,
+                             uintptr_t auxiliaryPath, int width, int height,
+                             double tolerance, uintptr_t contours) {
+  const uintptr_t mask = maskSharedPointer
+                             ? *reinterpret_cast<const uintptr_t *>(
+                                   maskSharedPointer)
+                             : 0;
+  const auto *maskBytes = mask
+                              ? *reinterpret_cast<uint8_t *const *>(
+                                    mask + 0x30)
+                              : nullptr;
+  const int maskWidth = mask
+                            ? *reinterpret_cast<const int *>(mask + 0x18)
+                            : 0;
+  const int maskHeight = mask
+                             ? *reinterpret_cast<const int *>(mask + 0x1c)
+                             : 0;
+  const size_t maskSize = maskWidth > 0 && maskHeight > 0
+                              ? static_cast<size_t>(maskWidth) * maskHeight
+                              : 0;
+  uint64_t toleranceBits = 0;
+  memcpy(&toleranceBits, &tolerance, sizeof(toleranceBits));
+  traceEvent("mask_post_enter", maskWidth, maskHeight,
+             sampledHash(maskBytes, maskSize), mask, 0);
+  traceEvent("mask_post_args", static_cast<uint64_t>(width),
+             static_cast<uint64_t>(height), toleranceBits, contours, 0);
+  if (auxiliaryPath) {
+    const auto *path =
+        reinterpret_cast<const std::string *>(auxiliaryPath);
+    tracePath("mask_post_aux_path", path->c_str(), 0);
+  }
+  dumpBorderAlpha("mask-post-input", maskBytes, maskWidth, maskHeight,
+                  atomic_fetch_add_explicit(&borderDumpSequence, 1,
+                                            memory_order_relaxed));
+  const int result = originalMaskPostProcessFrame(
+      algorithm, maskSharedPointer, auxiliaryPath, width, height, tolerance,
+      contours);
+  const auto *outputBytes = mask
+                                ? *reinterpret_cast<uint8_t *const *>(
+                                      mask + 0x30)
+                                : nullptr;
+  const int outputWidth = mask
+                              ? *reinterpret_cast<const int *>(mask + 0x18)
+                              : 0;
+  const int outputHeight = mask
+                               ? *reinterpret_cast<const int *>(mask + 0x1c)
+                               : 0;
+  const size_t outputSize = outputWidth > 0 && outputHeight > 0
+                                ? static_cast<size_t>(outputWidth) *
+                                      outputHeight
+                                : 0;
+  uint64_t contourCount = 0;
+  if (contours) {
+    const uintptr_t begin =
+        *reinterpret_cast<const uintptr_t *>(contours);
+    const uintptr_t end =
+        *reinterpret_cast<const uintptr_t *>(contours + 0x8);
+    if (begin && end >= begin) {
+      contourCount = (end - begin) / 24;
+    }
+  }
+  traceEvent("mask_post_exit", outputWidth, outputHeight,
+             sampledHash(outputBytes, outputSize), contourCount, result);
+  dumpBorderAlpha("mask-post-output", outputBytes, outputWidth, outputHeight,
+                  atomic_fetch_add_explicit(&borderDumpSequence, 1,
+                                            memory_order_relaxed));
+  return result;
+}
+
+void installCreatorHooks() {
+  if (creatorSlide == 0) {
+    return;
+  }
+  traceEvent("creator_image_ready", creatorSlide,
+             kExpectedArm64UuidBuildMarker);
+
+  originalSetRenderApi = reinterpret_cast<Function2>(installHook(
+      "hook_effect_set_render_api", 0x16431b0, 0xd10183ff,
+      reinterpret_cast<void *>(hookSetRenderApi)));
+
+  originalHandleFaceDetect = reinterpret_cast<Function2>(installHook(
+      "hook_handle_face", 0x1a89170, 0xd104c3ff,
+      reinterpret_cast<void *>(hookHandleFaceDetect)));
+  originalFaceSinkProcess = reinterpret_cast<Function3>(
+      installFaceSinkHook(reinterpret_cast<void *>(hookFaceSinkProcess)));
+  originalBachInitAlgorithm = reinterpret_cast<Function2>(installHook(
+      "hook_bach_init_algorithm", 0x19d273c, 0xd10203ff,
+      reinterpret_cast<void *>(hookBachInitAlgorithm)));
+  originalSetPreviewModel = reinterpret_cast<Function2>(installHook(
+      "hook_preview_model", 0x1a96fb8, 0xd10243ff,
+      reinterpret_cast<void *>(hookSetPreviewModel)));
+  originalGetMaskFile = reinterpret_cast<Function7>(installHook(
+      "hook_get_mask_file", 0x1a9d2e8, 0xd10243ff,
+      reinterpret_cast<void *>(hookGetMaskFile)));
+  originalGetMaskVideo = reinterpret_cast<Function5>(installHook(
+      "hook_get_mask_video", 0x1a9d5d8, 0xd104c3ff,
+      reinterpret_cast<void *>(hookGetMaskVideo)));
+  originalBlendRender = reinterpret_cast<Function8>(installHook(
+      "hook_blend_render", 0x1a9e164, 0xd10303ff,
+      reinterpret_cast<void *>(hookBlendRender)));
+  originalPreviousFrame = reinterpret_cast<Function7>(installHook(
+      "hook_previous_frame", 0x1a9e54c, 0xa9be4ff4,
+      reinterpret_cast<void *>(hookPreviousFrame)));
+  originalTakePrefetch = reinterpret_cast<Function5>(installHook(
+      "hook_take_prefetch", 0x1a9f390, 0xd101c3ff,
+      reinterpret_cast<void *>(hookTakePrefetch)));
+  originalSchedulePrefetch = reinterpret_cast<Function8>(installHook(
+      "hook_schedule_prefetch", 0x1a9f670, 0xa9ba6ffc,
+      reinterpret_cast<void *>(hookSchedulePrefetch)));
+  originalMattingRender = reinterpret_cast<Function12>(installHook(
+      "hook_matting_render", 0x1a9ffa4, 0xd10783ff,
+      reinterpret_cast<void *>(hookMattingRender)));
+  originalExtendFrames = reinterpret_cast<Function7>(installHook(
+      "hook_extend_frames", 0x1aa0ca8, 0xd10303ff,
+      reinterpret_cast<void *>(hookExtendFrames)));
+  originalBlendForContext = reinterpret_cast<Function8>(installHook(
+      "hook_blend_context", 0x1aa210c, 0xd10243ff,
+      reinterpret_cast<void *>(hookBlendForContext)));
+  originalSaveMane = reinterpret_cast<Function2>(installHook(
+      "hook_save_mane", 0x1dedce0, 0xd10503ff,
+      reinterpret_cast<void *>(hookSaveMane)));
+  originalCompleteSegment = reinterpret_cast<Function3>(installHook(
+      "hook_complete_segment", 0x1dee4a4, 0xd10243ff,
+      reinterpret_cast<void *>(hookCompleteSegment)));
+  originalInsertMaskPts = reinterpret_cast<Function2>(installHook(
+      "hook_insert_pts", 0x1dee844, 0xa9bd57f6,
+      reinterpret_cast<void *>(hookInsertMaskPts)));
+  originalProcessBorder = reinterpret_cast<ProcessBorderFunction>(installHook(
+      "hook_process_border", 0x12a1568, 0xd10403ff,
+      reinterpret_cast<void *>(hookProcessBorder)));
+  originalInternalProcessBorder =
+      reinterpret_cast<InternalProcessBorderFunction>(installHook(
+          "hook_internal_process_border", 0x129eec4, 0xd10683ff,
+          reinterpret_cast<void *>(hookInternalProcessBorder)));
+  installHook("hook_ignore_previous", 0x12a1694, 0xb40000a0,
+              reinterpret_cast<void *>(hookIgnorePrevious));
+  originalPortraitSetParam = reinterpret_cast<Function3>(installHook(
+      "hook_portrait_set_param", 0x129fd00, 0xa9bf7bfd,
+      reinterpret_cast<void *>(hookPortraitSetParam)));
+  originalSetStrokeParam = reinterpret_cast<Function5>(installHook(
+      "hook_stroke_param", 0x1e38bb8, 0xd10203ff,
+      reinterpret_cast<void *>(hookSetStrokeParam)));
+
+  contourParamBody = reinterpret_cast<ContourParamFunction>(creatorSlide +
+                                                             0x1299a20);
+  installHook("hook_contour_param_f", 0x1299a10, 0xb4000040,
+              reinterpret_cast<void *>(hookContourParamF));
+  installHook("hook_contour_param", 0x1299a90, 0xb4000040,
+              reinterpret_cast<void *>(hookContourParam));
+  originalInitModel = reinterpret_cast<InitModelFunction>(installHook(
+      "hook_init_model", 0x163432c, 0xd10143ff,
+      reinterpret_cast<void *>(hookInitModel)));
+  originalMaskPostProcessFrame =
+      reinterpret_cast<MaskPostProcessFrame>(installHook(
+          "hook_mask_post_process", 0x2022db0, 0x6db82beb,
+          reinterpret_cast<void *>(hookMaskPostProcessFrame)));
+}
+
+void imageAdded(const mach_header *header, intptr_t slide) {
+  for (uint32_t index = 0; index < _dyld_image_count(); ++index) {
+    if (_dyld_get_image_header(index) != header) {
+      continue;
+    }
+    const char *name = _dyld_get_image_name(index);
+    if (name && strstr(name, "/libcccreator.dylib")) {
+      creatorSlide = slide;
+      installCreatorHooks();
+    }
+    return;
+  }
+}
+
+__attribute__((constructor, used)) void startTrace() {
+  const char *path = getenv("QCUT_MATTING_TRACE_PATH");
+  borderDumpDirectory = getenv("QCUT_MATTING_BORDER_DUMP_DIR");
+  forceGruRoute = getenv("QCUT_MATTING_FORCE_GRU_ROUTE") != nullptr;
+  if (path) {
+    traceFile = __open(path, O_CREAT | O_WRONLY | O_APPEND, 0600);
+  }
+  traceEvent("trace_loaded");
+  _dyld_register_func_for_add_image(imageAdded);
+}
+
+} // namespace
+
+extern "C" int tracedOpen(const char *path, int flags, ...) {
+  mode_t mode = 0;
+  if (flags & O_CREAT) {
+    va_list arguments;
+    va_start(arguments, flags);
+    mode = static_cast<mode_t>(va_arg(arguments, int));
+    va_end(arguments);
+  }
+  const int result = __open(path, flags, mode);
+  tracePath("open", path, result);
+  return result;
+}
+
+#define DYLD_INTERPOSE(replacement, replacee)                                  \
+  __attribute__((used)) static struct {                                        \
+    const void *replacement;                                                   \
+    const void *replacee;                                                      \
+  } _interpose_##replacee __attribute__((section("__DATA,__interpose"))) = {   \
+      reinterpret_cast<const void *>(replacement),                             \
+      reinterpret_cast<const void *>(replacee)};
+
+DYLD_INTERPOSE(tracedOpen, open)

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/portrait-matting-blend-v2-probe.cpp
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/portrait-matting-blend-v2-probe.cpp
@@ -1,0 +1,612 @@
+// QCut-owned ABI probe; Jianying libraries are supplied from a private local runtime.
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/OpenGL.h>
+#include <OpenGL/gl.h>
+
+#include <objc/message.h>
+#include <objc/runtime.h>
+
+#include <dlfcn.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+using SetBlendMode = int (*)(void *, int);
+using SetCallerManagedLegacyFallback = int (*)(void *, bool);
+struct DeviceTexture {
+  void *texture = nullptr;
+  std::uint64_t metadata = 0;
+
+  DeviceTexture() = default;
+  DeviceTexture(const DeviceTexture &other)
+      : texture(other.texture), metadata(other.metadata) {}
+  DeviceTexture &operator=(const DeviceTexture &other) {
+    texture = other.texture;
+    metadata = other.metadata;
+    return *this;
+  }
+  ~DeviceTexture() {}
+};
+
+static_assert(sizeof(DeviceTexture) == 0x10);
+static_assert(!std::is_trivially_copy_constructible_v<DeviceTexture>);
+
+struct MattingImage {
+  std::uint32_t format = 0;
+  std::uint32_t reserved = 0;
+  const void *data = nullptr;
+  std::uint32_t width = 0;
+  std::uint32_t height = 0;
+};
+
+static_assert(sizeof(MattingImage) == 0x18);
+
+using BlendDeviceTextureWithData = int (*)(
+    void *, const MattingImage *, const MattingImage *, int, int,
+    const MattingImage *, const float *, const std::uint8_t *);
+using ConstructBlendEffect = void *(*)(void *);
+using DestroyBlendEffect = void (*)(void *);
+using GetRenderDevice = void *(*)(void *);
+using GetGpDevice = void *(*)(void *);
+using CreateRlContext = void (*)(std::shared_ptr<void> *, int);
+using InitRlContext = void (*)(void *);
+using BindRlContext = void (*)(void *, bool);
+using UnbindRlContext = void (*)(void *);
+using GetRlDeviceManager = void *(*)();
+using RemoveRlDevice = void (*)(void *, void *);
+using CreateSharedRlDevice = std::shared_ptr<void> (*)(void *, void *, void *);
+using GetGlobalAbConfig = void *(*)();
+using SetAbBool = void (*)(void *, int, bool);
+using GetAbBool = bool (*)(const void *, int);
+using CreateTexture2D = DeviceTexture (*)(
+    void *, int, int, const void *const *, int, int, int, int, int, int *,
+    const char *, bool, bool);
+using DestroyTexture = void (*)(void *, DeviceTexture);
+using ReadImage = void (*)(void *, DeviceTexture, int, int, void *, int, int,
+                           int, int);
+using ResolveBlendHandle = void (*)(void *, void *);
+using ReleaseResolvedBlendHandle = void (*)(void *);
+using SelectBlendPath = int (*)(void *, int, int, int, int, const void *, int,
+                                int, std::uint16_t);
+struct FrameSize {
+  int width;
+  int height;
+};
+using InitBlendEffect = int (*)(void *, const FrameSize &);
+using SetStrokeParam = void (*)(void *, std::int64_t, std::int64_t,
+                                std::int64_t, const std::string &);
+
+template <typename Function>
+Function requireSymbol(void *library, const char *name) {
+  auto *symbol = dlsym(library, name);
+  if (!symbol) {
+    throw std::runtime_error(std::string("missing symbol: ") + name);
+  }
+  return reinterpret_cast<Function>(symbol);
+}
+
+void setBooleanConfig(void *library, const char *name) {
+  auto *configId = static_cast<int *>(dlsym(library, name));
+  if (!configId) {
+    const std::string underscoredName = std::string("_") + name;
+    configId = static_cast<int *>(dlsym(library, underscoredName.c_str()));
+  }
+  if (!configId) {
+    throw std::runtime_error(std::string("config ID unavailable: ") + name);
+  }
+  const auto getGlobalConfig = requireSymbol<GetGlobalAbConfig>(
+      library, "_ZN10CCABConfig17getGlobalABConfigEv");
+  const auto setBool = requireSymbol<SetAbBool>(
+      library, "_ZN10CCABConfig7setBoolE11CCABKeyBoolb");
+  const auto getBool = requireSymbol<GetAbBool>(
+      library, "_ZNK10CCABConfig7getBoolE11CCABKeyBool");
+  void *config = getGlobalConfig();
+  setBool(config, *configId, true);
+  std::cerr << name << '=' << getBool(config, *configId)
+            << " key=" << *configId << '\n';
+}
+
+std::vector<std::uint8_t> readExact(const char *path, std::size_t size) {
+  std::ifstream input(path, std::ios::binary | std::ios::ate);
+  if (!input || static_cast<std::size_t>(input.tellg()) != size) {
+    throw std::runtime_error(std::string("unexpected input size: ") + path);
+  }
+  input.seekg(0);
+  std::vector<std::uint8_t> bytes(size);
+  input.read(reinterpret_cast<char *>(bytes.data()),
+             static_cast<std::streamsize>(bytes.size()));
+  if (!input) {
+    throw std::runtime_error(std::string("cannot read input: ") + path);
+  }
+  return bytes;
+}
+
+struct GlContext {
+  CGLPixelFormatObj pixelFormat = nullptr;
+  CGLContextObj context = nullptr;
+
+  GlContext() {
+    const CGLPixelFormatAttribute attributes[] = {
+        kCGLPFAOpenGLProfile,
+        static_cast<CGLPixelFormatAttribute>(kCGLOGLPVersion_Legacy),
+        kCGLPFAAccelerated,
+        kCGLPFAAllowOfflineRenderers,
+        kCGLPFAColorSize,
+        static_cast<CGLPixelFormatAttribute>(32),
+        kCGLPFAAlphaSize,
+        static_cast<CGLPixelFormatAttribute>(8),
+        static_cast<CGLPixelFormatAttribute>(0),
+    };
+    GLint count = 0;
+    if (CGLChoosePixelFormat(attributes, &pixelFormat, &count) != kCGLNoError ||
+        !pixelFormat) {
+      throw std::runtime_error("cannot choose OpenGL pixel format");
+    }
+    if (CGLCreateContext(pixelFormat, nullptr, &context) != kCGLNoError ||
+        !context || CGLSetCurrentContext(context) != kCGLNoError) {
+      throw std::runtime_error("cannot create OpenGL context");
+    }
+  }
+
+  ~GlContext() {
+    CGLSetCurrentContext(nullptr);
+    if (context) {
+      CGLDestroyContext(context);
+    }
+    if (pixelFormat) {
+      CGLDestroyPixelFormat(pixelFormat);
+    }
+  }
+};
+
+class BlendEffectRuntime {
+public:
+  BlendEffectRuntime(void *library, void *sharedContextStorage, int width,
+                     int height)
+      : library_(library), destroy_(requireSymbol<DestroyBlendEffect>(
+            library, "_ZN22TEMattingBlendEffectV2D1Ev")) {
+    const auto construct = requireSymbol<ConstructBlendEffect>(
+        library, "_ZN22TEMattingBlendEffectV2C1Ev");
+    const auto init = requireSymbol<InitBlendEffect>(
+        library, "_ZN22TEMattingBlendEffectV24initERK7TESizei");
+    construct(storage_.data());
+    isConstructed_ = true;
+    if (!sharedContextStorage) {
+      throw std::runtime_error("TEMattingBlendEffectV2 shared context missing");
+    }
+    auto &targetContext = *reinterpret_cast<std::shared_ptr<void> *>(
+        storage_.data() + 0x50);
+    const auto &sourceContext =
+        *reinterpret_cast<const std::shared_ptr<void> *>(sharedContextStorage);
+    targetContext = sourceContext;
+    const FrameSize frameSize = {.width = width, .height = height};
+    const int status = init(storage_.data(), frameSize);
+    handle_ = *reinterpret_cast<void **>(storage_.data() + 0x70);
+    std::cerr << "tematting_init_status=" << status
+              << " v2_active="
+              << static_cast<int>(storage_[0x48])
+              << " handle=" << handle_ << '\n';
+    if (!handle_) {
+      throw std::runtime_error("TEMattingBlendEffectV2 init failed: " +
+                               std::to_string(status));
+    }
+  }
+
+  ~BlendEffectRuntime() {
+    if (isConstructed_) {
+      destroy_(storage_.data());
+    }
+  }
+
+  BlendEffectRuntime(const BlendEffectRuntime &) = delete;
+  BlendEffectRuntime &operator=(const BlendEffectRuntime &) = delete;
+
+  void *handle() const { return handle_; }
+
+  void setStrokeParameters(const std::string &parameters) {
+    const auto setStrokeParam = requireSymbol<SetStrokeParam>(
+        library_,
+        "_ZN22TEMattingBlendEffectV214setStrokeParamExxxRKNSt3__1"
+        "12basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE");
+    setStrokeParam(storage_.data(), 0, 1'000'000, 0, parameters);
+  }
+
+private:
+  alignas(16) std::array<std::uint8_t, 256> storage_{};
+  void *library_ = nullptr;
+  DestroyBlendEffect destroy_;
+  void *handle_ = nullptr;
+  bool isConstructed_ = false;
+};
+
+struct EngineContext {
+  void *owner = nullptr;
+  void *sharedContextStorage = nullptr;
+  void *renderDevice = nullptr;
+  void *gpDevice = nullptr;
+};
+
+class RlHostContext {
+public:
+  explicit RlHostContext(void *library)
+      : unbind_(requireSymbol<UnbindRlContext>(
+            library, "_ZN17TERLRenderContext6unbindEv")) {
+    const auto construct = requireSymbol<void *(*)(void *, int)>(
+        library, "_ZN17TERLRenderContextC1Ei");
+    const auto create = reinterpret_cast<CreateRlContext>(
+        reinterpret_cast<std::uintptr_t>(construct) + 0x2178U);
+    create(&context_, 30);
+    if (!context_) {
+      throw std::runtime_error("cannot create TERLRenderContext");
+    }
+    const auto init = requireSymbol<InitRlContext>(
+        library, "_ZN17TERLRenderContext5_initEv");
+    const auto bind = requireSymbol<BindRlContext>(
+        library, "_ZN17TERLRenderContext4bindEb");
+    init(context_.get());
+    const auto getRlDeviceManager = requireSymbol<GetRlDeviceManager>(
+        library, "_ZN17TERLDeviceManager11getInstanceEv");
+    const auto removeRlDevice = requireSymbol<RemoveRlDevice>(
+        library,
+        "_ZN17TERLDeviceManager27removeRLDeviceFromGLContextEP17TESharedGLContext");
+    const auto createSharedRlDevice = requireSymbol<CreateSharedRlDevice>(
+        library,
+        "_ZN17TERLDeviceManager27createRLDeviceFromGLContextEP17TESharedGLContextS1_");
+    void *rlDeviceManager = getRlDeviceManager();
+    removeRlDevice(rlDeviceManager, context_.get());
+    const std::shared_ptr<void> metalRlDevice =
+        createSharedRlDevice(rlDeviceManager, context_.get(), nullptr);
+    if (!metalRlDevice) {
+      throw std::runtime_error("cannot create Metal RLDevice");
+    }
+    *reinterpret_cast<void **>(static_cast<std::uint8_t *>(context_.get()) +
+                               0x260) = metalRlDevice.get();
+    bind(context_.get(), true);
+    isBound_ = true;
+    const auto getRenderDevice = requireSymbol<GetRenderDevice>(
+        library, "_ZN17TESharedGLContext15getRenderDeviceEv");
+    const auto getGpDevice = requireSymbol<GetGpDevice>(
+        library, "_ZN13AmazingEngine14RendererDevice11getGPDeviceEv");
+    renderDevice_ = getRenderDevice(context_.get());
+    gpDevice_ = renderDevice_ ? getGpDevice(renderDevice_) : nullptr;
+    void *rlDevice = *reinterpret_cast<void **>(
+        static_cast<std::uint8_t *>(context_.get()) + 0x260);
+    void *ownerRenderDevice = rlDevice
+                                  ? *reinterpret_cast<void **>(
+                                        static_cast<std::uint8_t *>(rlDevice) +
+                                        0x8)
+                                  : nullptr;
+    void *ownerGpDevice =
+        ownerRenderDevice ? getGpDevice(ownerRenderDevice) : nullptr;
+    std::cout << "rl_context=" << context_.get()
+              << " render_device=" << renderDevice_
+              << " gp_device=" << gpDevice_
+              << " owner_render_device=" << ownerRenderDevice
+              << " owner_gp_device=" << ownerGpDevice
+              << " owner_match="
+              << (renderDevice_ == ownerRenderDevice &&
+                  gpDevice_ == ownerGpDevice)
+              << '\n';
+  }
+
+  ~RlHostContext() {
+    if (isBound_) {
+      unbind_(context_.get());
+    }
+  }
+
+  RlHostContext(const RlHostContext &) = delete;
+  RlHostContext &operator=(const RlHostContext &) = delete;
+
+  EngineContext engineContext() {
+    return {
+        .owner = context_.get(),
+        .sharedContextStorage = &context_,
+        .renderDevice = renderDevice_,
+        .gpDevice = gpDevice_,
+    };
+  }
+
+private:
+  std::shared_ptr<void> context_;
+  void *renderDevice_ = nullptr;
+  void *gpDevice_ = nullptr;
+  UnbindRlContext unbind_;
+  bool isBound_ = false;
+};
+
+EngineContext adoptEngineGlContext(void *library) {
+  Class contextClass = objc_getClass("HTSGLContext");
+  if (!contextClass) {
+    return {};
+  }
+  const auto send = reinterpret_cast<id (*)(id, SEL)>(objc_msgSend);
+  send(reinterpret_cast<id>(contextClass), sel_registerName("preloadGLContext"));
+  id context = send(reinterpret_cast<id>(contextClass),
+                    sel_registerName("sharedImageProcessingContext"));
+  if (!context) {
+    context = send(reinterpret_cast<id>(contextClass),
+                   sel_registerName("shareProcesingContext"));
+  }
+  if (!context) {
+    context = send(reinterpret_cast<id>(contextClass),
+                   sel_registerName("defaultImageProcessingContext"));
+  }
+  if (!context) {
+    return {};
+  }
+  reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(
+      context, sel_registerName("bind:"), YES);
+  std::cerr << "engine_context_bound=" << context << '\n';
+  const auto getCppContext =
+      reinterpret_cast<void *(*)(id, SEL)>(objc_msgSend);
+  void *cppContext =
+      getCppContext(context, sel_registerName("getCppContext"));
+  std::cerr << "cpp_context_resolved=" << cppContext << '\n';
+  void *cppContextObject =
+      cppContext ? *static_cast<void **>(cppContext) : nullptr;
+  const auto getRenderDevice = requireSymbol<GetRenderDevice>(
+      library, "_ZN17TESharedGLContext15getRenderDeviceEv");
+  const auto getGpDevice = requireSymbol<GetGpDevice>(
+      library, "_ZN13AmazingEngine14RendererDevice11getGPDeviceEv");
+  std::cerr << "resolving_render_device\n";
+  void *renderDevice =
+      cppContextObject ? getRenderDevice(cppContextObject) : nullptr;
+  std::cerr << "render_device_resolved=" << renderDevice << '\n';
+  void *gpDevice = renderDevice ? getGpDevice(renderDevice) : nullptr;
+  std::cout << "cpp_context=" << cppContext
+            << " render_device=" << renderDevice
+            << " gp_device=" << gpDevice << '\n';
+  return {
+      .owner = context,
+      .sharedContextStorage = cppContext,
+      .renderDevice = renderDevice,
+      .gpDevice = gpDevice};
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 9 && argc != 10) {
+    std::cerr << "usage: portrait-matting-blend-v2-probe <libcccreator> "
+                 "<input.rgba> <width> <height> <alpha.gray> <alpha-width> "
+                 "<alpha-height> <output.rgba> [--rl-host]\n";
+    return 2;
+  }
+  try {
+    const bool useRlHost =
+        argc == 10 && std::string_view(argv[9]) == "--rl-host";
+    if (argc == 10 && !useRlHost) {
+      throw std::runtime_error("unknown context mode");
+    }
+    const int width = std::stoi(argv[3]);
+    const int height = std::stoi(argv[4]);
+    const int alphaWidth = std::stoi(argv[6]);
+    const int alphaHeight = std::stoi(argv[7]);
+    const auto rgba = readExact(
+        argv[2], static_cast<std::size_t>(width) * height * 4U);
+    const auto alpha = readExact(
+        argv[5], static_cast<std::size_t>(alphaWidth) * alphaHeight);
+    void *library = dlopen(argv[1], RTLD_NOW | RTLD_GLOBAL);
+    if (!library) {
+      throw std::runtime_error(std::string("cannot load runtime: ") + dlerror());
+    }
+    if (useRlHost) {
+      setBooleanConfig(library, "ConfigID_EnableAGFXMetal");
+      setBooleanConfig(library, "ConfigID_VeabtestEnableMetalV2");
+      setBooleanConfig(library, "ConfigID_EnablePortraitMattingBlendV2");
+    }
+    std::unique_ptr<GlContext> fallbackContext;
+    if (useRlHost && !CGLGetCurrentContext()) {
+      fallbackContext = std::make_unique<GlContext>();
+    }
+    std::unique_ptr<RlHostContext> rlHostContext;
+    EngineContext engineContext;
+    if (useRlHost) {
+      rlHostContext = std::make_unique<RlHostContext>(library);
+      engineContext = rlHostContext->engineContext();
+    } else {
+      engineContext = adoptEngineGlContext(library);
+    }
+    if (!CGLGetCurrentContext()) {
+      fallbackContext = std::make_unique<GlContext>();
+    }
+    if (!CGLGetCurrentContext()) {
+      throw std::runtime_error("cannot bind OpenGL context");
+    }
+    std::cout << "context="
+              << (useRlHost ? "rl-host"
+                            : engineContext.owner ? "engine" : "standalone")
+              << '\n';
+    const auto setMode = requireSymbol<SetBlendMode>(
+        library, "bef_portrait_matting_v2_set_blend_mode");
+    const auto setCallerManagedLegacyFallback =
+        requireSymbol<SetCallerManagedLegacyFallback>(
+            library,
+            "bef_portrait_matting_v2_set_caller_managed_legacy_fallback");
+    const auto blend = requireSymbol<BlendDeviceTextureWithData>(
+        library, "bef_portrait_matting_v2_blend_device_texture_with_data");
+    BlendEffectRuntime blendEffect(
+        library, engineContext.sharedContextStorage, width, height);
+    if (useRlHost) {
+      blendEffect.setStrokeParameters(
+          R"({"morphologyParams":true,"erode_dilate_kernel_size":0,"blur_kernel_size":0,"enable_reverse":false,"blendPath":"device","featurePath":""})");
+    }
+    void *handle = blendEffect.handle();
+    const int modeStatus = setMode(handle, 0);
+    if (modeStatus != 0) {
+      throw std::runtime_error("set blend mode failed: " +
+                               std::to_string(modeStatus));
+    }
+    const int fallbackStatus = setCallerManagedLegacyFallback(handle, true);
+    if (fallbackStatus != 0) {
+      throw std::runtime_error("configure legacy fallback failed: " +
+                               std::to_string(fallbackStatus));
+    }
+
+    if (!engineContext.renderDevice) {
+      throw std::runtime_error("AGFX render device unavailable");
+    }
+    constexpr int kRgba8PixelFormat = 0x2b;
+    constexpr int kLinearFilter = 1;
+    constexpr int kClampWrap = 1;
+    const auto createTexture2D = requireSymbol<CreateTexture2D>(
+        library,
+        "_ZN13AmazingEngine14RendererDevice15createTexture2DEiiPKPKvNS_"
+        "14AMGPixelFormatENS_13AMGFilterModeES6_NS_11AMGWrapModeES7_PiPKcbb");
+    const auto destroyTexture = requireSymbol<DestroyTexture>(
+        library,
+        "_ZN13AmazingEngine14RendererDevice14destroyTextureE13DeviceTexture");
+    const auto readImage = requireSymbol<ReadImage>(
+        library,
+        "_ZN13AmazingEngine14RendererDevice9readImageE13DeviceTextureiiPvNS_"
+        "8FlipModeENS_10RotateModeENS_13AMGFilterModeENS_14AMGPixelFormatE");
+    const void *inputMipData[] = {rgba.data()};
+    std::vector<std::uint8_t> alphaRgba(alpha.size() * 4U);
+    for (std::size_t index = 0; index < alpha.size(); ++index) {
+      const std::uint8_t value = alpha[index];
+      const std::size_t pixelOffset = index * 4U;
+      alphaRgba[pixelOffset] = value;
+      alphaRgba[pixelOffset + 1U] = value;
+      alphaRgba[pixelOffset + 2U] = value;
+      alphaRgba[pixelOffset + 3U] = value;
+    }
+    const void *alphaMipData[] = {alphaRgba.data()};
+    const DeviceTexture inputTexture = createTexture2D(
+        engineContext.renderDevice, width, height, inputMipData,
+        kRgba8PixelFormat, kLinearFilter, kLinearFilter, kClampWrap,
+        kClampWrap, nullptr, "qcut matting v2 input", false, false);
+    const DeviceTexture outputTexture = createTexture2D(
+        engineContext.renderDevice, width, height, nullptr, kRgba8PixelFormat,
+        kLinearFilter, kLinearFilter, kClampWrap, kClampWrap, nullptr,
+        "qcut matting v2 output", false, false);
+    const DeviceTexture alphaTexture = createTexture2D(
+        engineContext.renderDevice, alphaWidth, alphaHeight, alphaMipData,
+        kRgba8PixelFormat, kLinearFilter, kLinearFilter, kClampWrap,
+        kClampWrap, nullptr, "qcut matting v2 alpha", false, false);
+    std::cerr << "agfx_input=" << inputTexture.texture
+              << " metadata=" << inputTexture.metadata
+              << " agfx_output=" << outputTexture.texture
+              << " metadata=" << outputTexture.metadata
+              << " agfx_alpha=" << alphaTexture.texture
+              << " metadata=" << alphaTexture.metadata << '\n';
+    if (!inputTexture.texture || !outputTexture.texture ||
+        !alphaTexture.texture) {
+      if (alphaTexture.texture) {
+        destroyTexture(engineContext.renderDevice, alphaTexture);
+      }
+      if (outputTexture.texture) {
+        destroyTexture(engineContext.renderDevice, outputTexture);
+      }
+      if (inputTexture.texture) {
+        destroyTexture(engineContext.renderDevice, inputTexture);
+      }
+      throw std::runtime_error("cannot create AGFX textures");
+    }
+    const std::array<float, 4> fullFrame = {0.0F, 0.0F, 1.0F, 1.0F};
+    const MattingImage inputImage = {
+        .data = &inputTexture,
+        .width = static_cast<std::uint32_t>(width),
+        .height = static_cast<std::uint32_t>(height),
+    };
+    const MattingImage outputImage = {
+        .data = &outputTexture,
+        .width = static_cast<std::uint32_t>(width),
+        .height = static_cast<std::uint32_t>(height),
+    };
+    const MattingImage alphaImage = {
+        .data = &alphaTexture,
+        .width = static_cast<std::uint32_t>(alphaWidth),
+        .height = static_cast<std::uint32_t>(alphaHeight),
+    };
+    const std::array<std::uint8_t, 4> transparent = {0, 0, 0, 0};
+    const auto blendAddress = reinterpret_cast<std::uintptr_t>(blend);
+    const auto resolveBlendHandle = reinterpret_cast<ResolveBlendHandle>(
+        blendAddress - 0x1490U);
+    const auto releaseResolvedBlendHandle =
+        reinterpret_cast<ReleaseResolvedBlendHandle>(blendAddress - 0x13b8U);
+    const auto selectBlendPath =
+        reinterpret_cast<SelectBlendPath>(blendAddress - 0x534U);
+    alignas(16) std::array<std::uint8_t, 32> resolvedHandle{};
+    resolveBlendHandle(resolvedHandle.data(), handle);
+    void *internalHandle = *reinterpret_cast<void **>(resolvedHandle.data());
+    const int selectedPath = internalHandle
+                                 ? selectBlendPath(
+                                       internalHandle, width, height,
+                                       alphaWidth, alphaHeight,
+                                       transparent.data(), 0, 0, 0x101)
+                                 : -1;
+    std::cerr << "internal_handle=" << internalHandle
+              << " selected_path=" << selectedPath;
+    if (internalHandle) {
+      const auto *bytes = static_cast<const std::uint8_t *>(internalHandle);
+      std::cerr << " flags=" << static_cast<int>(bytes[0x9c]) << ','
+                << static_cast<int>(bytes[0xc9]) << ','
+                << static_cast<int>(bytes[0xb8]) << ','
+                << static_cast<int>(bytes[0xc8]);
+    }
+    std::cerr << '\n';
+    releaseResolvedBlendHandle(resolvedHandle.data());
+    const int blendStatus = blend(
+        handle, &inputImage, &outputImage, width, height, &alphaImage,
+        fullFrame.data(), transparent.data());
+    std::vector<std::uint8_t> output(rgba.size());
+    if (blendStatus == 0) {
+      readImage(engineContext.renderDevice, outputTexture, width, height,
+                output.data(), 0, 0, kLinearFilter, kRgba8PixelFormat);
+      std::uint64_t totalAbsoluteError = 0;
+      std::uint8_t maximumAbsoluteError = 0;
+      std::size_t differentChannels = 0;
+      for (std::size_t pixel = 0; pixel < alpha.size(); ++pixel) {
+        for (std::size_t channel = 0; channel < 4U; ++channel) {
+          const std::size_t offset = pixel * 4U + channel;
+          const auto expected = static_cast<std::uint8_t>(
+              (static_cast<unsigned int>(rgba[offset]) * alpha[pixel] + 127U) /
+              255U);
+          const auto difference = static_cast<std::uint8_t>(
+              output[offset] > expected ? output[offset] - expected
+                                        : expected - output[offset]);
+          totalAbsoluteError += difference;
+          maximumAbsoluteError = std::max(maximumAbsoluteError, difference);
+          differentChannels += difference != 0 ? 1U : 0U;
+        }
+      }
+      std::cout << "formula_max_error="
+                << static_cast<unsigned int>(maximumAbsoluteError)
+                << " formula_mae="
+                << static_cast<double>(totalAbsoluteError) / output.size()
+                << " different_channels=" << differentChannels << '\n';
+    }
+    destroyTexture(engineContext.renderDevice, alphaTexture);
+    destroyTexture(engineContext.renderDevice, outputTexture);
+    destroyTexture(engineContext.renderDevice, inputTexture);
+    if (blendStatus != 0) {
+      throw std::runtime_error("blend failed: status=" +
+                               std::to_string(blendStatus));
+    }
+    std::ofstream outputFile(argv[8], std::ios::binary);
+    outputFile.write(reinterpret_cast<const char *>(output.data()),
+                     static_cast<std::streamsize>(output.size()));
+    if (!outputFile) {
+      throw std::runtime_error("cannot write output");
+    }
+    std::cout << "ok width=" << width << " height=" << height
+              << " alphaWidth=" << alphaWidth
+              << " alphaHeight=" << alphaHeight << '\n';
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/portrait-matting-border-oracle.cpp
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/portrait-matting-border-oracle.cpp
@@ -1,0 +1,299 @@
+#include <dlfcn.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct MattingInput {
+  const std::uint8_t *data;
+  std::int32_t pixelFormat;
+  std::int32_t width;
+  std::int32_t height;
+  std::int32_t stride;
+  std::int32_t orientation;
+  std::int32_t reserved;
+  bool invertAlpha;
+};
+
+static_assert(offsetof(MattingInput, invertAlpha) == 0x20);
+
+struct MattingOutput {
+  std::uint8_t *alpha;
+  std::int32_t width;
+  std::int32_t height;
+};
+
+using CreateHandle = int (*)(void **);
+using InitModel = int (*)(void *, int, const char *);
+using GetAlphaSize = int (*)(void *, int, int, int *, int *);
+using SetParam = int (*)(void *, int, int);
+using ProcessFrame = int (*)(void *, const MattingInput *, MattingOutput *);
+using ProcessBorder = int (*)(void *, const MattingInput *, int, int,
+                              MattingOutput *);
+using ReleaseHandle = int (*)(void *);
+
+template <typename Function>
+Function requireSymbol(void *library, const char *name) {
+  auto *symbol = dlsym(library, name);
+  if (!symbol) {
+    throw std::runtime_error(std::string("missing symbol: ") + name);
+  }
+  return reinterpret_cast<Function>(symbol);
+}
+
+std::uint8_t expectedLutValue(std::uint8_t input, float slope, float center) {
+  constexpr float halfPi = 1.57079632679489661923F;
+  const float normalized = static_cast<float>(input) / 255.0F;
+  const float halfWidth = halfPi / slope;
+  if (normalized < center - halfWidth) {
+    return 0;
+  }
+  if (normalized > center + halfWidth) {
+    return 255;
+  }
+  const float mapped =
+      (std::sin((normalized - center) * slope) * 0.5F + 0.5F) * 255.0F;
+  return static_cast<std::uint8_t>(mapped);
+}
+
+std::vector<std::uint8_t> rampPattern(int width, int height) {
+  std::vector<std::uint8_t> pixels(static_cast<std::size_t>(width) * height);
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      pixels[static_cast<std::size_t>(y) * width + x] =
+          static_cast<std::uint8_t>((x + y * 37) & 0xff);
+    }
+  }
+  return pixels;
+}
+
+std::vector<std::uint8_t> spatialPattern(int width, int height) {
+  std::vector<std::uint8_t> pixels(static_cast<std::size_t>(width) * height);
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      const bool border = x == 0 || y == 0 || x == width - 1 ||
+                          y == height - 1;
+      const bool rectangle = x >= width / 4 && x < width * 3 / 4 &&
+                             y >= height / 4 && y < height * 3 / 4;
+      const int value =
+          border ? 255 : (rectangle ? 180 : ((x * 17 + y * 29) & 0xff));
+      pixels[static_cast<std::size_t>(y) * width + x] =
+          static_cast<std::uint8_t>(value);
+    }
+  }
+  return pixels;
+}
+
+struct VerifyCaseOptions {
+  void *handle;
+  ProcessBorder processBorder;
+  const std::vector<std::uint8_t> &inputPixels;
+  int width;
+  int height;
+  float slope;
+  float center;
+  const std::string &name;
+};
+
+void verifyCase(const VerifyCaseOptions &options) {
+  const auto &[handle, processBorder, inputPixels, width, height, slope, center,
+               name] = options;
+  std::vector<std::uint8_t> outputPixels(inputPixels.size(), 0xcd);
+  MattingInput input = {
+      .data = inputPixels.data(),
+      .pixelFormat = 5,
+      .width = width,
+      .height = height,
+      .stride = width,
+      .orientation = 0,
+      .reserved = 0,
+      .invertAlpha = false,
+  };
+  MattingOutput output = {
+      .alpha = outputPixels.data(),
+      .width = 0,
+      .height = 0,
+  };
+  const int status = processBorder(handle, &input, width, height, &output);
+  if (status != 0 || output.width != width || output.height != height) {
+    throw std::runtime_error(name + " failed: status=" +
+                             std::to_string(status) + " output=" +
+                             std::to_string(output.width) + "x" +
+                             std::to_string(output.height));
+  }
+
+  std::size_t mismatchCount = 0;
+  int maximumDifference = 0;
+  std::size_t firstMismatch = outputPixels.size();
+  for (std::size_t index = 0; index < outputPixels.size(); ++index) {
+    const auto expected = expectedLutValue(inputPixels[index], slope, center);
+    const int difference =
+        std::abs(static_cast<int>(outputPixels[index]) - expected);
+    maximumDifference = std::max(maximumDifference, difference);
+    if (difference == 0) {
+      continue;
+    }
+    mismatchCount += 1;
+    firstMismatch = std::min(firstMismatch, index);
+  }
+  std::cout << "case=" << name << " size=" << width << "x" << height
+            << " mismatch=" << mismatchCount
+            << " max_difference=" << maximumDifference;
+  if (firstMismatch != outputPixels.size()) {
+    std::cout << " first_index=" << firstMismatch
+              << " input=" << static_cast<int>(inputPixels[firstMismatch])
+              << " actual=" << static_cast<int>(outputPixels[firstMismatch])
+              << " expected="
+              << static_cast<int>(
+                     expectedLutValue(inputPixels[firstMismatch], slope, center));
+  }
+  std::cout << '\n';
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 3) {
+    std::cerr << "usage: portrait-matting-border-oracle <libcccreator> "
+                 "<gru-model>\n";
+    return 2;
+  }
+
+  try {
+    void *library = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+    if (!library) {
+      throw std::runtime_error(std::string("cannot load runtime: ") +
+                               dlerror());
+    }
+    const auto createHandle = requireSymbol<CreateHandle>(
+        library, "bef_Portrait_Matting_CreateHandle");
+    const auto initModel = requireSymbol<InitModel>(
+        library, "bef_Portrait_Matting_InitModel");
+    const auto getAlphaSize =
+        requireSymbol<GetAlphaSize>(library, "bef_MP_GetAlphaSize");
+    const auto setParam =
+        requireSymbol<SetParam>(library, "bef_MP_SetParam");
+    const auto processFrame = requireSymbol<ProcessFrame>(
+        library, "bef_Portrait_Matting_DoPortraitMatting");
+    const auto processBorder =
+        requireSymbol<ProcessBorder>(library, "MP_ProcessBorder");
+    const auto releaseHandle = requireSymbol<ReleaseHandle>(
+        library, "bef_Portrait_Matting_ReleaseHandle");
+
+    void *handle = nullptr;
+    const int createStatus = createHandle(&handle);
+    if (createStatus != 0 || !handle) {
+      throw std::runtime_error("cannot create matting handle: " +
+                               std::to_string(createStatus));
+    }
+    const int initStatus = initModel(handle, 4, argv[2]);
+    std::cerr << "oracle create=" << createStatus << " init=" << initStatus
+              << '\n';
+    if (initStatus != 0) {
+      releaseHandle(handle);
+      throw std::runtime_error("cannot initialize matting model: " +
+                               std::to_string(initStatus));
+    }
+    void *internalHandle = *static_cast<void **>(handle);
+    if (!internalHandle) {
+      releaseHandle(handle);
+      throw std::runtime_error("matting wrapper has no internal handle");
+    }
+    constexpr std::pair<int, int> graphParameters[] = {
+        {5, 1}, {6, -1}, {7, 1}, {8, 1}, {1, 15}, {0, 1}, {5, 1},
+    };
+    for (const auto &[parameter, value] : graphParameters) {
+      const int status = setParam(handle, parameter, value);
+      if (status != 0) {
+        releaseHandle(handle);
+        throw std::runtime_error("cannot set graph parameter: " +
+                                 std::to_string(status));
+      }
+    }
+
+    constexpr int sourceWidth = 360;
+    constexpr int sourceHeight = 640;
+    int alphaWidth = 0;
+    int alphaHeight = 0;
+    const int sizeStatus = getAlphaSize(
+        handle, sourceWidth, sourceHeight, &alphaWidth, &alphaHeight);
+    if (sizeStatus != 0 || alphaWidth <= 0 || alphaHeight <= 0) {
+      releaseHandle(handle);
+      throw std::runtime_error("cannot resolve alpha size: " +
+                               std::to_string(sizeStatus));
+    }
+    std::vector<std::uint8_t> bgr(
+        static_cast<std::size_t>(sourceWidth) * sourceHeight * 3, 0);
+    std::vector<std::uint8_t> initialAlpha(
+        static_cast<std::size_t>(alphaWidth) * alphaHeight);
+    MattingInput frameInput = {
+        .data = bgr.data(),
+        .pixelFormat = 2,
+        .width = sourceWidth,
+        .height = sourceHeight,
+        .stride = sourceWidth * 3,
+        .orientation = 0,
+        .reserved = 0,
+        .invertAlpha = false,
+    };
+    MattingOutput frameOutput = {
+        .alpha = initialAlpha.data(),
+        .width = alphaWidth,
+        .height = alphaHeight,
+    };
+    const int frameStatus = processFrame(handle, &frameInput, &frameOutput);
+    if (frameStatus != 0) {
+      releaseHandle(handle);
+      throw std::runtime_error("cannot initialize processor dimensions: " +
+                               std::to_string(frameStatus));
+    }
+    std::cerr << "oracle alpha=" << alphaWidth << "x" << alphaHeight
+              << " frame_output=" << frameOutput.width << "x"
+              << frameOutput.height << " initialized="
+              << static_cast<int>(
+                     *(static_cast<std::uint8_t *>(internalHandle) + 0x42c))
+              << '\n';
+
+    constexpr float slope = 8.0F;
+    constexpr float center = 0.65F;
+    std::cerr << "oracle configured\n";
+    verifyCase({.handle = internalHandle,
+                .processBorder = processBorder,
+                .inputPixels = rampPattern(256, 4),
+                .width = 256,
+                .height = 4,
+                .slope = slope,
+                .center = center,
+                .name = "ramp"});
+    verifyCase({.handle = internalHandle,
+                .processBorder = processBorder,
+                .inputPixels = spatialPattern(37, 29),
+                .width = 37,
+                .height = 29,
+                .slope = slope,
+                .center = center,
+                .name = "spatial"});
+    verifyCase({.handle = internalHandle,
+                .processBorder = processBorder,
+                .inputPixels = spatialPattern(alphaWidth, alphaHeight),
+                .width = alphaWidth,
+                .height = alphaHeight,
+                .slope = slope,
+                .center = center,
+                .name = "host-size"});
+    releaseHandle(handle);
+    dlclose(library);
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/portrait-matting-param-probe.cpp
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/portrait-matting-param-probe.cpp
@@ -1,0 +1,76 @@
+#include <dlfcn.h>
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using CreateHandle = int (*)(void **);
+using InitModel = int (*)(void *, int, const char *);
+using GetParam = int (*)(void *, int, int *);
+using ReleaseHandle = int (*)(void *);
+
+template <typename Function>
+Function requireSymbol(void *library, const char *name) {
+  auto *symbol = dlsym(library, name);
+  if (!symbol) {
+    throw std::runtime_error(std::string("missing symbol: ") + name);
+  }
+  return reinterpret_cast<Function>(symbol);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 4) {
+    std::cerr << "usage: portrait-matting-param-probe <libcccreator> <model> "
+                 "<model-type>\n";
+    return 2;
+  }
+
+  try {
+    void *library = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+    if (!library) {
+      throw std::runtime_error(std::string("cannot load runtime: ") +
+                               dlerror());
+    }
+    const auto createHandle = requireSymbol<CreateHandle>(
+        library, "bef_Portrait_Matting_CreateHandle");
+    const auto initModel =
+        requireSymbol<InitModel>(library, "bef_Portrait_Matting_InitModel");
+    const auto getParam =
+        requireSymbol<GetParam>(library, "bef_Portrait_Matting_GetParam");
+    const auto releaseHandle = requireSymbol<ReleaseHandle>(
+        library, "bef_Portrait_Matting_ReleaseHandle");
+
+    void *handle = nullptr;
+    const int createStatus = createHandle(&handle);
+    if (createStatus != 0 || !handle) {
+      throw std::runtime_error("cannot create matting handle: " +
+                               std::to_string(createStatus));
+    }
+
+    const int modelType = std::stoi(argv[3]);
+    const int initStatus = initModel(handle, modelType, argv[2]);
+    if (initStatus != 0) {
+      releaseHandle(handle);
+      throw std::runtime_error("cannot initialize matting model: " +
+                               std::to_string(initStatus));
+    }
+
+    for (int paramType = 0; paramType <= 8; ++paramType) {
+      int value = -1;
+      const int status = getParam(handle, paramType, &value);
+      std::cout << "param=" << paramType << " status=" << status
+                << " value=" << value << '\n';
+    }
+
+    releaseHandle(handle);
+    dlclose(library);
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/saliency-seg-abi-probe.cpp
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/saliency-seg-abi-probe.cpp
@@ -1,0 +1,213 @@
+#include <dlfcn.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct BingoMat {
+  std::uint8_t *data;
+  std::uint32_t width;
+  std::uint32_t height;
+  std::uint32_t channels;
+  std::uint32_t reserved;
+  std::uint64_t stride;
+  std::uint32_t flags;
+  std::uint32_t reservedTail;
+};
+
+static_assert(sizeof(BingoMat) == 0x28);
+static_assert(offsetof(BingoMat, stride) == 0x18);
+
+struct SaliencyInput {
+  BingoMat image;
+  std::int32_t pixelFormat;
+  std::int32_t modelIndex;
+  bool generateBoundingBox;
+  bool singleObjectMask;
+  bool enablePostRefine;
+  bool forceSync;
+  std::uint32_t reserved0;
+  double refineRadius;
+  double refineEpsilon;
+  std::int32_t reserved1;
+  std::int32_t reserved2;
+  std::uint32_t reserved3;
+  bool asynchronous;
+  std::uint8_t tail[3];
+};
+
+static_assert(sizeof(SaliencyInput) == 0x58);
+static_assert(offsetof(SaliencyInput, pixelFormat) == 0x28);
+static_assert(offsetof(SaliencyInput, asynchronous) == 0x54);
+
+struct SaliencyResult {
+  bool valid;
+  std::uint8_t padding[7];
+  BingoMat mask;
+  float boundingBox[8];
+  float score;
+  std::uint8_t tail[28];
+};
+
+static_assert(offsetof(SaliencyResult, mask) == 0x8);
+
+struct SaliencyParams {
+  std::int32_t inferenceMode;
+  std::uint8_t reserved[68];
+};
+
+using CreateHandle = int (*)(void **);
+using Init = int (*)(void *, const char *);
+using GetInputShape = int (*)(void *, std::uint32_t &, std::uint32_t &);
+using SetParams = int (*)(void *, const SaliencyParams &);
+using Process = int (*)(void *, const SaliencyInput *, SaliencyResult *);
+using ReleaseHandle = int (*)(void *);
+
+template <typename Function>
+Function requireSymbol(void *library, const char *name) {
+  auto *symbol = dlsym(library, name);
+  if (!symbol) {
+    throw std::runtime_error(std::string("missing symbol: ") + name);
+  }
+  return reinterpret_cast<Function>(symbol);
+}
+
+int parsePositiveInteger(const char *text, const char *label) {
+  const int value = std::stoi(text);
+  if (value <= 0) {
+    throw std::runtime_error(std::string(label) + " must be positive");
+  }
+  return value;
+}
+
+std::vector<std::uint8_t> readFrame(const char *path, std::size_t bytes) {
+  std::ifstream input(path, std::ios::binary | std::ios::ate);
+  if (!input || input.tellg() != static_cast<std::streamoff>(bytes)) {
+    throw std::runtime_error("input must contain exactly one RGBA frame");
+  }
+  input.seekg(0);
+  std::vector<std::uint8_t> frame(bytes);
+  input.read(reinterpret_cast<char *>(frame.data()),
+             static_cast<std::streamsize>(frame.size()));
+  if (!input) {
+    throw std::runtime_error("cannot read RGBA frame");
+  }
+  return frame;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 9) {
+    std::cerr << "usage: saliency-seg-abi-probe <libcccreator> <model> "
+                 "<input.rgba> <width> <height> <pixel-format> <model-index> "
+                 "<output.gray>\n";
+    return 2;
+  }
+  try {
+    const int width = parsePositiveInteger(argv[4], "width");
+    const int height = parsePositiveInteger(argv[5], "height");
+    const int pixelFormat = std::stoi(argv[6]);
+    const int modelIndex = std::stoi(argv[7]);
+    auto frame = readFrame(
+        argv[3], static_cast<std::size_t>(width) * height * 4);
+    void *library = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+    if (!library) {
+      throw std::runtime_error(std::string("cannot load runtime: ") +
+                               dlerror());
+    }
+    const auto createHandle = requireSymbol<CreateHandle>(
+        library, "_Z30Bingo_SaliencySeg_createHandlePPv");
+    const auto initialize = requireSymbol<Init>(
+        library, "_Z22Bingo_SaliencySeg_initPvPKc");
+    const auto getInputShape = requireSymbol<GetInputShape>(
+        library, "_Z31Bingo_SaliencySeg_getInputShapePvRjS0_");
+    const auto setParams = requireSymbol<SetParams>(
+        library, "_Z27Bingo_SaliencySeg_setParamsPvRK24Bingo_SaliencySeg_Params");
+    const auto process = requireSymbol<Process>(
+        library, "_Z25Bingo_SaliencySeg_processPvPK23Bingo_SaliencySeg_InputP24Bingo_SaliencySeg_Result");
+    const auto releaseHandle = requireSymbol<ReleaseHandle>(
+        library, "_Z31Bingo_SaliencySeg_releaseHandlePv");
+
+    void *handle = nullptr;
+    const int createStatus = createHandle(&handle);
+    if (createStatus != 0 || !handle) {
+      throw std::runtime_error("cannot create saliency handle: " +
+                               std::to_string(createStatus));
+    }
+    const int initStatus = initialize(handle, argv[2]);
+    std::cout << "init=" << initStatus << '\n';
+    if (initStatus != 0) {
+      releaseHandle(handle);
+      return 3;
+    }
+    std::uint32_t inputWidth = 0;
+    std::uint32_t inputHeight = 0;
+    const int shapeStatus =
+        getInputShape(handle, inputWidth, inputHeight);
+    std::cout << "shape_status=" << shapeStatus
+              << " input_width=" << inputWidth
+              << " input_height=" << inputHeight << '\n';
+    const SaliencyParams params{.inferenceMode = 2, .reserved = {}};
+    std::cout << "set_params=" << setParams(handle, params) << '\n';
+    const SaliencyInput input{
+        .image = BingoMat{
+            .data = frame.data(),
+            .width = static_cast<std::uint32_t>(width),
+            .height = static_cast<std::uint32_t>(height),
+            .channels = 4,
+            .reserved = 0,
+            .stride = static_cast<std::uint64_t>(width) * 4,
+            .flags = 0,
+            .reservedTail = 0,
+        },
+        .pixelFormat = pixelFormat,
+        .modelIndex = modelIndex,
+        .generateBoundingBox = false,
+        .singleObjectMask = false,
+        .enablePostRefine = false,
+        .forceSync = true,
+        .reserved0 = 0,
+        .refineRadius = 3.0,
+        .refineEpsilon = 0.01,
+        .reserved1 = 0,
+        .reserved2 = 0,
+        .reserved3 = 0,
+        .asynchronous = false,
+        .tail = {},
+    };
+    SaliencyResult result{};
+    const int processStatus = process(handle, &input, &result);
+    std::cout << "process=" << processStatus
+              << " valid=" << static_cast<int>(result.valid)
+              << " mask_width=" << result.mask.width
+              << " mask_height=" << result.mask.height
+              << " mask_channels=" << result.mask.channels
+              << " mask_stride=" << result.mask.stride
+              << " score=" << result.score << '\n';
+    if (processStatus == 0 && result.valid && result.mask.data &&
+        result.mask.width > 0 && result.mask.height > 0) {
+      const auto outputBytes = static_cast<std::size_t>(result.mask.width) *
+                               result.mask.height * result.mask.channels;
+      std::ofstream output(argv[8], std::ios::binary);
+      output.write(reinterpret_cast<const char *>(result.mask.data),
+                   static_cast<std::streamsize>(outputBytes));
+      if (!output) {
+        throw std::runtime_error("cannot write saliency mask");
+      }
+    }
+    releaseHandle(handle);
+    dlclose(library);
+    return processStatus == 0 && result.valid ? 0 : 4;
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}

--- a/qcut/docs/task/jianying-filter-runtime-research/probes/vision-person-segmentation-probe.cpp
+++ b/qcut/docs/task/jianying-filter-runtime-research/probes/vision-person-segmentation-probe.cpp
@@ -1,0 +1,70 @@
+#include "vision-person-segmentation.hpp"
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int positiveInteger(const char *value, const char *label) {
+  const int parsed = std::stoi(value);
+  if (parsed <= 0) {
+    throw std::invalid_argument(std::string(label) + " must be positive");
+  }
+  return parsed;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 5) {
+    std::cerr << "usage: vision-person-segmentation-probe <input.rgba> "
+                 "<width> <height> <output.gray>\n";
+    return 2;
+  }
+  try {
+    const int width = positiveInteger(argv[2], "width");
+    const int height = positiveInteger(argv[3], "height");
+    const auto frameBytes = static_cast<std::size_t>(width) * height * 4;
+    std::ifstream input(argv[1], std::ios::binary | std::ios::ate);
+    if (!input) {
+      throw std::runtime_error("cannot open input");
+    }
+    const auto inputBytes = input.tellg();
+    if (inputBytes <= 0 ||
+        static_cast<std::size_t>(inputBytes) % frameBytes != 0) {
+      throw std::runtime_error("input does not contain complete RGBA frames");
+    }
+    const auto frameCount = static_cast<std::size_t>(inputBytes) / frameBytes;
+    input.seekg(0);
+    std::ofstream output(argv[4], std::ios::binary);
+    if (!output) {
+      throw std::runtime_error("cannot open output");
+    }
+
+    qcut::matting::VisionPersonSegmentation segmentation(width, height);
+    std::vector<std::uint8_t> rgba(frameBytes);
+    for (std::size_t frame = 0; frame < frameCount; ++frame) {
+      input.read(reinterpret_cast<char *>(rgba.data()),
+                 static_cast<std::streamsize>(rgba.size()));
+      if (static_cast<std::size_t>(input.gcount()) != rgba.size()) {
+        throw std::runtime_error("input ended with an incomplete frame");
+      }
+      const auto alpha = segmentation.segment(rgba);
+      output.write(reinterpret_cast<const char *>(alpha.data()),
+                   static_cast<std::streamsize>(alpha.size()));
+      if (!output) {
+        throw std::runtime_error("cannot write output");
+      }
+      std::cerr << "progress frame=" << frame + 1 << " total=" << frameCount
+                << '\n';
+    }
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+  return 0;
+}

--- a/qcut/docs/task/jianying-filter-runtime-research/tematting-blend-v2-native-metal-2026-08-27.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/tematting-blend-v2-native-metal-2026-08-27.zh.md
@@ -258,3 +258,12 @@ ok width=360 height=640 alphaWidth=360 alphaHeight=640
 | 连续真人视频原生 V2 稳定性 | 已确认，60 帧 + 桌面 E2E |
 | 连续真人视频原生 V2速度 | 已测：流式整链 4.91 秒，兼容链 4.11 秒；原生仍慢 0.80 秒 |
 | QCut 与剪映导出逐像素平价 | 未验证 |
+
+## 2026-08-28 产品路径更新
+
+上文保留了原始接入的历史链路和基准。当前 Alpha 缓存链已停止把 native Metal 当作默认逐帧 fast path：缓存需要的是合成前语义 Alpha，而旧实现上传并回读完整 RGBA 后仍只提取 Alpha，无法为 CPU `libvpx-vp9` 编码形成零拷贝。
+
+现在仅在显式诊断开关下用首帧执行原生 V2 canary，逐字节验证 `sourceAlpha × matte / 255`，其余帧直接写相同语义 Alpha。产出路径与 metadata 始终标记 `TEMattingBlendEffectV2-compatible`，canary 状态另写 `qcut_matting_native_canary=passed`，不再把单帧验证冒充整段 native Metal 输出。修正后的 `total_us` 已包含 flush、对象释放与 `dlclose`：三次 60 帧真人基准中，compatible 中位数为 `6533.095 ms`，native canary 中位数为 `6526.306 ms`，只差约 `0.10%`，应视为性能持平；六份 Alpha SHA-256 均为 `7f36016c92476d48e6ef50376b1ae46955feb2c0d6e7f23dfbd0d4b215b1fbe3`。
+
+完整实现、分阶段计时、桌面 E2E 和剩余边界见
+[QCut 人物抠像差距收敛记录](person-cutout-gap-reduction-2026-08-28.zh.md)。

--- a/qcut/docs/task/jianying-filter-runtime-research/tematting-blend-v2-native-metal-2026-08-27.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/tematting-blend-v2-native-metal-2026-08-27.zh.md
@@ -1,0 +1,260 @@
+# 剪映人物抠像原生 GPU 合成链路（2026-08-27）
+
+## 结论
+
+剪映专业版 11.3.0 的人物抠像不是“模型输出一张 Alpha 后直接叠图”。已确认的完整链路是：
+
+```text
+TEMattingUnit2
+  -> GRU 人物分割与时序状态
+  -> TEMattingReaderUnit2::preProcessAlphaChannel
+  -> TEMattingBlendEffectV2
+  -> TERLDeviceManager 中与当前上下文绑定的 Metal RLDevice
+  -> 输入、输出、Mask 三张 AGFX DeviceTexture
+  -> bef_portrait_matting_v2_blend_device_texture_with_data
+  -> FastBlend / FastMorphologyBlend / 带 LegacyStroke 的两种路径
+```
+
+本轮已在独立探针中复现到真正的原生 Metal `FastBlend`，不是只创建 handle：
+
+- `RLDevice` 的 renderer 与 `TESharedGLContext` renderer、GPDevice 完全同源；
+- `TEMattingBlendEffectV2::init` 返回 `1`，对象内 `v2_active=1`；
+- `selected_path=1`，对应 `FastBlend`；
+- `bef_portrait_matting_v2_blend_device_texture_with_data` 返回 `0`；
+- 真人首帧的原生 GPU 输出与 `source × mask / 255` 的预乘透明公式逐通道完全一致：最大误差 `0`、MAE `0`、不同通道数 `0`；
+- 输出 Alpha 与送入的 GRU Mask 完全一致，PSNR 为 `inf`。
+
+这证明原生 V2 合成已经可独立调用。随后 QCut 产品 provider 也已接入同一条 Metal 路径并通过真人视频桌面 E2E；它仍不等于与剪映导出达到逐像素平价。
+
+## QCut 产品接入结果
+
+产品接入保留了 renderer 与私有 ABI 的隔离：UI 只调用 Electron IPC，主进程选择 provider，独立 native bridge 同时持有连续 GRU 状态和 `TEMattingBlendEffectV2`。每帧流程为：
+
+```text
+RGBA -> BGR888 GRU -> 全尺寸 Alpha -> AGFX input/mask/output textures
+     -> TEMattingBlendEffectV2 native Metal -> 回读输出 Alpha
+     -> 直通 RGB + native Alpha -> VP9 WebM
+```
+
+回读后只采用 native 输出的 Alpha，RGB 继续直通源画面。原因是 Effect 输出为预乘 RGBA，而 WebM/Chromium 的透明视频契约需要直通 RGB；直接编码预乘 RGB 会在播放器合成时再次乘 Alpha，产生黑边。
+
+安全边界：
+
+- 只在 macOS arm64 且 `libcccreator.dylib` SHA-256 精确等于本报告版本时选择 native Metal；
+- bridge 再校验三个 AB config ID 必须分别为 `372 / 377 / 568`；
+- native 初始化、任一纹理、任一帧 Blend 或 Alpha 公式校验失败时，删除半成品并对整段视频重跑兼容路径；
+- 打包校验要求 helper 包含 native Metal 能力标记，macOS 签名为该 helper 保留本地私有 runtime 所需的 dyld entitlement；
+- dylib、模型、视频和生成结果仍只保存在用户本机，不进入仓库。
+
+真人 2 秒、360×640、30 fps、60 帧连续视频结果：
+
+- native Metal Alpha 与兼容路径 Alpha 逐字节相同；
+- 两份 13,824,000 字节输出 SHA-256 均为 `010310f238172a43dbf8b2cda7cb6bf3dc3d943f5ef92728e06b44a77c2ad294`；
+- QCut runtime 返回 `blendImplementation=TEMattingBlendEffectV2-native-metal`；
+- WebM 流包含 `ALPHA_MODE=1`、`QCUT_MATTING_BLEND=TEMattingBlendEffectV2-native-metal` 和正确 GRU 模型标记；
+- Electron E2E 完成“精细 -> 开始并应用 -> 素材入库 -> 时间线人物蒙版 -> 播放器加载”，播放器 `readyState >= 2`、`videoWidth=360`；
+- 桌面 E2E 通过，耗时 18.3 秒；UI 中单次抠像任务显示约 5 秒。
+
+同机串行冷运行一次，仅比较 60 帧 bridge 阶段：兼容路径 `1.70s`，当前 native 接入 `2.56s`。这不是正式多轮 benchmark，但已经足以否定“接入 FastBlend 后整链路必然更快”。当前版本每帧创建三张纹理并把结果读回 CPU，约多 `0.86s`；它的价值是先锁定剪映同一 Blend 语义和产品回退边界。只有完成纹理复用、减少读回并测量预览链路后，才能把它称为 QCut 性能 fast path。
+
+本机证据：
+
+```text
+/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/
+  qcut-native-metal-person-cutout-2s.webm
+  qcut-native-metal-e2e-compare-frame0-alpha.png
+  qcut-desktop-e2e-native-metal/
+    desktop-person-cutout.webm
+    01-fine-cutout-ready.png
+    02-cutout-completed.png
+    03-mask-playing-in-preview.png
+    e2e-evidence.json
+```
+
+## 样本与版本边界
+
+- 剪映专业版运行时备份来源版本：`11.3.0`，来源应用为 `/Applications/VideoFusion-macOS.app`，不是 CapCut。
+- `libcccreator.dylib` SHA-256：`0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9`。
+- arm64 UUID：`D6342ECD-5432-33F0-A2AD-0C28F5699994`。
+- x86_64 UUID：`D633A4BB-4D09-30AE-88CA-A389782087BE`。
+- GRU 模型 SHA-256：`101688825490be3704babc7ce49f6d002cdb4fe69e879556b4687ac9006f8596`。
+- 真人输入：360×640，来自仓库外 `improve_voice` 证据目录。
+
+最终复核时，当前应用仍显示 `11.3.0`，但 universal dylib 已变为 SHA-256 `b09c395d934169cb20ec865dd1d4032ca68023b287a7264e1b06ff4d71fd1be4`、arm64 UUID `100726E3-FCB0-31BC-98EE-1B196A1714A3`。这说明相同产品版本号下发生过运行时 build 漂移。本报告的 Native Metal 成功结论只绑定上面的 QCut 私有备份指纹；当前产品也正是从该备份读取运行时，并不会对白名单外的新 build 开启私有 fast path。
+
+以下私有符号地址和对象偏移只对上述 UUID 有效，不应作为跨版本稳定 ABI。
+
+## 宿主设备链
+
+### 1. RL 线程生命周期
+
+静态调用关系：
+
+```text
+TERLThread::onThreadEnter / willEnterTask
+  -> 创建 TERLRenderContext
+  -> TERLRenderContext::_init
+  -> TERLDeviceManager::createRLDeviceFromGLContext
+  -> 以 TESharedGLContext* 为键缓存 RLDevice
+
+TERLRenderContext 析构
+  -> TERLDeviceManager::removeRLDeviceFromGLContext
+```
+
+`TERLThread` 构造时把 render-context 类型写为 `30`；独立探针使用同一值。`TERLRenderContext::_init` 还会建立 `TECoreFrameBufferCache`，所以不能只手工伪造一个 RLDevice 指针。
+
+### 2. `TEMattingBlendEffectV2::init` 的接受条件
+
+`init` 先检查 `ConfigID_EnableAGFXMetal`，再取得当前 `TESharedGLContext` 的 renderer、GPDevice 和 `TERLDeviceManager` 缓存的 RLDevice。V2 只有在以下条件全部成立时才激活：
+
+```text
+context renderer != null
+RLDevice owner renderer != null
+RLDevice owner renderer == context renderer
+RLDevice owner GPDevice == context GPDevice
+context GPDevice != null
+```
+
+任一条件失败都会输出：
+
+```text
+[MattingBlendV2] reject V2: gpdevice owner unavailable, ...
+```
+
+并清除对象 `+0x48` 的 V2 激活位。此前只看到 handle 被创建，不能证明进入了原生 V2。
+
+### 3. macOS 必须是 Metal renderer
+
+标准 `TERLRenderContext::_init` 的双参数创建分支会先创建 GLES 设备。该设备可以通过上面的 owner 校验，但 EffectSDK 在 macOS 上仍会拒绝：
+
+```text
+fast device fallback: mac requires metal renderer, actual=8
+fast circuit open, plan=FastBlend,
+reason=deterministic_device_context,
+detail=mac_metal_renderer_required
+```
+
+`TERLDeviceManager::createRenderDevice` 的另一条分支在 `ConfigID_EnableAGFXMetal` 与 `ConfigID_VeabtestEnableMetalV2` 打开时创建 renderer type `6`。探针移除临时 GLES 注册，再通过共享上下文重建 Metal RLDevice；随后 `getRenderDevice()`、RLDevice owner renderer 与 GPDevice 再次全部相等，V2 才能实际执行。
+
+因此“缺一个 RLDevice 注册”仍不够精确。macOS 的必要条件是：同一上下文、同一 Metal renderer、同一 GPDevice，并由 `TERLDeviceManager` 维护所有权关系。
+
+## EffectSDK 合成链
+
+### 1. 三张输入都是设备纹理
+
+入口名 `blend_device_texture_with_data` 容易误读。对 `TEMattingBlendEffectV2::renderBlendEffect` 的调用点反汇编确认，三个 24 字节图像描述符都是：
+
+```cpp
+struct MattingImage {
+  uint32_t format;
+  uint32_t reserved;
+  const void* data;
+  uint32_t width;
+  uint32_t height;
+};
+```
+
+其中 `data` 分别指向输入、输出和 Mask 的 AGFX `DeviceTexture`。Mask 不是裸灰度字节。把 CPU Mask 指针直接传入会在 `DeviceWrapper<TextureBase>::getGPDevice()` 中崩溃；正确做法是先上传为 R8 或 RGBA Mask 纹理。
+
+### 2. 参数会选择四条执行计划
+
+`TEMattingUnit2::getFilterParam` 从模型片段取出 stroke 参数，`TEMattingBlendEffectV2::setStrokeParam` 再调用 `bef_portrait_matting_v2_set_stroke_params`。已确认字段包括：
+
+- `morphologyParams`
+- `erode_dilate_kernel_size`
+- `blur_kernel_size`
+- `enable_reverse`
+- `blendPath`
+- `featurePath`
+
+内部选择器返回值与字符串表对应为：
+
+| 值 | 计划 | 用途 |
+| ---: | --- | --- |
+| 1 | `FastBlend` | 直接 Mask 合成 |
+| 2 | `FastMorphologyBlend` | 腐蚀/膨胀或模糊后合成 |
+| 3 | `FastBlendThenLegacyStroke` | 直接合成后接旧描边链 |
+| 4 | `FastMorphologyBlendThenLegacyStroke` | 形态学合成后接旧描边链 |
+
+本轮真人首帧关闭 `featurePath`、保留 `blendPath`，命中计划 `1`。打开 `featurePath` 会进入带 LegacyStroke 的计划 `3`。
+
+### 3. 实际像素公式
+
+透明模式的片元公式为：
+
+```glsl
+mix(vec4(0), source, mask.r)
+```
+
+对 360×640 真人首帧读取 GPU 输出后，探针逐通道计算：
+
+```text
+expected = round(source_channel * mask / 255)
+```
+
+结果为：
+
+```text
+formula_max_error=0
+formula_mae=0
+different_channels=0
+```
+
+所以原生输出是预乘 RGBA。QCut 当前 WebM 兼容链保留直通 RGB 和相同 Alpha，再交给 Chromium 合成；最终显示公式相同，但内存布局与执行位置不同。
+
+## 可复现实验
+
+探针源码：
+
+```text
+docs/task/jianying-filter-runtime-research/probes/portrait-matting-blend-v2-probe.cpp
+```
+
+编译：
+
+```bash
+xcrun clang++ -std=c++20 -Wall -Wextra -Werror \
+  docs/task/jianying-filter-runtime-research/probes/portrait-matting-blend-v2-probe.cpp \
+  -framework OpenGL -framework Foundation -lobjc -ldl \
+  -o /tmp/qcut-portrait-matting-blend-v2-probe-rl
+```
+
+运行时需要研究者自己有权使用的本地剪映运行时与真人素材。成功门禁是：
+
+```text
+owner_match=1
+tematting_init_status=1 v2_active=1
+selected_path=1 flags=1,1,1,0
+formula_max_error=0 formula_mae=0 different_channels=0
+ok width=360 height=640 alphaWidth=360 alphaHeight=640
+```
+
+仓库只提交 QCut 自有探针和研究结论，不提交 dylib、模型、剪映资源、原始日志或素材。
+
+## 对 QCut 的实际意义
+
+当前 QCut 的 GRU 模型、输入通道、Alpha 放大、状态重置和原生 V2 Blend 已接入受控 provider。剩余工作是把当前可用接入继续收敛为低往返的生产快路径：
+
+1. 直接创建 Metal RLDevice，避免探针当前“先建 GLES、再替换 Metal”的研究性过渡和纹理桥警告。
+2. 已定位并接入 `RendererDevice::updateTexture(DeviceTexture, const void *)`，input、Mask、output 三张纹理现在都在同一 GPDevice 上跨帧复用；Alpha 仍需回读后编码，因此仍不是零拷贝。
+3. 为源切换、seek、取消和任务结束执行明确的 Effect handle、RLDevice 与 GRU 状态清理。
+4. 当前 60 帧端到端 bridge 基准中 compatible 中位数 `2510 ms`、native 中位数 `3341 ms`；后续还需分别记录模型推理、Mask 上传、GPU Blend、读回和编码耗时。
+5. 用同一真人、同一背景、同一导出设置取得剪映 Alpha/成片真值后，再做视觉与数值平价判定。
+
+原生 `FastBlend` 可以减少 CPU 合成和部分纹理往返，主要改善预览合成延迟。它不会自动加速 GRU 推理、视频解码或 VP9/导出编码；在完成连续视频 benchmark 前，不给出整条人物抠像的速度提升百分比。
+
+## 证据分级
+
+| 项目 | 状态 |
+| --- | --- |
+| 同一 GRU 模型与哈希 | 已确认 |
+| RLDevice owner / context / GPDevice 身份门禁 | 已确认 |
+| macOS Metal renderer type 6 要求 | 已确认 |
+| 三张 AGFX DeviceTexture 调用契约 | 已确认 |
+| 四种 FastBlend 计划映射 | 已确认 |
+| 真人首帧原生 Metal 输出 | 已确认 |
+| 原生输出与预乘公式逐通道一致 | 已确认 |
+| QCut 产品 provider 已切换原生 V2 | 已确认，精确版本门禁并自动回退 |
+| 连续真人视频原生 V2 稳定性 | 已确认，60 帧 + 桌面 E2E |
+| 连续真人视频原生 V2速度 | 已测：流式整链 4.91 秒，兼容链 4.11 秒；原生仍慢 0.80 秒 |
+| QCut 与剪映导出逐像素平价 | 未验证 |

--- a/qcut/docs/task/jianying-filter-runtime-research/tematting-blend-v2-native-metal-2026-08-27.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/tematting-blend-v2-native-metal-2026-08-27.zh.md
@@ -60,7 +60,7 @@ RGBA -> BGR888 GRU -> 全尺寸 Alpha -> AGFX input/mask/output textures
 本机证据：
 
 ```text
-/Users/peter/Desktop/improve_voice/qcut-gru-real-person-test-2026-08-26/
+<仓库外 improve_voice 证据目录>/qcut-gru-real-person-test-2026-08-26/
   qcut-native-metal-person-cutout-2s.webm
   qcut-native-metal-e2e-compare-frame0-alpha.png
   qcut-desktop-e2e-native-metal/

--- a/qcut/docs/task/jianying-filter-runtime-research/video-object-bach-host-boundary-2026-08-28.zh.md
+++ b/qcut/docs/task/jianying-filter-runtime-research/video-object-bach-host-boundary-2026-08-28.zh.md
@@ -1,0 +1,551 @@
+# 剪映 Video Object Matting 宿主边界审计（2026-08-28）
+
+## 结论
+
+`ai_matting_video_object -> video_saliency_seg_bce` 的真实人物抠像执行边界不是
+`SwingManager` 的全局 Effect handle，也不是把一张 Metal/GL texture 交给
+`bef_effect_algorithm_texture`。剪映的 `TEBachMattingAlgorithm` 直接把
+`ITEVideoFrame` 转成 CPU 可读的 Bach 图像输入，执行其持有的
+`BachAlgorithmSystem`，再从节点 `video_saliency_seg_0` 的结果中读取
+`saliency_mask`。
+
+因此，当前结论已经从“只能设计未来 worker”推进到“固定版本 worker 已动态跑通”：
+
+- QCut 的独立 worker 现在用固定 UUID 中的具名构造/析构符号创建 `TECVPixelBufferFrame` 和
+  `TEBachMattingAlgorithm`，连续帧复用同一 `BachAlgorithmSystem`；
+- worker 内同时锁死主 dylib SHA/UUID、graph SHA、packed model SHA，以及本机快照中
+  全部 23 个私有 Framework dylib 的内容闭包；任一不匹配都在 `dlopen`/推理前失败；
+- raw `saliency_mask` 是 `256×256` u8；默认产品输出把它作为低分辨率 Mask texture
+  交给同一固定版 `TEMattingBlendEffectV2`，由 vendor `FastBlend` 放大并回读源尺寸
+  Alpha，不再用 QCut 双线性近似；
+- 每帧私有 ObjC/CoreML 推理都在独立 autorelease pool 中完成，避免长视频把
+  vendor 临时对象累积到 worker 退出；
+- 高级参数只有非默认时才进入 QCut refinement，因此会使用独立的 refined
+  pipeline identity，不能标成 raw Bach exact；
+- Swing V2/Effect handle 仍不是这张图的结果 owner，它只保留作普通 Swing 特效研究。
+
+实现位于
+[video-object-bach-bridge.mm](../../../electron/jianying-person-cutout/native/video-object-bach-bridge.mm)
+和 [metal-matting-blend.cpp](../../../electron/jianying-person-cutout/native/metal-matting-blend.cpp)，
+进程崩溃、超时和资源缺失仍由 Electron parent 的 watchdog/circuit breaker 回退，
+不会让 vendor pointer 进入主进程。
+
+## 审计对象
+
+本轮结论只适用于以下本机 ARM64 运行时：
+
+```text
+libcccreator.dylib SHA-256:
+0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9
+
+ARM64 UUID:
+D6342ECD-5432-33F0-A2AD-0C28F5699994
+
+private Framework closure（按 basename 排序的 `basename=sha256\n`）：
+e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e
+
+capability marker:
+jianying-runtime-framework-closure-d634-v1-e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e
+```
+
+闭包来自本机 `qcut-effect-runtime.json` 的完整 `Frameworks/` 清单：主
+`libcccreator.dylib` 单独校验，另外 22 个 dylib 逐文件校验，包含
+`libAGFX`、`libEGL`、`libGLESv2`、`libLumiGeneRuntime`、`libbytenn`、
+`libfastcv`、`libIESAppLogger`、`libsamicore`、`libvecryptor` 和同快照其余
+编解码依赖。这避免 `RTLD_NOW | RTLD_GLOBAL` 从混合版本目录加载未门禁的私有
+`@rpath` image。把临时快照中的 `libIESAppLogger.dylib` 截断到 16 bytes 后，
+worker 在 `dlopen` 前以退出码 1 拒绝，并精确报告该文件 SHA 不匹配。
+
+该闭包只锁剪映随包私有 dylib、graph 和 model；macOS 系统 Framework、CoreML
+实现、GPU 驱动和硬件仍属于宿主环境边界，不能由本地文件 SHA 固定。因而这里的
+“exact”是“同一私有运行时快照与同一宿主数值路径”，不是跨 OS/GPU 的数学承诺。
+
+下文虚拟地址只用于说明这个 UUID 的静态证据，不能作为跨版本产品常量。
+
+测试 graph：
+
+```text
+name: AlgorithmGraph_9bpck63bYbqbZAcfdUcjcAbNdWcf
+node: video_saliency_seg_0
+type: general_seg
+model_name: video_saliency_seg_bce
+output key: saliency_mask
+model input/output: 256x256
+source input in verified run: 360x640 RGBA
+```
+
+旧的 `360×640 -> 288×512 -> 256×256` 推断已被真实 tensor capture 排除。
+`texture_blit` 的无效 view size/default `128×224` 日志不参与这条 CPU model input；
+packed graph 把源尺寸直接送入 `mobilecv2` resize，再得到 `256×256`。
+
+## 已验证的真实调用链
+
+### 1. 输入不是 Swing Effect texture
+
+`TEBachMattingAlgorithm::AIMattingInternal` 位于 `0x201fc70`。它在
+`0x201fd14` 调用：
+
+```text
+TEBachAlgorithmBase::executeBachAlgorithm(
+  shared_ptr<ITEVideoFrame> const&,
+  shared_ptr<Bach::BachAlgorithmSystem> const&
+)
+```
+
+目标函数位于 `0x200b3e4`。其输入处理顺序为：
+
+1. 通过 `ITEVideoFrame` 虚接口取得 frame buffer 描述；
+2. 取得其中的 CVPixelBuffer/raw buffer；
+3. 需要 CPU 拷贝时，按 `width * height * 4` 分配内存并在 `0x200b4ac`
+   调用 `TECVPixelBufferGetRawData`；
+4. 在 `0x200b538–0x200b590` 逐像素交换第 0、2 通道，即 BGRA/RGBA 转换；
+5. 构造 Bach 输入，按源 frame format 映射像素格式；
+6. 在 `0x200b70c–0x200b71c` 调用 `BachAlgorithmSystem` 的 execute 虚接口。
+
+这条函数中没有调用 `bef_effect_algorithm_texture`、Swing segment seek 或
+RLDevice texture 输入。上游 frame 可以由 CVPixelBuffer 背书，但在 Bach execute
+前已经显式落到 CPU 可读 payload；这里不是端到端 Metal 零拷贝边界。
+
+### 2. Object route 的精确结果 owner
+
+`TEBachMattingAlgorithm::getMaskAndBoundingBox` 位于 `0x2021250`。object route
+进入条件已经由分支直接确认：
+
+```text
+VEMattingType = 1
+VEMattingModelType = 3
+```
+
+对应分支从 `0x2021f48` 开始：
+
+1. 构造字符串 `video_saliency_seg_0`；
+2. `0x2021f70` 取得 `BachAlgorithmSystem` vtable；
+3. `0x2021f74` 读取 vtable `+0x78`；
+4. 以 `(system, "video_saliency_seg_0", 0)` 调用 result getter；
+5. 从返回 wrapper 的 `+0x18` 取得第一项结果；
+6. 以键 `saliency_mask` 查 Bach result map；
+7. 将其转换成 `BachMap/BachTextureInfo`；
+8. 从 `BachTextureInfo::data()` 复制 soft Alpha；
+9. 用 `BachTextureInfo::width()/height()` 写入 `TEMattingMaskInfo` 的尺寸。
+
+这里的 `+0x78` 是对真实调用点的说明，不是建议 QCut 直接调用该 vtable 槽。
+运行时同时导出了具名方法：
+
+```text
+Bach::BachAlgorithmSystemGE::execute(Bach::BachAlgorithmInput const&)
+Bach::BachAlgorithmSystemGE::getResult(std::string const&, unsigned int)
+```
+
+产品 worker 没有调用 vtable `+0x78`；它调用已经在该 UUID 上动态验证的
+`TEBachMattingAlgorithm::getMaskAndBoundingBox` 具名导出，并由该方法内部读取
+结果。`TEMattingMaskInfo+0x10` 返回的数据来自 `operator new[]`，worker 使用
+`operator delete[]` 释放，不能用 `free`。
+
+## Packed graph 数值链
+
+### 源帧直接缩到 256
+
+packed model 的 `saliency_seg` graph 已确认：
+
+```text
+input: Uint8 NHWC, source-variable shape
+resize: CPU, source -> fixinput[1,256,256,4]
+cvt_color: RGBA -> BGR
+nhwc2nchw
+convert: uint8 -> float32, alpha=1/255, beta=0
+bytenn_op: data + prev_img + prev_mask -> nn_3
+convert_2: float32 nn_3 -> uint8 saliency_mask
+```
+
+`bce::device::cpu::resize` 位于 `0x13906e0`：它读取属性 `interpolation`，并把
+该整数原样传给 `0xea9240`。后者的断言路径直接指向
+`mobilecv/mobilecv2/modules/imgproc/src/imgwarp.cpp::resize`。model header 的
+`cpuresize_mode` 为 `1`，运行日志版本为 `mobilecv2 1.8.27`，即这条图使用
+mobilecv2 `INTER_LINEAR`，不是 Metal texture blit 或两段 graph-size resize。
+
+同一真实首帧 capture 的 `data` 为 BGR NCHW float32，形状
+`[1,3,256,256]`。QCut 自写 half-pixel bilinear uint8-round 与它比较时，归一化
+MAE `0.000343496`、最大误差 `1/255`；差值只到 1 LSB，但并非 bit-exact。
+这一差异现在不需要继续在 direct CoreML fallback 中猜：Bach provider 把源
+RGBA 交给同一 packed graph，由上述 mobilecv2 op 本身产生输入。
+
+### `nn_3 -> saliency_mask` 已 bit-exact
+
+研究 hook 在同一次 Bach 执行中同时抓取 ByteCoreML 返回的 `nn_3` float32 和
+`getMaskAndBoundingBox` 返回的 u8 `saliency_mask`。对 identity、翻转、转置和
+旋转候选做全量对照后，唯一逐像素完全相等的规则是：
+
+```text
+saliency_mask = round(clamp(nn_3, 0, 1) * 255)
+```
+
+首帧 `65536/65536` 像素完全相同，MAE `0`、最大误差 `0`，没有翻转、转置或
+中间 resize。此前 standalone CoreML replay 的 `0.0441437/255` MAE、最大
+`1/255` 是 Apple CoreML 与 ByteCoreML backend inference drift，不是
+`convert_2` 的量化差异。
+
+### V2 context/config 不改变 Bach 推理
+
+最终 full-framework-closure capture worker 会先构造同进程
+`TEMattingBlendEffectV2`，因此会走 V2 所需的 TERL context 与固定 ConfigID；随后
+在同一 worker 连续处理两帧。capture 位于
+`/private/tmp/qcut-jy-bach-v2-framework-closure-capture-final-20260828-1521`：
+
+| tensor | V2 worker SHA-256 | 与 V2 接入前比较 |
+| --- | --- | --- |
+| frame 0 `nn_3` | `18914e224988222bf3f47b1bf07ef9c71b877c278c21b8c986f751fcbba43a07` | `cmp=0` |
+| frame 1 `nn_3` | `a6febb781f79279295a55018a0a4882cb3c374e13169f428f9df787356da4a59` | `cmp=0` |
+
+再按已锁定规则把两帧 `nn_3` 量化成 u8，与 V2 接入前直接保存的
+`/private/tmp/qcut-jy-bach-two-frame-raw-256.gray` 比较，`131072/131072`
+像素完全相同，MAE `0`、最大误差 `0`。因此 V2 的全局 config/context 初始化
+没有改变 Bach 原始 256 Mask；当前输出差异只发生在 raw Mask 之后的 vendor V2
+源尺寸合成阶段。
+
+## 两帧时序实证
+
+两帧真人输入在一个 worker、一个 `TEBachMattingAlgorithm` 和一个内部
+`BachAlgorithmSystem` 中连续执行。输入 hook 与 ByteCoreML 输出 hook 得到：
+
+| tensor | SHA-256 | 结论 |
+| --- | --- | --- |
+| frame 0 `data` | `209e3e1a88dc2464eee4d35575850cade736b8a916ae1125b1d7dffed77af801` | 真实 256 BGR NCHW input |
+| frame 0 `prev_img` | `599c1bb5ffd4b87229a81958f33f1060821cd01cd7aa7ccafa0d862f4522f3f6` | 786432 bytes 全零 |
+| frame 0 `prev_mask` | `8a39d2abd3999ab73c34db2476849cddf303ce389b35826850f9a700589b4a90` | 262144 bytes 全零 |
+| frame 0 `nn_3` | `18914e224988222bf3f47b1bf07ef9c71b877c278c21b8c986f751fcbba43a07` | ByteCoreML 原始 float32 |
+| frame 1 `data` | `cc74c2458883139c3fe54e2f8f2734e88a6bbe1d91fc1f6ada9bdaf8e1603bff` | 第二个源帧的真实 input |
+| frame 1 `prev_img` | `209e3e1a88dc2464eee4d35575850cade736b8a916ae1125b1d7dffed77af801` | 与 frame 0 `data` bit-exact |
+| frame 1 `prev_mask` | `18914e224988222bf3f47b1bf07ef9c71b877c278c21b8c986f751fcbba43a07` | 与 frame 0 `nn_3` bit-exact |
+| frame 1 `nn_3` | `a6febb781f79279295a55018a0a4882cb3c374e13169f428f9df787356da4a59` | 使用真实上一帧状态后的输出 |
+
+两帧 raw 256 mask 串联文件 SHA-256 为
+`1e49daa89eeade3d40ece0d5ea6658bf2bbb016dfb3585a56f5b09c7af4473f0`。
+其中第二帧 warm mask SHA-256 为
+`2ad1da78ee5ae715dd9bc803f3b433ba7b4fa07e8327bbd13adf931489f3dea4`；
+把完全相同的第二个 RGBA 帧放进新 worker 冷启动，mask SHA-256 为
+`10da001c8db46377f21f32e39aab9393db6a45268a37b33d7203ffedc95519c9`。
+两者有 `23213/65536` 像素不同，u8 MAE `0.6737823486`、最大误差 `69`。
+这排除了“同一个进程但每帧重置”的假阳性。
+
+## Swing V2 probe 的复用结论
+
+现有 [effect-probe.mm](../../../research/jianying-runtime-probe/effect-probe.mm)
+已经验证以下宿主链：
+
+```text
+HTSGLContext bind
+  -> GPDevice(RendererType=6, Metal)
+  -> CVPixelBuffer-backed DeviceTexture(flags=false,false,true)
+  -> SwingManager(create_with_gpdevice)
+  -> VideoSegment(type=7) + FeatureSegment(type=0)
+  -> seek_frame_device_texture
+```
+
+该 probe 使用的已验证入口如下。具名导出按符号绑定；只有 context scope 两项是
+UUID 锁定的研究偏移：
+
+| 入口 | 所属库/地址 | 约束 |
+| --- | --- | --- |
+| `GPDevice::createDevice(RendererType, unsigned int)` | `libAGFX.dylib` 具名导出 | `RendererType=6` |
+| `Utils::createCVPixelBuffer(...)` | `libAGFX.dylib` 具名导出 | BGRA、明确 stride |
+| `RendererDevice::createTextureFromNativeBuffer(..., bool, bool, bool, ...)` | `libAGFX.dylib` 具名导出 | flags 必须为 `false,false,true` |
+| `bef_swing_manager_create_with_gpdevice` | `libcccreator.dylib` `0x1664ffc` | manager 必须返回同一 GPDevice |
+| `bef_swing_segment_video_set_device_texture` | `libcccreator.dylib` `0x166fe00` | 只传已验证的 `DeviceTexture` |
+| `SwingTexture::convertMetalTextureInPlace` | `libcccreator.dylib` `0x27a9128` | manager/device 必须匹配 |
+| `bef_swing_manager_seek_frame_device_texture` | `libcccreator.dylib` `0x1665710` | worker 内调用 |
+| `SwingManager::getOrCreateEffectManagerHandle` | `libcccreator.dylib` `0x17e4a70` | 仅证明 manager Effect owner |
+| Amazer context scope ctor/dtor | `0x3fb3bc` / `0x3fb3e8` | 仅限上述 ARM64 UUID 的 research probe |
+
+本轮把同样的链放进一次性、显式 opt-in 的诊断 worker，并用真人 RGBA 输入运行。
+实测结果为：
+
+```text
+Apple M4 Pro Metal GPDevice: created
+manager GPDevice identity: matched
+CVPixelBuffer-backed DeviceTexture: accepted
+Swing seek: returned success
+```
+
+随后通过真实导出
+`AmazingEngine::SwingManager::getOrCreateEffectManagerHandle()` 取得 manager 的
+Effect handle。该方法本身不是猜测偏移：静态调用确认它负责创建/初始化 manager
+拥有的 Effect 实例。
+
+但在该 handle 上读取 object graph 结果全部失败：
+
+```text
+bef_effect_get_bach_result(handle, ..., 198): no BachBuffer
+bef_effect_get_bach_result_by_node_name(
+  handle, "video_saliency_seg_0", ...
+): -1 / null
+bef_effect_get_bach_result_by_graph_and_node_name(
+  handle,
+  "AlgorithmGraph_9bpck63bYbqbZAcfdUcjcAbNdWcf",
+  "video_saliency_seg_0",
+  ...
+): -1 / null
+```
+
+这不是“同设备 texture 仍然没有送达”的证据。相反，同设备输入和 Swing seek
+已经成功；失败原因是结果 owner 不同：Feature/Swing algorithm 的结果不在
+manager 的全局 Effect handle 中，而剪映人物抠像的真实消费者直接持有
+`BachAlgorithmSystem`。
+
+因此现有 Swing V2 probe 的复用判定是：
+
+| 能力 | 是否可复用 | 说明 |
+| --- | --- | --- |
+| Metal GPDevice 创建/销毁 | 是 | 已在固定 UUID 上动态验证 |
+| HTSGLContext / Amazer context 作用域 | 是 | 必须先 bind，且只限隔离进程 |
+| CVPixelBuffer-backed DeviceTexture | 是 | 第三个 native flag 必须为 true |
+| Swing Video/Feature segment 生命周期 | 是 | 适合继续研究普通 Swing 特效 |
+| `ai_matting_video_object` 输入 owner | 否 | 真实入口是 `ITEVideoFrame -> BachAlgorithmInput` |
+| `ai_matting_video_object` 结果 owner | 否 | 真实 owner 是 `BachAlgorithmSystem` |
+| manager Effect handle 的 type 198 | 否 | type/by-node/by-graph 均已动态证伪 |
+
+## 最小安全桥实现
+
+当前 exact 路径采用独立的 `jianying-video-object-bach-bridge`，没有扩展旧 Effect
+bridge 的职责。其进程协议遵循以下最小边界：
+
+### 进程边界
+
+```text
+QCut parent
+  -> spawn isolated worker
+  -> INIT(runtime UUID/hash, graph path, model root, width, height)
+  -> FRAME(index, pts, owned RGBA bytes/FD)
+  <- ALPHA(index, width, height, bytes, diagnostics)
+  <- ERROR(stage, vendor code, recoverable=true)
+```
+
+要求：
+
+- worker 每个任务独立，vendor crash 不影响 Electron；
+- 固定 runtime SHA/UUID、graph SHA、model SHA；
+- 任一符号、尺寸、模型或结果类型不匹配立即退出；
+- parent 保留现有 watchdog、取消、完整帧数校验、坏 Alpha 门禁和 GRU + Vision
+  回退；
+- 只有固定 runtime/model/graph 与 bridge capability 全部匹配才启用；
+- 不共享或缓存 vendor object pointer；只返回 QCut 自有 Alpha bytes。
+
+### 允许绑定的接口层
+
+worker 只绑定已经在固定 UUID 上动态验证的具名 C++ 导出：
+
+1. `TEEffectConfig::getInstance/setExternalFinder`；
+2. `TECVPixelBufferFrame` 官方 ctor/dtor 与 `storeCVPixelBuffer`；
+3. `TEBachMattingAlgorithm` 官方 ctor/dtor；
+4. `initBach`、`AIMattingInternal`、`getMaskAndBoundingBox`。
+
+固定版 layout 为 frame object `0x2c8`、matting object `0x388`、
+`VEMattingTypeParam` `0xa0`（graph path `+0x20`、model type `+0x68`）。
+只有 dylib SHA 和 LC_UUID 同时匹配才允许使用；其他版本直接不可用。
+
+禁止：
+
+- 直接调用 vtable `+0x78`；
+- 读取 `FeatureSegment + guessedOffset` 或 `SwingAlgorithmV2 + guessedOffset`；
+- 伪造 `ITEVideoFrame` vtable；
+- 把 manager Effect handle 当成 per-graph result owner；
+- 默认启用私有 AB/renderer 开关；
+- 失败时写入缓存或把空/量化噪声标成成功。
+
+### 固定 D634 路径的 blocker 状态
+
+此前的 `BachAlgorithmInput/BachImageBuffer/BachInitConfig` 聚合类型 blocker 已被
+真实 wrapper 的更高层入口绕开：worker 不自行构造这些对象，而是用匹配 UUID 中的
+`TECVPixelBufferFrame` 具名构造器和 `storeCVPixelBuffer` 交付 CVPixelBuffer，随后
+让 `TEBachMattingAlgorithm::AIMattingInternal` 在 vendor runtime 内部构造并执行
+`BachAlgorithmInput`。结果也由具名 `getMaskAndBoundingBox` 返回，不读取
+`BachAlgorithmSystem` vtable 或 graph result 私有容器。
+
+固定版入口已经动态完成同一真人素材的连续两帧：模型解析为 type 198
+`video_saliency_seg_bce`。下面是接入 vendor V2 外层之前、仍使用 QCut resize 的历史
+bridge 日志；它保留用于证明 Bach 时序，不代表当前 route 或 source-size 算法：
+
+```text
+progress frame=1 total=2
+progress frame=2 total=2
+ok width=360 height=640 frames=2 route=video-object-jianying-bach-d634-v1
+```
+
+同一进程内注入的只读 CoreML hook 还证明：首帧两个 previous tensor 全零；第二帧
+`prev_img` 与首帧 `data` 逐字节相同，第二帧 `prev_mask` 与首帧 ByteCoreML
+`nn_3` 逐字节相同。完整 capture、SHA 和日志见
+[人物抠像差距收敛记录](person-cutout-gap-reduction-2026-08-28.zh.md#两帧-temporal-capture)。
+
+因此，对这个固定 SHA/UUID 的 exact Bach provider，输入 ABI、模型执行、结果读取和
+跨帧状态都已不再构成 blocker。仍然不支持的是跨版本 ABI：frame/matting object size、
+`VEMattingTypeParam` layout 或导出集合任一变化，都必须拒绝该 exact provider，而不是
+尝试兼容或猜测。独立 same-model CoreML runner 继续作为不依赖私有 runtime 的
+fallback；它的 source→256 输入已收敛到最大 `1/255` 的残差，但仍不冒充 Bach
+bit-exact。
+
+这里必须区分两层 Alpha：
+
+1. `raw Bach mask` 是 packed graph 的原生 `256×256` u8 结果；
+2. 产品 `source-size Alpha` 是 raw mask 经固定版 `TEMattingBlendEffectV2`
+   `FastBlend` 与源 RGBA 合成后，从源尺寸输出纹理回读的 Alpha。
+
+默认参数或显式 `0.5 0 0 0` 会直接返回第二层结果，不调用 `refineAlpha`，避免
+浮点回转。非默认高级参数才进入 QCut refinement，并由上层使用不同的
+provider/pipeline/cache identity。V2 输出 Alpha 包含源 RGBA Alpha，即透明源像素不会
+被 Mask 重新变为不透明；低分辨率路径还门禁 `outputAlpha <= sourceAlpha`。
+
+### 原生 V2 外层已接入
+
+同一真人首帧、同一 raw `256×256 saliency_mask` 下，旧 QCut 双线性与 vendor V2
+源尺寸 Alpha 仅有 `1840/230400` 像素相差 `1`，u8 MAE `0.007986`、最大误差
+`1`、soft IoU `0.99999355`。vendor V2 结果相对剪映黑白背景代理的 u8 MAE 为
+`1.877075`，旧 QCut resize 为 `1.878021`；代理还包含导出/重建误差，不能把该数值
+当作内部 raw truth，但方向与宿主链一致。
+
+产品 helper 现在逐帧执行：
+
+```text
+source RGBA -> Bach packed graph -> raw 256 mask
+  -> TEMattingBlendEffectV2 FastBlend -> source-size RGBA
+  -> extract source-size Alpha
+  -> optional QCut advanced refinement
+```
+
+route 为 `video-object-jianying-bach-v2-exact-d634-v1`，blend identity 为
+`TEMattingBlendEffectV2-vendor-exact`。默认 refinement identity 是
+`vendor-v2-exact-no-qcut-refinement-v1`；非默认参数则是
+`qcut-alpha-refinement-after-vendor-v2-v1`。运行时闭包 identity 是
+`jianying-runtime-framework-closure-d634-v1-e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e`。
+resolver 同时要求 route、blend、默认/高级 refinement、闭包、主库/graph/model
+固定值；旧 bridge marker 因 resolver marker 与源码 fingerprint 同时变化而失效，
+不能被误认为新能力。
+
+worker 每帧在 Bach 前恢复 Engine GL context，V2 自己在合成前恢复其 CGL/RL
+context。销毁顺序由声明顺序固定为：先销毁 V2 纹理/Effect/RL context，再用
+noexcept restorer 恢复 Engine context，最后销毁 Bach session；context 恢复失败会
+直接终止隔离 helper，让 parent watchdog/fallback 接管，不会在错误 context 上静默析构。
+库使用 `RTLD_GLOBAL`，因为固定版 V2/RLDevice 内部会跨其依赖图解析 Effect/AGFX
+符号；该扩大只存在于独立 helper 进程内，且 `dlopen` 前已经逐 SHA 校验完整 23
+个私有 Framework dylib，而不是只检查会直接参与数值计算的六个库。
+
+source Alpha 边界不只做了纯函数单测：把同一真人首帧的所有源 Alpha 固定为 `64`
+后，真实 V2 输出范围为 `0..64`，`230400` 个像素中没有一个
+`outputAlpha > sourceAlpha`。输入 SHA-256 为
+`5e9ffe9e92dd5eb5a56147aae7d84c4f17ceda990b6c1ec3729eee1cd43ef5bf`，
+输出 Alpha SHA-256 为
+`ae06c9597f7d2e85024858862aad8939610a74f96ffc4ee2d85e20af017c39e2`。
+同一 Alpha=64 输入再启用非默认 `0.6 0.2 1 2`，advanced 输出仍有 `0`
+个越界像素；本例阈值后全零，SHA-256 为
+`2a589ae1f2fa2a6328223ff195a29c9244bec633dca49139f6f231e1d79c0eb2`。
+advanced 最后显式取 `min(refinedAlpha, sourceAlpha)`，不会把半透明/透明源像素
+重新“复活”为更高 Alpha。
+
+最终 full-framework-closure helper 的产品构建产物为
+`/private/tmp/qcut-resolver-built-bach-v2-framework-closure-final`，本次 Mach-O
+SHA-256 为 `5e48a1337b33d52c7319a5ea9f85be3d9c155151568dea437ef1d55083f0a1f1`。
+两帧真人 source-size Alpha 为 `460800` bytes，SHA-256
+`dca0f2912ba0188939737920b18c66834d7354aca7e11b8c906d4effd85f6c3e`；
+它与闭包升级前、第二次运行和显式 `0.5 0 0 0` 全部逐字节一致。
+
+60 帧真人运行产生 `13,824,000` 字节 Alpha，SHA-256 为
+`f1a113fc4b4330e9c405508253848376bf60b6f9b0eddcbddb712abdf0cc7b91`；两次运行
+逐字节一致。相同 raw mask 的旧 QCut resize 输出 SHA-256 为
+`589b1e55c8ec7265b3fc00ab55bb5e4d5ab3009e54602b345324f9553cdd3c8c`，
+两条 60 帧输出只在 `168640/13824000` 像素上相差 `1`，u8 MAE `0.0121991`、
+最大误差 `1`。最终完整闭包门禁版本同机单次 wall-clock 为 vendor V2 `1.10s`、
+旧 CPU resize `0.94s`，相差约 `0.16s`。使用缺失输入、只走 SHA 门禁而不进入
+`dlopen` 的 warm-cache 测量为 `0.61s`；它包含主库、22 个其余 Framework、graph
+和 model 的 SHA 读取。这是一轮本机微基准，不是发布性能承诺。
+
+最终成功日志含完整身份：
+
+```text
+ok width=360 height=640 frames=60 route=video-object-jianying-bach-v2-exact-d634-v1 blend=TEMattingBlendEffectV2-vendor-exact closure=jianying-runtime-framework-closure-d634-v1-e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e refinement=vendor-v2-exact-no-qcut-refinement-v1
+```
+
+流式输入在完成一帧后再收到 1 个残缺字节的故障注入，会先输出第一帧，然后以
+`video-object input ended mid-frame` 返回 1，并完整执行 V2、Engine context、Bach
+三段清理，验证异常路径不会按错误 context 顺序析构。仍未替上层决定 seek、切镜、
+倒放和变速时何时重建 worker。流式 stdout 的 duplicated fd 若在异常路径提前退出，
+会在隔离进程终止时由 OS 回收；这是低严重度的进程内资源寿命问题，不会跨任务保留
+vendor 或文件句柄。
+
+## 可复现命令
+
+普通产品 helper：
+
+```bash
+xcrun clang++ -std=c++20 -fobjc-arc -Wall -Wextra -Werror \
+  -Wno-deprecated-declarations \
+  electron/jianying-person-cutout/native/alpha-refinement.cpp \
+  electron/jianying-person-cutout/native/metal-matting-blend.cpp \
+  electron/jianying-person-cutout/native/video-object-bach-bridge.mm \
+  -framework AppKit -framework OpenGL -framework CoreVideo \
+  -framework CoreFoundation \
+  -o /private/tmp/jianying-video-object-bach-bridge
+```
+
+两帧 tensor capture 复用同一个 worker，只额外编译两个只读 probe：
+
+```bash
+xcrun clang++ -std=c++20 -fobjc-arc -Wall -Wextra -Werror \
+  -Wno-deprecated-declarations -DQCUT_BACH_RESEARCH_CAPTURE \
+  electron/jianying-person-cutout/native/alpha-refinement.cpp \
+  electron/jianying-person-cutout/native/metal-matting-blend.cpp \
+  electron/jianying-person-cutout/native/video-object-bach-bridge.mm \
+  docs/task/jianying-filter-runtime-research/probes/bytecoreml-nn3-capture.mm \
+  -framework AppKit -framework OpenGL -framework CoreVideo \
+  -framework CoreFoundation -framework CoreML -framework Foundation \
+  -o /private/tmp/jianying-video-object-bach-capture-worker
+
+xcrun clang++ -std=c++20 -fobjc-arc -Wall -Wextra -Werror -dynamiclib \
+  -framework CoreML -framework Foundation \
+  docs/task/jianying-filter-runtime-research/probes/coreml-feature-capture.mm \
+  -o /private/tmp/qcut-jy-coreml-feature-capture.dylib
+
+DYLD_LIBRARY_PATH="$FRAMEWORKS" \
+DYLD_INSERT_LIBRARIES=/private/tmp/qcut-jy-coreml-feature-capture.dylib \
+JY_COREML_CAPTURE_DIR="$CAPTURE_DIR" \
+JY_BACH_NN3_CAPTURE_DIR="$CAPTURE_DIR" \
+/private/tmp/jianying-video-object-bach-capture-worker \
+  "$FRAMEWORKS/libcccreator.dylib" "$GRAPH_DIR" "$PACKED_MODEL" \
+  "$RGBA" 360 640 "$ALPHA"
+```
+
+worker 需要在独立进程并允许 macOS GPU/OpenGL context 的环境运行。文件系统
+sandbox 内无法创建 context 时是环境失败，不是模型失败。
+
+## 上线前验证门禁
+
+固定 D634 exact provider 已完成第 1、2、3、5、6、7、8、9、10 项；第 4 项中的连续帧与取消已有测试，seek、切镜和倒放仍作为宿主策略的后续覆盖项。最新真人 Electron E2E 为 `1/1 passed (22.1s)`，首轮执行 Bach+vendor V2、第二轮命中独立新缓存，两轮均无 fallback，并已生成三张桌面截图和白底左右对比。详情见 [固定版同算法验收](./jianying-person-cutout-exact-bach-v2-2026-08-28.zh.md)。
+
+exact Bach worker 与 direct same-model fallback 上线均至少要求：
+
+1. 固定真人片段，剪映与 QCut 同帧 raw Alpha 对齐；
+2. 校验 raw `256×256 saliency_mask`、回到源尺寸后的 soft Alpha 和方向；
+3. 检查近景人脸、头发、身体边缘，不只看非零像素数；
+4. 首帧、连续帧、seek、切镜、倒放和取消；
+5. 模型缺失、finder 失败、空结果、坏尺寸、vendor crash 和 watchdog；
+6. 合法全零蒙版与 hostless `0/1/2` 噪声必须可区分；
+7. 缓存只在完整帧数、内容哈希和 Alpha 质量均通过后提交；
+8. helper 编译使用 `-Wall -Wextra -Werror`，并验证打包后的 runtime/symbol
+   capability；
+9. 真实 Electron E2E、截图和白底左右对比；
+10. 任一失败自动回退，不改变用户默认人物抠像可用性。
+
+## 本轮保留与未保留
+
+保留：
+
+- 本文静态调用链、动态 tensor/result 结果和安全接口设计；
+- 既有 Swing V2 research probe；
+- 固定 SHA/UUID 的独立 `jianying-video-object-bach-bridge`；
+- compile resolver、原子发布单测和 CoreML/ByteCoreML capture probes；
+- 当前产品已有的隔离、watchdog、Alpha 质量门禁和回退链。
+
+未保留：
+
+- 临时 Swing-device-to-Effect 产品接线；
+- manager Effect handle 的 type 198/by-node/by-graph 读取；
+- vendor dylib、模型、graph、真人帧、捕获 tensor 和完整运行日志。
+
+仓库不保存剪映 dylib、模型、真人输入或完整 vendor 日志。

--- a/qcut/electron/__tests__/cli-filter-lab-render.test.ts
+++ b/qcut/electron/__tests__/cli-filter-lab-render.test.ts
@@ -1,0 +1,267 @@
+// @vitest-environment node
+import {
+	link,
+	mkdtemp,
+	readFile,
+	readdir,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { JianyingFilterCatalogCard } from "../jianying-filter-catalog-export.js";
+import {
+	handleFilterLabRender,
+	type FilterLabRenderDependencies,
+} from "../native-pipeline/cli/cli-handlers-filter-lab-render.js";
+import type { CLIRunOptions } from "../native-pipeline/cli/cli-runner/types.js";
+import type { FilterLabRenderPlan } from "../native-pipeline/filters/filter-lab-render-plan.js";
+
+const card: JianyingFilterCatalogCard = {
+	resourceId: "123",
+	title: "Test LUT",
+	version: "v1",
+	categories: [],
+	available: true,
+	cacheStatus: "cached",
+	implementation: "single-lut",
+	lutCount: 1,
+	verification: "unverified",
+};
+const media = {
+	width: 64,
+	height: 48,
+	duration: 2,
+	frameRate: 24,
+	hasAudio: true,
+};
+const plan: FilterLabRenderPlan = {
+	kind: "ffmpeg",
+	filterGraph: "[0:v]null[out]",
+	outputLabel: "out",
+	evidence: {
+		resourceId: "123",
+		title: "Test LUT",
+		version: "v1",
+		implementation: "single-lut",
+		verification: "unverified",
+		intensity: 100,
+		backend: "ffmpeg-lut",
+		fidelity: "lut",
+	},
+};
+let directory: string;
+let options: CLIRunOptions;
+let deps: FilterLabRenderDependencies;
+
+beforeEach(async () => {
+	directory = await mkdtemp(join(tmpdir(), "qcut-filter-render-test-"));
+	options = {
+		command: "filter-lab-render",
+		input: join(directory, "input.png"),
+		output: join(directory, "output.png"),
+		resourceId: "123",
+		outputDir: directory,
+		json: true,
+		quiet: true,
+		verbose: false,
+		saveIntermediates: false,
+	};
+	await writeFile(options.input!, "source");
+	deps = {
+		exportCatalog: vi.fn(async () => ({ count: 1, cards: [card] })),
+		resolvePlan: vi.fn(async () => plan),
+		probe: vi.fn(async () => media),
+		render: vi.fn(async ({ output }) => {
+			await writeFile(output, "rendered");
+		}),
+	};
+});
+afterEach(async () => {
+	await rm(directory, { recursive: true, force: true });
+});
+
+function run({
+	overrides = {},
+	dependencies = {},
+}: {
+	overrides?: Partial<CLIRunOptions>;
+	dependencies?: Partial<FilterLabRenderDependencies>;
+} = {}) {
+	return handleFilterLabRender({
+		options: { ...options, ...overrides },
+		onProgress: vi.fn(),
+		signal: new AbortController().signal,
+		dependencies: { ...deps, ...dependencies },
+	});
+}
+
+describe("filter-lab render CLI", () => {
+	it("publishes verified media with renderer metadata and cleans staging files", async () => {
+		const result = await run();
+		expect(result).toMatchObject({
+			success: true,
+			outputPath: options.output,
+			data: { filter: plan.evidence, frameRateMode: "still" },
+		});
+		expect(await readFile(options.output!, "utf8")).toBe("rendered");
+		expect(await readdir(directory)).toEqual(["input.png", "output.png"]);
+	});
+
+	it.each([
+		[{ resourceId: undefined }, "--resource-id"],
+		[{ resourceId: "../123" }, "--resource-id"],
+		[{ resourceIds: ["123", "456"] }, "one --resource-id"],
+		[{ input: undefined }, "--input"],
+		[{ filterIntensity: Number.NaN }, "--filter-intensity"],
+		[{ filterIntensity: 101 }, "--filter-intensity"],
+		[{ duration: "oops" }, "--duration"],
+		[{ duration: "-1" }, "--duration"],
+		[{ fps: 0 }, "--fps"],
+		[{ fps: 121 }, "--fps"],
+		[{ duration: "1" }, "only to video"],
+		[{ output: "result.mp4" }, ".png"],
+	] as Array<
+		[Partial<CLIRunOptions>, string]
+	>)("rejects bad flags %j", async (overrides, message) => {
+		const result = await run({ overrides });
+		expect(result.success).toBe(false);
+		expect(result.error).toContain(message);
+		expect(deps.render).not.toHaveBeenCalled();
+	});
+
+	it("does not unlock cached-but-unsupported cards", async () => {
+		const result = await run({
+			dependencies: {
+				exportCatalog: async () => ({
+					count: 1,
+					cards: [{ ...card, available: false, implementation: "face-ai" }],
+				}),
+			},
+		});
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("not supported");
+		expect(deps.resolvePlan).not.toHaveBeenCalled();
+	});
+
+	it("rejects an unknown card or a mismatched version", async () => {
+		expect((await run({ overrides: { resourceId: "999" } })).error).toContain(
+			"not in the local catalog"
+		);
+		expect(
+			(await run({ overrides: { filterVersion: "old" } })).error
+		).toContain("--filter-version");
+		expect(deps.render).not.toHaveBeenCalled();
+	});
+
+	it("protects source files, hard links, and symlinks even with force", async () => {
+		expect(
+			(await run({ overrides: { output: options.input, force: true } })).error
+		).toContain("overwrite the input");
+		const alias = join(directory, "alias.png");
+		await link(options.input!, alias);
+		expect(
+			(await run({ overrides: { output: alias, force: true } })).error
+		).toContain("overwrite the input");
+		const symbolic = join(directory, "symlink.png");
+		await symlink(options.input!, symbolic);
+		expect(
+			(await run({ overrides: { output: symbolic, force: true } })).error
+		).toContain("symlink");
+		expect(await readFile(options.input!, "utf8")).toBe("source");
+	});
+
+	it("leaves an existing output unchanged on failure, even with force", async () => {
+		await writeFile(options.output!, "original");
+		expect((await run()).error).toContain("--force");
+		const result = await run({
+			overrides: { force: true },
+			dependencies: {
+				render: async ({ output }) => {
+					await writeFile(output, "partial");
+					throw new Error("render failed");
+				},
+			},
+		});
+		expect(result.error).toBe("render failed");
+		expect(await readFile(options.output!, "utf8")).toBe("original");
+		expect(
+			(await readdir(directory)).some((name) =>
+				name.startsWith(".qcut-filter-")
+			)
+		).toBe(false);
+	});
+
+	it("does not overwrite a new file that appears while rendering", async () => {
+		const result = await run({
+			dependencies: {
+				render: async ({ output }) => {
+					await writeFile(output, "rendered");
+					await writeFile(options.output!, "external");
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		expect(await readFile(options.output!, "utf8")).toBe("external");
+	});
+
+	it("validates dry runs without producing an output", async () => {
+		const result = await run({ overrides: { dryRun: true } });
+		expect(result).toMatchObject({
+			success: true,
+			data: { dryRun: true, filter: plan.evidence },
+		});
+		expect(deps.render).not.toHaveBeenCalled();
+		expect(await readdir(directory)).toEqual(["input.png"]);
+	});
+
+	it("keeps audio and duration for video, and supports a shorter preview", async () => {
+		const input = join(directory, "input.mp4");
+		await writeFile(input, "video");
+		const probe = vi
+			.fn()
+			.mockResolvedValueOnce(media)
+			.mockResolvedValueOnce({ ...media, duration: 1, frameRate: 12 });
+		const result = await run({
+			overrides: {
+				input,
+				output: join(directory, "output.mp4"),
+				duration: "1",
+				fps: 12,
+			},
+			dependencies: { probe },
+		});
+		expect(result).toMatchObject({
+			success: true,
+			data: { frameRateMode: "cfr", audioPreserved: true },
+		});
+		expect(deps.render).toHaveBeenCalledWith(
+			expect.objectContaining({
+				media: { ...media, duration: 1, frameRate: 12 },
+			})
+		);
+	});
+
+	it.each([
+		[{ ...media, width: 60 }, "dimensions"],
+		[{ ...media, duration: 1 }, "duration"],
+		[{ ...media, hasAudio: false }, "audio"],
+		[{ ...media, frameRate: 30 }, "frame rate"],
+	])("refuses to publish invalid video output %j", async (outputMedia, message) => {
+		const input = join(directory, "input.mp4");
+		await writeFile(input, "video");
+		const probe = vi
+			.fn()
+			.mockResolvedValueOnce(media)
+			.mockResolvedValueOnce(outputMedia);
+		const result = await run({
+			overrides: { input, output: join(directory, "output.mp4") },
+			dependencies: { probe },
+		});
+		expect(result.success).toBe(false);
+		expect(result.error).toContain(message);
+		expect((await readdir(directory)).includes("output.mp4")).toBe(false);
+	});
+});

--- a/qcut/electron/__tests__/filter-lab-frame-stream.test.ts
+++ b/qcut/electron/__tests__/filter-lab-frame-stream.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it, vi } from "vitest";
+import { createFilterLabFrameStream } from "../native-pipeline/filters/filter-lab-frame-stream.js";
+
+async function renderChunks({
+	chunks,
+	renderFrame,
+}: {
+	chunks: Buffer[];
+	renderFrame: (input: { rgba: Buffer; index: number }) => Promise<Uint8Array>;
+}) {
+	const outputs: Buffer[] = [];
+	await pipeline(
+		Readable.from(chunks),
+		createFilterLabFrameStream({ frameBytes: 8, renderFrame }),
+		new Writable({
+			write(chunk: Buffer, _encoding, callback) {
+				outputs.push(chunk);
+				callback();
+			},
+		})
+	);
+	return Buffer.concat(outputs);
+}
+
+describe("Filter Lab RGBA stream", () => {
+	it("reassembles split frames and serializes tracker calls", async () => {
+		let active = 0;
+		let maxActive = 0;
+		const indices: number[] = [];
+		const bytes = Buffer.from(Array.from({ length: 24 }, (_, index) => index));
+		const output = await renderChunks({
+			chunks: [
+				bytes.subarray(0, 3),
+				bytes.subarray(3, 5),
+				bytes.subarray(5, 24),
+			],
+			renderFrame: async ({ rgba, index }) => {
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				indices.push(index);
+				await Promise.resolve();
+				active -= 1;
+				return rgba;
+			},
+		});
+		expect(output).toEqual(bytes);
+		expect(indices).toEqual([0, 1, 2]);
+		expect(maxActive).toBe(1);
+	});
+
+	it("rejects incomplete and empty frame streams", async () => {
+		const renderFrame = async ({ rgba }: { rgba: Buffer }) => rgba;
+		await expect(
+			renderChunks({ chunks: [Buffer.alloc(9)], renderFrame })
+		).rejects.toThrow("incomplete");
+		await expect(renderChunks({ chunks: [], renderFrame })).rejects.toThrow(
+			"No frames"
+		);
+	});
+
+	it("rejects an invalid native result before publishing it", async () => {
+		await expect(
+			renderChunks({
+				chunks: [Buffer.alloc(8)],
+				renderFrame: async () => Buffer.alloc(4),
+			})
+		).rejects.toThrow("invalid frame size");
+	});
+
+	it("stops after a failed native frame", async () => {
+		const renderFrame = vi.fn(async () => {
+			throw new Error("native failed");
+		});
+		await expect(
+			renderChunks({ chunks: [Buffer.alloc(24)], renderFrame })
+		).rejects.toThrow("native failed");
+		expect(renderFrame).toHaveBeenCalledTimes(1);
+	});
+});

--- a/qcut/electron/__tests__/filter-lab-render-plan.test.ts
+++ b/qcut/electron/__tests__/filter-lab-render-plan.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { JianyingFilterCatalogCard } from "../jianying-filter-catalog-export.js";
 import { inspectJianyingFilterPackages } from "../jianying-filter-package-inspector.js";
@@ -178,7 +179,7 @@ describe("Filter Lab render plan", () => {
 		});
 		expect(result.evidence.backend).toBe("ffmpeg-lut");
 		expect(loadTiledLutCube).toHaveBeenCalledWith({
-			filePath: "/private/Cache/artistEffect/123/v1/filter.png",
+			filePath: join("/private/Cache/artistEffect", "123", "v1", "filter.png"),
 		});
 		expect(loadJianyingLut).not.toHaveBeenCalled();
 	});
@@ -215,7 +216,7 @@ describe("Filter Lab render plan", () => {
 		expect(result).toMatchObject({
 			kind: "native",
 			mode: "portrait",
-			packagePath: "/private/Cache/artistEffect/123/v1",
+			packagePath: join("/private/Cache/artistEffect", "123", "v1"),
 			evidence: { backend: "jianying-native-portrait", intensity: 50 },
 		});
 		vi.mocked(inspectJianyingFilterLocalRuntime).mockResolvedValue({

--- a/qcut/electron/__tests__/filter-lab-render-plan.test.ts
+++ b/qcut/electron/__tests__/filter-lab-render-plan.test.ts
@@ -1,0 +1,289 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { JianyingFilterCatalogCard } from "../jianying-filter-catalog-export.js";
+import { inspectJianyingFilterPackages } from "../jianying-filter-package-inspector.js";
+import { inspectJianyingFilterLocalRuntime } from "../jianying-filter-local-runtime/runtime-discovery.js";
+import { loadJianyingFilterLabRenderer } from "../jianying-filter-multi-pass-loader.js";
+import { materializeVideoCubeLut } from "../ffmpeg/color-lut-file.js";
+import {
+	listJianyingLutReferences,
+	loadJianyingLut,
+} from "../native-pipeline/filters/filter-lab-lut.js";
+import { loadTiledLutCube } from "../native-pipeline/filters/filter-lab-tiled-lut.js";
+import { resolveFilterLabRenderPlan } from "../native-pipeline/filters/filter-lab-render-plan.js";
+
+vi.mock("../jianying-filter-package-inspector.js", () => ({
+	inspectJianyingFilterPackages: vi.fn(),
+}));
+vi.mock("../jianying-filter-local-runtime/runtime-discovery.js", () => ({
+	inspectJianyingFilterLocalRuntime: vi.fn(),
+}));
+vi.mock("../jianying-filter-multi-pass-loader.js", () => ({
+	loadJianyingFilterLabRenderer: vi.fn(),
+}));
+vi.mock("../ffmpeg/color-lut-file.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../ffmpeg/color-lut-file.js")>()),
+	materializeVideoCubeLut: vi.fn(() => "/tmp/synthetic.cube"),
+}));
+vi.mock(
+	"../native-pipeline/filters/filter-lab-lut.js",
+	async (importOriginal) => ({
+		...(await importOriginal<
+			typeof import("../native-pipeline/filters/filter-lab-lut.js")
+		>()),
+		jianyingFilterCacheRoots: () => ["/private/Cache/artistEffect"],
+		listJianyingLutReferences: vi.fn(),
+		loadJianyingLut: vi.fn(),
+	})
+);
+vi.mock(
+	"../native-pipeline/filters/filter-lab-tiled-lut.js",
+	async (importOriginal) => ({
+		...(await importOriginal<
+			typeof import("../native-pipeline/filters/filter-lab-tiled-lut.js")
+		>()),
+		loadTiledLutCube: vi.fn(),
+	})
+);
+
+const card: JianyingFilterCatalogCard = {
+	resourceId: "123",
+	title: "Test",
+	version: "v1",
+	categories: [],
+	available: true,
+	cacheStatus: "cached",
+	implementation: "single-lut",
+	verification: "unverified",
+	lutCount: 1,
+};
+const reference = {
+	resourceId: "123",
+	version: "v1",
+	role: "single" as const,
+	lutId: "123/v1/filter.cube.vf",
+	fileName: "filter.cube.vf",
+	filePath: "/private/Cache/artistEffect/123/v1/filter.cube.vf",
+	size: 2,
+};
+const cube = { size: 2, values: new Float64Array(24) };
+const packageSummary = {
+	cacheStatus: "cached" as const,
+	implementation: "single-lut" as const,
+	versions: ["v1"],
+	hasThumbnail: false,
+	issues: [],
+};
+const tiled = {
+	kind: "tiled-lut-8x8" as const,
+	container: "artistEffect" as const,
+	packageIdentifier: "123",
+	version: "v1",
+	relativePath: "filter.png",
+	cubeSize: 64 as const,
+};
+const runtime = {
+	status: {
+		state: "ready" as const,
+		message: "ready",
+		provider: "jianying-local-effect-v1" as const,
+		platform: "darwin",
+		bridgeReady: true,
+		runtimeReady: true,
+		modelReady: true,
+		offlineReady: true,
+		runtimeSource: "qcut-private" as const,
+		modelSource: "qcut-private" as const,
+	},
+	bridgePath: "/private/bridge",
+	effectLibraryPath: "/private/lib",
+	frameworkDirectory: "/private/framework",
+	modelDirectory: "/private/model",
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(listJianyingLutReferences).mockResolvedValue([reference]);
+	vi.mocked(loadJianyingLut).mockResolvedValue({
+		...reference,
+		cube,
+		chroma: 1,
+	});
+	vi.mocked(inspectJianyingFilterPackages).mockResolvedValue(
+		new Map([["123", packageSummary]])
+	);
+	vi.mocked(inspectJianyingFilterLocalRuntime).mockResolvedValue(runtime);
+	vi.mocked(loadTiledLutCube).mockResolvedValue(cube);
+});
+
+describe("Filter Lab render plan", () => {
+	it("uses the shared LUT materializer and export interpolation", async () => {
+		const result = await resolveFilterLabRenderPlan({ card, intensity: 35 });
+		expect(result).toMatchObject({
+			kind: "ffmpeg",
+			evidence: {
+				backend: "ffmpeg-lut",
+				intensity: 35,
+				verification: "unverified",
+			},
+		});
+		if (result.kind === "ffmpeg")
+			expect(result.filterGraph).toContain("interp=tetrahedral");
+		expect(materializeVideoCubeLut).toHaveBeenCalledWith(
+			expect.objectContaining({ intensity: 35, skinProtection: 0 })
+		);
+		expect(inspectJianyingFilterLocalRuntime).not.toHaveBeenCalled();
+	});
+
+	it("bypasses LUT interpolation at zero strength after validating its bytes", async () => {
+		const result = await resolveFilterLabRenderPlan({ card, intensity: 0 });
+		expect(result).toMatchObject({
+			kind: "ffmpeg",
+			filterGraph: "[0:v:0]null[filter_output]",
+			evidence: { backend: "ffmpeg-lut", intensity: 0 },
+		});
+		expect(loadJianyingLut).toHaveBeenCalled();
+		expect(materializeVideoCubeLut).not.toHaveBeenCalled();
+	});
+
+	it("does not execute unavailable or stale-version cards", async () => {
+		await expect(
+			resolveFilterLabRenderPlan({
+				card: { ...card, available: false },
+				intensity: 100,
+			})
+		).rejects.toThrow("not available");
+		vi.mocked(listJianyingLutReferences).mockResolvedValue([
+			{ ...reference, version: "old" },
+		]);
+		await expect(
+			resolveFilterLabRenderPlan({ card, intensity: 100 })
+		).rejects.toThrow("no longer loadable");
+		expect(loadJianyingLut).not.toHaveBeenCalled();
+	});
+
+	it("loads shader-backed tiled LUTs instead of treating all shader cards as native graphs", async () => {
+		vi.mocked(listJianyingLutReferences).mockResolvedValue([]);
+		vi.mocked(inspectJianyingFilterPackages).mockResolvedValue(
+			new Map([
+				[
+					"123",
+					{ ...packageSummary, implementation: "shader", renderer: tiled },
+				],
+			])
+		);
+		const result = await resolveFilterLabRenderPlan({
+			card: { ...card, implementation: "shader" },
+			intensity: 100,
+		});
+		expect(result.evidence.backend).toBe("ffmpeg-lut");
+		expect(loadTiledLutCube).toHaveBeenCalledWith({
+			filePath: "/private/Cache/artistEffect/123/v1/filter.png",
+		});
+		expect(loadJianyingLut).not.toHaveBeenCalled();
+	});
+
+	it("rejects unreadable LUT bytes", async () => {
+		vi.mocked(loadJianyingLut).mockResolvedValue(null);
+		await expect(
+			resolveFilterLabRenderPlan({ card, intensity: 100 })
+		).rejects.toThrow("could not be decoded");
+	});
+
+	it("requires real native skin segmentation for a dual LUT", async () => {
+		vi.mocked(listJianyingLutReferences).mockResolvedValue([]);
+		vi.mocked(inspectJianyingFilterPackages).mockResolvedValue(
+			new Map([
+				[
+					"123",
+					{
+						...packageSummary,
+						implementation: "dual-lut",
+						dualRenderer: {
+							kind: "dual-tiled-lut-8x8",
+							background: { ...tiled, relativePath: "filter_bg.png" },
+							skin: { ...tiled, relativePath: "filter_skin.png" },
+						},
+					},
+				],
+			])
+		);
+		const result = await resolveFilterLabRenderPlan({
+			card: { ...card, implementation: "dual-lut" },
+			intensity: 50,
+		});
+		expect(result).toMatchObject({
+			kind: "native",
+			mode: "portrait",
+			packagePath: "/private/Cache/artistEffect/123/v1",
+			evidence: { backend: "jianying-native-portrait", intensity: 50 },
+		});
+		vi.mocked(inspectJianyingFilterLocalRuntime).mockResolvedValue({
+			...runtime,
+			status: {
+				...runtime.status,
+				state: "model-missing",
+				message: "missing model",
+			},
+		});
+		await expect(
+			resolveFilterLabRenderPlan({ card, intensity: 100 })
+		).rejects.toThrow("missing model");
+		expect(materializeVideoCubeLut).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		false,
+		true,
+	])("preserves multi-pass routing (native=%s)", async (native) => {
+		vi.mocked(listJianyingLutReferences).mockResolvedValue([]);
+		vi.mocked(inspectJianyingFilterPackages).mockResolvedValue(
+			new Map([
+				[
+					"123",
+					{
+						...packageSummary,
+						implementation: "shader",
+						multiPassRenderer: {
+							kind: "fog-lut",
+							container: "artistEffect",
+							packageIdentifier: "123",
+							version: "v1",
+							lutRelativePath: "filter.png",
+							passCount: 2,
+							fidelity: "structural",
+						},
+					},
+				],
+			])
+		);
+		vi.mocked(loadJianyingFilterLabRenderer).mockResolvedValue({
+			resourceId: "123",
+			version: "v1",
+			name: "Test",
+			enabled: true,
+			presetId: "test",
+			intensity: 100,
+			fidelity: native ? "native-local" : "structural",
+			...(native
+				? {
+						nativeEffect: {
+							provider: "jianying-local-effect-v1",
+							resourceId: "123",
+							version: "v1",
+						} as const,
+					}
+				: {}),
+			passes: [{ kind: "sharpen", amount: 20 }],
+		});
+		const result = await resolveFilterLabRenderPlan({
+			card: { ...card, implementation: "shader" },
+			intensity: 50,
+		});
+		expect(result.kind).toBe(native ? "native" : "ffmpeg");
+		expect(result.evidence).toMatchObject({
+			backend: native ? "jianying-native-multi-pass" : "ffmpeg-multi-pass",
+			fidelity: native ? "native-local" : "structural",
+		});
+	});
+});

--- a/qcut/electron/__tests__/filter-lab-tiled-lut.test.ts
+++ b/qcut/electron/__tests__/filter-lab-tiled-lut.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	decodeTiledLutPixels,
+	inspectDualTiledLutRenderer,
 	isSupportedDualTiledLutShader,
 	isSupportedTiledLutImage,
 	isSupportedTiledLutShader,
@@ -14,6 +15,36 @@ import { sampleCube } from "../native-pipeline/filters/filter-lab-lut.js";
 
 const IMAGE_SIZE = 512;
 const CUBE_SIZE = 64;
+
+const NATIVE_SKIN_SEG_DUAL_LUT_SHADER = `
+	precision highp float;
+	varying vec2 uv0;
+	uniform sampler2D inputImageTexture;
+	uniform sampler2D filterBgTexture;
+	uniform sampler2D filterSkinTexture;
+	uniform sampler2D maskTexture;
+	uniform float intensity;
+	vec4 lm_take_effect_filter(sampler2D filterTex, vec4 inputColor, float uniAlpha) {
+		vec4 textureColor = inputColor;
+		float blueColor = textureColor.b * 63.;
+		vec2 texPos1;
+		vec2 texPos2;
+		vec4 newColor1 = texture2D(filterTex, texPos1);
+		vec4 newColor2 = texture2D(filterTex, texPos2);
+		vec4 newColor = mix(newColor1, newColor2, fract(blueColor));
+		return mix(textureColor, vec4(newColor.rgb, textureColor.w), uniAlpha);
+	}
+	void main() {
+		vec2 maskCoord = vec2(uv0.x, 1.0 - uv0.y);
+		float mask = texture2D(maskTexture, maskCoord).a;
+		vec4 color = texture2D(inputImageTexture, uv0);
+		float bgBaseIntensity = 0.8;
+		float skinBaseIntensity = 0.6;
+		vec4 bgResultColor = lm_take_effect_filter(filterBgTexture, color, intensity * bgBaseIntensity);
+		vec4 skinResultColor = lm_take_effect_filter(filterSkinTexture, color, intensity * skinBaseIntensity);
+		gl_FragColor = mix(bgResultColor, skinResultColor, mask);
+	}
+`;
 
 function createIdentityTiledPixels(): Uint8Array {
 	const pixels = new Uint8Array(IMAGE_SIZE * IMAGE_SIZE * 3);
@@ -75,6 +106,78 @@ describe("Jianying tiled LUT renderer", () => {
 				source: source.replace("mask.a", "0.5"),
 			})
 		).toBe(false);
+	});
+
+	it("recognizes the native skin-seg dual LUT shader without accepting a global mix", () => {
+		expect(
+			isSupportedDualTiledLutShader({
+				source: NATIVE_SKIN_SEG_DUAL_LUT_SHADER,
+			})
+		).toBe(true);
+		expect(
+			isSupportedDualTiledLutShader({
+				source: NATIVE_SKIN_SEG_DUAL_LUT_SHADER.replace(
+					"texture2D(maskTexture, maskCoord).a",
+					"0.5"
+				),
+			})
+		).toBe(false);
+	});
+
+	it("requires a skin-seg graph and Lua mask binding for the native shader family", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "qcut-dual-skin-seg-"));
+		try {
+			const imageDirectory = join(directory, "AmazingFeature", "image");
+			const shaderDirectory = join(directory, "AmazingFeature", "xshader");
+			const luaDirectory = join(directory, "AmazingFeature", "lua");
+			await Promise.all([
+				mkdir(imageDirectory, { recursive: true }),
+				mkdir(shaderDirectory, { recursive: true }),
+				mkdir(luaDirectory, { recursive: true }),
+			]);
+			const paths = [
+				"algorithmConfig.json",
+				"AmazingFeature/image/filter_bg.png",
+				"AmazingFeature/image/filter_skin.png",
+				"AmazingFeature/xshader/quad.frag",
+				"AmazingFeature/lua/TempScriptLua.lua",
+			];
+			await Promise.all([
+				writeFile(
+					join(directory, paths[0]),
+					JSON.stringify({ nodes: [{ type: "skin_seg" }] })
+				),
+				writeFile(join(directory, paths[1]), createPngHeader()),
+				writeFile(join(directory, paths[2]), createPngHeader()),
+				writeFile(join(directory, paths[3]), NATIVE_SKIN_SEG_DUAL_LUT_SHADER),
+				writeFile(
+					join(directory, paths[4]),
+					`local segInfo = result:getSkinSegInfo()
+					local mask = segInfo.data
+					local tex = material:getTex("maskTexture")
+					tex:storage(mask)
+					material:setFloat("intensity", intensity)`
+				),
+			]);
+			const inspect = () =>
+				inspectDualTiledLutRenderer({
+					container: "artistEffect",
+					identifier: "dual-filter",
+					version: "v1",
+					root: directory,
+					paths,
+				});
+			await expect(inspect()).resolves.toMatchObject({
+				kind: "dual-tiled-lut-8x8",
+			});
+			await writeFile(
+				join(directory, paths[4]),
+				'material:setFloat("intensity", intensity)'
+			);
+			await expect(inspect()).resolves.toBeNull();
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
 	});
 
 	it("decodes red-fastest cube values from the 8x8 tile layout", () => {

--- a/qcut/electron/__tests__/person-cutout-abort.test.ts
+++ b/qcut/electron/__tests__/person-cutout-abort.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	throwIfPersonCutoutAborted,
+	waitForPersonCutoutPromise,
+} from "../jianying-person-cutout/abort.js";
+
+function deferred<Result>() {
+	let resolve!: (value: Result) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<Result>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, reject, resolve };
+}
+
+describe("person cutout cancellation", () => {
+	it("stops one subscriber without cancelling a shared build", async () => {
+		const shared = deferred<string>();
+		const firstController = new AbortController();
+		const secondController = new AbortController();
+		const first = waitForPersonCutoutPromise({
+			promise: shared.promise,
+			signal: firstController.signal,
+		});
+		const second = waitForPersonCutoutPromise({
+			promise: shared.promise,
+			signal: secondController.signal,
+		});
+
+		firstController.abort();
+		await expect(first).rejects.toMatchObject({ name: "AbortError" });
+		shared.resolve("cached-alpha");
+		await expect(second).resolves.toBe("cached-alpha");
+	});
+
+	it("does not attach to a build after cancellation", async () => {
+		const then = vi.fn();
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			waitForPersonCutoutPromise({
+				promise: { then } as unknown as Promise<string>,
+				signal: controller.signal,
+			})
+		).rejects.toMatchObject({ name: "AbortError" });
+		expect(then).not.toHaveBeenCalled();
+		expect(() =>
+			throwIfPersonCutoutAborted({ signal: controller.signal })
+		).toThrow(expect.objectContaining({ name: "AbortError" }));
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-alpha-refinement.test.ts
+++ b/qcut/electron/__tests__/person-cutout-alpha-refinement.test.ts
@@ -1,0 +1,44 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const describeOnMac = process.platform === "darwin" ? describe : describe.skip;
+let temporaryDirectory = "";
+
+describeOnMac("person cutout alpha refinement", () => {
+	beforeAll(async () => {
+		temporaryDirectory = await mkdtemp(
+			path.join(os.tmpdir(), "qcut-alpha-refinement-test-")
+		);
+	});
+
+	afterAll(async () => {
+		if (!temporaryDirectory) return;
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	});
+
+	it("keeps parity defaults and applies advanced controls", async () => {
+		const nativeDirectory = path.resolve(
+			"electron",
+			"jianying-person-cutout",
+			"native"
+		);
+		const executablePath = path.join(temporaryDirectory, "alpha-refinement-test");
+		await execFileAsync("xcrun", [
+			"clang++",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			path.join(nativeDirectory, "alpha-refinement.cpp"),
+			path.join(nativeDirectory, "alpha-refinement.test.cpp"),
+			"-o",
+			executablePath,
+		]);
+		await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-alpha-refinement.test.ts
+++ b/qcut/electron/__tests__/person-cutout-alpha-refinement.test.ts
@@ -27,7 +27,10 @@ describeOnMac("person cutout alpha refinement", () => {
 			"jianying-person-cutout",
 			"native"
 		);
-		const executablePath = path.join(temporaryDirectory, "alpha-refinement-test");
+		const executablePath = path.join(
+			temporaryDirectory,
+			"alpha-refinement-test"
+		);
 		await execFileAsync("xcrun", [
 			"clang++",
 			"-std=c++20",

--- a/qcut/electron/__tests__/person-cutout-bridge-timing.test.ts
+++ b/qcut/electron/__tests__/person-cutout-bridge-timing.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { parsePersonCutoutBridgeTiming } from "../jianying-person-cutout/bridge-timing.js";
+
+const validTiming = {
+	schema: 1,
+	frames: 60,
+	total_us: 2_010_000,
+	wall_us: 2_010_000,
+	setup_us: 100_000,
+	processing_us: 1_900_000,
+	teardown_us: 10_000,
+	input_read_us: 20_000,
+	rgba_to_bgr_us: 15_000,
+	gru_infer_us: 700_000,
+	alpha_resize_us: 10_000,
+	vision_infer_us: 800_000,
+	postprocess_us: 100_000,
+	native_validation_us: 25_000,
+	native_canary_us: 25_000,
+	cache_write_us: 5_000,
+	output_flush_us: 1_000,
+	native_validation_frames: 1,
+	native_canary_frames: 1,
+};
+
+describe("person cutout bridge timing", () => {
+	it("parses one versioned timing record", () => {
+		expect(
+			parsePersonCutoutBridgeTiming({
+				line: `qcut-person-cutout-timing ${JSON.stringify(validTiming)}`,
+			})
+		).toEqual({
+			alphaResizeMicros: 10_000,
+			cacheWriteMicros: 5_000,
+			frameCount: 60,
+			gruInferenceMicros: 700_000,
+			inputReadMicros: 20_000,
+			nativeCanaryFrames: 1,
+			nativeCanaryMicros: 25_000,
+			outputFlushMicros: 1_000,
+			postprocessMicros: 100_000,
+			processingMicros: 1_900_000,
+			rgbaToBgrMicros: 15_000,
+			setupMicros: 100_000,
+			teardownMicros: 10_000,
+			totalMicros: 2_010_000,
+			visionInferenceMicros: 800_000,
+			wallMicros: 2_010_000,
+		});
+	});
+
+	it("keeps parsing the version-one timing aliases", () => {
+		expect(
+			parsePersonCutoutBridgeTiming({
+				line: `qcut-person-cutout-timing ${JSON.stringify({
+					...validTiming,
+					native_canary_frames: undefined,
+					native_canary_us: undefined,
+					output_flush_us: undefined,
+					teardown_us: undefined,
+					wall_us: undefined,
+				})}`,
+			})
+		).toMatchObject({
+			nativeCanaryFrames: 1,
+			nativeCanaryMicros: 25_000,
+			outputFlushMicros: 0,
+			teardownMicros: 0,
+			wallMicros: 2_010_000,
+		});
+	});
+
+	it("rejects unrelated, malformed, and impossible timing records", () => {
+		expect(
+			parsePersonCutoutBridgeTiming({ line: "progress frame=1 total=2" })
+		).toBeNull();
+		expect(
+			parsePersonCutoutBridgeTiming({ line: "qcut-person-cutout-timing {" })
+		).toBeNull();
+		expect(
+			parsePersonCutoutBridgeTiming({
+				line: `qcut-person-cutout-timing ${JSON.stringify({
+					...validTiming,
+					processing_us: 2_010_001,
+				})}`,
+			})
+		).toBeNull();
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-frame-count.test.ts
+++ b/qcut/electron/__tests__/person-cutout-frame-count.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+	resolvePersonCutoutFrameCountExpectation,
+	validatePersonCutoutAlphaFrameCount,
+} from "../jianying-person-cutout/frame-count.js";
+
+describe("person cutout frame count", () => {
+	it("prefers the counted frame total and validates it exactly", () => {
+		const expectation = resolvePersonCutoutFrameCountExpectation({
+			declaredFrames: "59",
+			duration: 2,
+			frameRate: 30,
+			readFrames: "60",
+		});
+
+		expect(expectation).toEqual({
+			count: 60,
+			source: "counted",
+			tolerance: 0,
+		});
+		expect(() =>
+			validatePersonCutoutAlphaFrameCount({
+				actualFrameCount: 59,
+				expectation,
+			})
+		).toThrow("人物蒙版帧数不完整");
+	});
+
+	it("uses a valid declared count when frame counting is unavailable", () => {
+		expect(
+			resolvePersonCutoutFrameCountExpectation({
+				declaredFrames: "42",
+				duration: 1.4,
+				frameRate: 30,
+				readFrames: "N/A",
+			})
+		).toEqual({ count: 42, source: "declared", tolerance: 0 });
+	});
+
+	it("allows one-frame container rounding only for an estimate", () => {
+		const expectation = resolvePersonCutoutFrameCountExpectation({
+			declaredFrames: "N/A",
+			duration: 2,
+			frameRate: 30,
+			readFrames: "N/A",
+		});
+
+		expect(expectation).toEqual({
+			count: 60,
+			source: "estimated",
+			tolerance: 1,
+		});
+		expect(() =>
+			validatePersonCutoutAlphaFrameCount({
+				actualFrameCount: 59,
+				expectation,
+			})
+		).not.toThrow();
+		expect(() =>
+			validatePersonCutoutAlphaFrameCount({
+				actualFrameCount: 58,
+				expectation,
+			})
+		).toThrow("人物蒙版帧数不完整");
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-inference-pipeline.test.ts
+++ b/qcut/electron/__tests__/person-cutout-inference-pipeline.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { executePersonCutoutInferencePipeline } from "../jianying-person-cutout/inference-pipeline.js";
+
+const exactRuntime = {
+  modelRoute: "video-object" as const,
+  provider: "bach-exact",
+};
+const directRuntime = {
+  modelRoute: "video-object" as const,
+  provider: "coreml-direct",
+};
+const portraitRuntime = {
+  modelRoute: "portrait-gru" as const,
+  provider: "gru",
+};
+
+describe("person cutout inference finalization", () => {
+  it("finalizes only after selecting a successful provider", async () => {
+    const executeInference = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("exact unavailable"))
+      .mockResolvedValueOnce("direct-alpha");
+    const finalize = vi.fn().mockResolvedValue("transparent-video");
+
+    await expect(
+      executePersonCutoutInferencePipeline({
+        executeInference,
+        fallbackRuntimes: [directRuntime],
+        finalize,
+        portraitRuntime,
+        selectedRuntime: exactRuntime,
+      }),
+    ).resolves.toMatchObject({
+      finalResult: "transparent-video",
+      inferenceAttempt: {
+        didFallback: true,
+        result: "direct-alpha",
+        runtime: directRuntime,
+      },
+    });
+    expect(finalize).toHaveBeenCalledOnce();
+    expect(finalize).toHaveBeenCalledWith({
+      inferenceResult: "direct-alpha",
+      runtime: directRuntime,
+    });
+  });
+
+  it("does not retry another provider when transparent encoding fails", async () => {
+    const encoderFailure = new Error("VP9 encoder failed");
+    const executeInference = vi.fn().mockResolvedValue("exact-alpha");
+    const finalize = vi.fn().mockRejectedValue(encoderFailure);
+    const onFallback = vi.fn();
+
+    await expect(
+      executePersonCutoutInferencePipeline({
+        executeInference,
+        fallbackRuntimes: [directRuntime],
+        finalize,
+        onFallback,
+        portraitRuntime,
+        selectedRuntime: exactRuntime,
+      }),
+    ).rejects.toBe(encoderFailure);
+    expect(executeInference).toHaveBeenCalledOnce();
+    expect(executeInference).toHaveBeenCalledWith(exactRuntime);
+    expect(finalize).toHaveBeenCalledOnce();
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+});

--- a/qcut/electron/__tests__/person-cutout-inference-pipeline.test.ts
+++ b/qcut/electron/__tests__/person-cutout-inference-pipeline.test.ts
@@ -2,68 +2,68 @@ import { describe, expect, it, vi } from "vitest";
 import { executePersonCutoutInferencePipeline } from "../jianying-person-cutout/inference-pipeline.js";
 
 const exactRuntime = {
-  modelRoute: "video-object" as const,
-  provider: "bach-exact",
+	modelRoute: "video-object" as const,
+	provider: "bach-exact",
 };
 const directRuntime = {
-  modelRoute: "video-object" as const,
-  provider: "coreml-direct",
+	modelRoute: "video-object" as const,
+	provider: "coreml-direct",
 };
 const portraitRuntime = {
-  modelRoute: "portrait-gru" as const,
-  provider: "gru",
+	modelRoute: "portrait-gru" as const,
+	provider: "gru",
 };
 
 describe("person cutout inference finalization", () => {
-  it("finalizes only after selecting a successful provider", async () => {
-    const executeInference = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("exact unavailable"))
-      .mockResolvedValueOnce("direct-alpha");
-    const finalize = vi.fn().mockResolvedValue("transparent-video");
+	it("finalizes only after selecting a successful provider", async () => {
+		const executeInference = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("exact unavailable"))
+			.mockResolvedValueOnce("direct-alpha");
+		const finalize = vi.fn().mockResolvedValue("transparent-video");
 
-    await expect(
-      executePersonCutoutInferencePipeline({
-        executeInference,
-        fallbackRuntimes: [directRuntime],
-        finalize,
-        portraitRuntime,
-        selectedRuntime: exactRuntime,
-      }),
-    ).resolves.toMatchObject({
-      finalResult: "transparent-video",
-      inferenceAttempt: {
-        didFallback: true,
-        result: "direct-alpha",
-        runtime: directRuntime,
-      },
-    });
-    expect(finalize).toHaveBeenCalledOnce();
-    expect(finalize).toHaveBeenCalledWith({
-      inferenceResult: "direct-alpha",
-      runtime: directRuntime,
-    });
-  });
+		await expect(
+			executePersonCutoutInferencePipeline({
+				executeInference,
+				fallbackRuntimes: [directRuntime],
+				finalize,
+				portraitRuntime,
+				selectedRuntime: exactRuntime,
+			})
+		).resolves.toMatchObject({
+			finalResult: "transparent-video",
+			inferenceAttempt: {
+				didFallback: true,
+				result: "direct-alpha",
+				runtime: directRuntime,
+			},
+		});
+		expect(finalize).toHaveBeenCalledOnce();
+		expect(finalize).toHaveBeenCalledWith({
+			inferenceResult: "direct-alpha",
+			runtime: directRuntime,
+		});
+	});
 
-  it("does not retry another provider when transparent encoding fails", async () => {
-    const encoderFailure = new Error("VP9 encoder failed");
-    const executeInference = vi.fn().mockResolvedValue("exact-alpha");
-    const finalize = vi.fn().mockRejectedValue(encoderFailure);
-    const onFallback = vi.fn();
+	it("does not retry another provider when transparent encoding fails", async () => {
+		const encoderFailure = new Error("VP9 encoder failed");
+		const executeInference = vi.fn().mockResolvedValue("exact-alpha");
+		const finalize = vi.fn().mockRejectedValue(encoderFailure);
+		const onFallback = vi.fn();
 
-    await expect(
-      executePersonCutoutInferencePipeline({
-        executeInference,
-        fallbackRuntimes: [directRuntime],
-        finalize,
-        onFallback,
-        portraitRuntime,
-        selectedRuntime: exactRuntime,
-      }),
-    ).rejects.toBe(encoderFailure);
-    expect(executeInference).toHaveBeenCalledOnce();
-    expect(executeInference).toHaveBeenCalledWith(exactRuntime);
-    expect(finalize).toHaveBeenCalledOnce();
-    expect(onFallback).not.toHaveBeenCalled();
-  });
+		await expect(
+			executePersonCutoutInferencePipeline({
+				executeInference,
+				fallbackRuntimes: [directRuntime],
+				finalize,
+				onFallback,
+				portraitRuntime,
+				selectedRuntime: exactRuntime,
+			})
+		).rejects.toBe(encoderFailure);
+		expect(executeInference).toHaveBeenCalledOnce();
+		expect(executeInference).toHaveBeenCalledWith(exactRuntime);
+		expect(finalize).toHaveBeenCalledOnce();
+		expect(onFallback).not.toHaveBeenCalled();
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-mask-cache.test.ts
+++ b/qcut/electron/__tests__/person-cutout-mask-cache.test.ts
@@ -1,0 +1,194 @@
+import { copyFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	commitPersonCutoutMaskCache,
+	createPersonCutoutCacheIdentity,
+	createPersonCutoutCacheKey,
+	createPersonCutoutMaskCacheBuild,
+	discardPersonCutoutMaskCacheBuild,
+	inspectPersonCutoutMaskCache,
+} from "../jianying-person-cutout/mask-cache.js";
+import { TEMATTING_COMPATIBLE_BLEND } from "../jianying-person-cutout/tematting-blend.js";
+
+describe("person cutout mask cache", () => {
+	let temporaryDirectory = "";
+	let sourcePath = "";
+	const previousCacheRoot = process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT;
+
+	beforeEach(async () => {
+		temporaryDirectory = await mkdtemp(
+			path.join(os.tmpdir(), "qcut-person-cutout-cache-test-")
+		);
+		process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = path.join(
+			temporaryDirectory,
+			"cache"
+		);
+		sourcePath = path.join(temporaryDirectory, "source.mp4");
+		await writeFile(sourcePath, Buffer.alloc(256 * 1024, 7));
+	});
+
+	afterEach(async () => {
+		if (previousCacheRoot === undefined) {
+			Reflect.deleteProperty(process.env, "QCUT_PERSON_CUTOUT_CACHE_ROOT");
+		} else {
+			process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = previousCacheRoot;
+		}
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	});
+
+	async function createIdentity({
+		modelRoute = "portrait-gru",
+		processorSha256 = "processor-sha",
+		threshold = 0.5,
+	}: {
+		modelRoute?: "portrait-gru" | "video-object" | "saliency-script";
+		processorSha256?: string;
+		threshold?: number;
+	} = {}) {
+		return createPersonCutoutCacheIdentity({
+			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+			frameRate: 30,
+			height: 3,
+			modelName: "tt_matting_video_gru_v1.0.model",
+			modelRoute,
+			modelSha256: "model-sha",
+			processorSha256,
+			settings: {
+				edgeShift: 0,
+				feather: 0,
+				temporalSmoothing: 0,
+				threshold,
+			},
+			sourcePath,
+			width: 4,
+		});
+	}
+
+	it("commits only complete, frame-addressable alpha data", async () => {
+		const identity = await createIdentity();
+		const build = await createPersonCutoutMaskCacheBuild({ identity });
+		await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+		const committed = await commitPersonCutoutMaskCache({
+			buildDirectory: build.directory,
+			frameCount: 2,
+			identity,
+		});
+
+		expect(await inspectPersonCutoutMaskCache({ identity })).toEqual(committed);
+	});
+
+	it("rejects a cache whose alpha payload lost one byte", async () => {
+		const identity = await createIdentity();
+		const build = await createPersonCutoutMaskCacheBuild({ identity });
+		await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+		const committed = await commitPersonCutoutMaskCache({
+			buildDirectory: build.directory,
+			frameCount: 2,
+			identity,
+		});
+		await writeFile(committed.alphaPath, Buffer.alloc(23, 255));
+
+		expect(await inspectPersonCutoutMaskCache({ identity })).toBeNull();
+	});
+
+	it("does not publish an incomplete build", async () => {
+		const identity = await createIdentity();
+		const build = await createPersonCutoutMaskCacheBuild({ identity });
+		await writeFile(build.alphaPath, Buffer.alloc(23, 255));
+
+		await expect(
+			commitPersonCutoutMaskCache({
+				buildDirectory: build.directory,
+				frameCount: 2,
+				identity,
+			})
+		).rejects.toThrow("人物蒙版缓存不完整");
+		await discardPersonCutoutMaskCacheBuild({
+			buildDirectory: build.directory,
+		});
+	});
+
+	it("invalidates the key when a mask-producing setting changes", async () => {
+		const [defaultIdentity, shiftedIdentity] = await Promise.all([
+			createIdentity(),
+			createIdentity({ threshold: 0.6 }),
+		]);
+
+		expect(createPersonCutoutCacheKey({ identity: defaultIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: shiftedIdentity })
+		);
+	});
+
+	it("invalidates the key when the native mask processor changes", async () => {
+		const [firstIdentity, updatedIdentity] = await Promise.all([
+			createIdentity(),
+			createIdentity({ processorSha256: "updated-processor-sha" }),
+		]);
+
+		expect(createPersonCutoutCacheKey({ identity: firstIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: updatedIdentity })
+		);
+	});
+
+	it("invalidates the key when only the middle of source media changes", async () => {
+		const originalIdentity = await createIdentity();
+		const changedSource = Buffer.alloc(256 * 1024, 7);
+		changedSource[128 * 1024] = 8;
+		await writeFile(sourcePath, changedSource);
+		const changedIdentity = await createIdentity();
+
+		expect(createPersonCutoutCacheKey({ identity: originalIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: changedIdentity })
+		);
+	});
+
+	it("never reuses a GRU mask for the saliency route", async () => {
+		const [portraitIdentity, saliencyIdentity] = await Promise.all([
+			createIdentity(),
+			createIdentity({ modelRoute: "saliency-script" }),
+		]);
+
+		expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: saliencyIdentity })
+		);
+	});
+
+	it("never reuses a GRU mask for the video-object route", async () => {
+		const [portraitIdentity, objectIdentity] = await Promise.all([
+			createIdentity(),
+			createIdentity({ modelRoute: "video-object" }),
+		]);
+
+		expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: objectIdentity })
+		);
+	});
+
+	it("reuses content after the editor copies it to a new temporary path", async () => {
+		const originalIdentity = await createIdentity();
+		const copiedSourcePath = path.join(temporaryDirectory, "copied-source.mp4");
+		await copyFile(sourcePath, copiedSourcePath);
+		const copiedIdentity = await createPersonCutoutCacheIdentity({
+			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+			frameRate: 30,
+			height: 3,
+			modelName: "tt_matting_video_gru_v1.0.model",
+			modelSha256: "model-sha",
+			processorSha256: "processor-sha",
+			settings: {
+				edgeShift: 0,
+				feather: 0,
+				temporalSmoothing: 0,
+				threshold: 0.5,
+			},
+			sourcePath: copiedSourcePath,
+			width: 4,
+		});
+
+		expect(createPersonCutoutCacheKey({ identity: copiedIdentity })).toBe(
+			createPersonCutoutCacheKey({ identity: originalIdentity })
+		);
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-mask-cache.test.ts
+++ b/qcut/electron/__tests__/person-cutout-mask-cache.test.ts
@@ -3,192 +3,417 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-	commitPersonCutoutMaskCache,
-	createPersonCutoutCacheIdentity,
-	createPersonCutoutCacheKey,
-	createPersonCutoutMaskCacheBuild,
-	discardPersonCutoutMaskCacheBuild,
-	inspectPersonCutoutMaskCache,
+  commitPersonCutoutMaskCache,
+  createPersonCutoutCacheIdentity,
+  createPersonCutoutCacheKey,
+  createPersonCutoutMaskCacheBuild,
+  discardPersonCutoutMaskCacheBuild,
+  inspectPersonCutoutMaskCache,
+  type PersonCutoutPipelineDescriptor,
 } from "../jianying-person-cutout/mask-cache.js";
-import { TEMATTING_COMPATIBLE_BLEND } from "../jianying-person-cutout/tematting-blend.js";
+import {
+  GRU_ONLY_PERSON_CUTOUT_PIPELINE,
+  GRU_VISION_PERSON_CUTOUT_PIPELINE,
+  JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+  JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+  SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE,
+  selectVideoObjectPersonCutoutPipeline,
+  VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE,
+  VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+} from "../jianying-person-cutout/pipeline-descriptor.js";
+import {
+  TEMATTING_COMPATIBLE_BLEND,
+  TEMATTING_NATIVE_METAL_CANARY,
+  type TemattingBlendImplementation,
+} from "../jianying-person-cutout/tematting-blend.js";
 
 describe("person cutout mask cache", () => {
-	let temporaryDirectory = "";
-	let sourcePath = "";
-	const previousCacheRoot = process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT;
+  let temporaryDirectory = "";
+  let sourcePath = "";
+  const previousCacheRoot = process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT;
 
-	beforeEach(async () => {
-		temporaryDirectory = await mkdtemp(
-			path.join(os.tmpdir(), "qcut-person-cutout-cache-test-")
-		);
-		process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = path.join(
-			temporaryDirectory,
-			"cache"
-		);
-		sourcePath = path.join(temporaryDirectory, "source.mp4");
-		await writeFile(sourcePath, Buffer.alloc(256 * 1024, 7));
-	});
+  beforeEach(async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(os.tmpdir(), "qcut-person-cutout-cache-test-"),
+    );
+    process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = path.join(
+      temporaryDirectory,
+      "cache",
+    );
+    sourcePath = path.join(temporaryDirectory, "source.mp4");
+    await writeFile(sourcePath, Buffer.alloc(256 * 1024, 7));
+  });
 
-	afterEach(async () => {
-		if (previousCacheRoot === undefined) {
-			Reflect.deleteProperty(process.env, "QCUT_PERSON_CUTOUT_CACHE_ROOT");
-		} else {
-			process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = previousCacheRoot;
-		}
-		await rm(temporaryDirectory, { force: true, recursive: true });
-	});
+  afterEach(async () => {
+    if (previousCacheRoot === undefined) {
+      Reflect.deleteProperty(process.env, "QCUT_PERSON_CUTOUT_CACHE_ROOT");
+    } else {
+      process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = previousCacheRoot;
+    }
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  });
 
-	async function createIdentity({
-		modelRoute = "portrait-gru",
-		processorSha256 = "processor-sha",
-		threshold = 0.5,
-	}: {
-		modelRoute?: "portrait-gru" | "video-object" | "saliency-script";
-		processorSha256?: string;
-		threshold?: number;
-	} = {}) {
-		return createPersonCutoutCacheIdentity({
-			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-			frameRate: 30,
-			height: 3,
-			modelName: "tt_matting_video_gru_v1.0.model",
-			modelRoute,
-			modelSha256: "model-sha",
-			processorSha256,
-			settings: {
-				edgeShift: 0,
-				feather: 0,
-				temporalSmoothing: 0,
-				threshold,
-			},
-			sourcePath,
-			width: 4,
-		});
-	}
+  async function createIdentity({
+    blendImplementation = TEMATTING_COMPATIBLE_BLEND,
+    modelRoute = "portrait-gru",
+    pipelineDescriptor,
+    processorSha256 = "processor-sha",
+    signal,
+    threshold = 0.5,
+  }: {
+    blendImplementation?: TemattingBlendImplementation;
+    modelRoute?: "portrait-gru" | "video-object" | "saliency-script";
+    pipelineDescriptor?: PersonCutoutPipelineDescriptor;
+    processorSha256?: string;
+    signal?: AbortSignal;
+    threshold?: number;
+  } = {}) {
+    return createPersonCutoutCacheIdentity({
+      blendImplementation,
+      frameRate: 30,
+      height: 3,
+      modelName: "tt_matting_video_gru_v1.0.model",
+      modelRoute,
+      modelSha256: "model-sha",
+      pipelineDescriptor,
+      processorSha256,
+      settings: {
+        edgeShift: 0,
+        feather: 0,
+        temporalSmoothing: 0,
+        threshold,
+      },
+      signal,
+      sourcePath,
+      width: 4,
+    });
+  }
 
-	it("commits only complete, frame-addressable alpha data", async () => {
-		const identity = await createIdentity();
-		const build = await createPersonCutoutMaskCacheBuild({ identity });
-		await writeFile(build.alphaPath, Buffer.alloc(24, 255));
-		const committed = await commitPersonCutoutMaskCache({
-			buildDirectory: build.directory,
-			frameCount: 2,
-			identity,
-		});
+  it("commits only complete, frame-addressable alpha data", async () => {
+    const identity = await createIdentity();
+    const build = await createPersonCutoutMaskCacheBuild({ identity });
+    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+    const committed = await commitPersonCutoutMaskCache({
+      buildDirectory: build.directory,
+      frameCount: 2,
+      identity,
+    });
 
-		expect(await inspectPersonCutoutMaskCache({ identity })).toEqual(committed);
-	});
+    expect(await inspectPersonCutoutMaskCache({ identity })).toEqual(committed);
+  });
 
-	it("rejects a cache whose alpha payload lost one byte", async () => {
-		const identity = await createIdentity();
-		const build = await createPersonCutoutMaskCacheBuild({ identity });
-		await writeFile(build.alphaPath, Buffer.alloc(24, 255));
-		const committed = await commitPersonCutoutMaskCache({
-			buildDirectory: build.directory,
-			frameCount: 2,
-			identity,
-		});
-		await writeFile(committed.alphaPath, Buffer.alloc(23, 255));
+  it("rejects a cache whose alpha payload lost one byte", async () => {
+    const identity = await createIdentity();
+    const build = await createPersonCutoutMaskCacheBuild({ identity });
+    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+    const committed = await commitPersonCutoutMaskCache({
+      buildDirectory: build.directory,
+      frameCount: 2,
+      identity,
+    });
+    await writeFile(committed.alphaPath, Buffer.alloc(23, 255));
 
-		expect(await inspectPersonCutoutMaskCache({ identity })).toBeNull();
-	});
+    expect(await inspectPersonCutoutMaskCache({ identity })).toBeNull();
+  });
 
-	it("does not publish an incomplete build", async () => {
-		const identity = await createIdentity();
-		const build = await createPersonCutoutMaskCacheBuild({ identity });
-		await writeFile(build.alphaPath, Buffer.alloc(23, 255));
+  it("rejects equal-size alpha corruption", async () => {
+    const identity = await createIdentity();
+    const build = await createPersonCutoutMaskCacheBuild({ identity });
+    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+    const committed = await commitPersonCutoutMaskCache({
+      buildDirectory: build.directory,
+      frameCount: 2,
+      identity,
+    });
+    await writeFile(committed.alphaPath, Buffer.alloc(24, 0));
 
-		await expect(
-			commitPersonCutoutMaskCache({
-				buildDirectory: build.directory,
-				frameCount: 2,
-				identity,
-			})
-		).rejects.toThrow("人物蒙版缓存不完整");
-		await discardPersonCutoutMaskCacheBuild({
-			buildDirectory: build.directory,
-		});
-	});
+    expect(await inspectPersonCutoutMaskCache({ identity })).toBeNull();
+  });
 
-	it("invalidates the key when a mask-producing setting changes", async () => {
-		const [defaultIdentity, shiftedIdentity] = await Promise.all([
-			createIdentity(),
-			createIdentity({ threshold: 0.6 }),
-		]);
+  it("does not swallow cancellation while hashing source or cached Alpha", async () => {
+    const sourceController = new AbortController();
+    sourceController.abort();
+    await expect(
+      createIdentity({ signal: sourceController.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
 
-		expect(createPersonCutoutCacheKey({ identity: defaultIdentity })).not.toBe(
-			createPersonCutoutCacheKey({ identity: shiftedIdentity })
-		);
-	});
+    const identity = await createIdentity();
+    const build = await createPersonCutoutMaskCacheBuild({ identity });
+    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+    await commitPersonCutoutMaskCache({
+      buildDirectory: build.directory,
+      frameCount: 2,
+      identity,
+    });
+    const cacheController = new AbortController();
+    cacheController.abort();
+    await expect(
+      inspectPersonCutoutMaskCache({
+        identity,
+        signal: cacheController.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
 
-	it("invalidates the key when the native mask processor changes", async () => {
-		const [firstIdentity, updatedIdentity] = await Promise.all([
-			createIdentity(),
-			createIdentity({ processorSha256: "updated-processor-sha" }),
-		]);
+  it("does not publish an incomplete build", async () => {
+    const identity = await createIdentity();
+    const build = await createPersonCutoutMaskCacheBuild({ identity });
+    await writeFile(build.alphaPath, Buffer.alloc(23, 255));
 
-		expect(createPersonCutoutCacheKey({ identity: firstIdentity })).not.toBe(
-			createPersonCutoutCacheKey({ identity: updatedIdentity })
-		);
-	});
+    await expect(
+      commitPersonCutoutMaskCache({
+        buildDirectory: build.directory,
+        frameCount: 2,
+        identity,
+      }),
+    ).rejects.toThrow("人物蒙版缓存不完整");
+    await discardPersonCutoutMaskCacheBuild({
+      buildDirectory: build.directory,
+    });
+  });
 
-	it("invalidates the key when only the middle of source media changes", async () => {
-		const originalIdentity = await createIdentity();
-		const changedSource = Buffer.alloc(256 * 1024, 7);
-		changedSource[128 * 1024] = 8;
-		await writeFile(sourcePath, changedSource);
-		const changedIdentity = await createIdentity();
+  it("invalidates the key when a mask-producing setting changes", async () => {
+    const [defaultIdentity, shiftedIdentity] = await Promise.all([
+      createIdentity(),
+      createIdentity({ threshold: 0.6 }),
+    ]);
 
-		expect(createPersonCutoutCacheKey({ identity: originalIdentity })).not.toBe(
-			createPersonCutoutCacheKey({ identity: changedIdentity })
-		);
-	});
+    expect(createPersonCutoutCacheKey({ identity: defaultIdentity })).not.toBe(
+      createPersonCutoutCacheKey({ identity: shiftedIdentity }),
+    );
+  });
 
-	it("never reuses a GRU mask for the saliency route", async () => {
-		const [portraitIdentity, saliencyIdentity] = await Promise.all([
-			createIdentity(),
-			createIdentity({ modelRoute: "saliency-script" }),
-		]);
+  it("invalidates the key when the native mask processor changes", async () => {
+    const [firstIdentity, updatedIdentity] = await Promise.all([
+      createIdentity(),
+      createIdentity({ processorSha256: "updated-processor-sha" }),
+    ]);
 
-		expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
-			createPersonCutoutCacheKey({ identity: saliencyIdentity })
-		);
-	});
+    expect(createPersonCutoutCacheKey({ identity: firstIdentity })).not.toBe(
+      createPersonCutoutCacheKey({ identity: updatedIdentity }),
+    );
+  });
 
-	it("never reuses a GRU mask for the video-object route", async () => {
-		const [portraitIdentity, objectIdentity] = await Promise.all([
-			createIdentity(),
-			createIdentity({ modelRoute: "video-object" }),
-		]);
+  it("invalidates the key when only the middle of source media changes", async () => {
+    const originalIdentity = await createIdentity();
+    const changedSource = Buffer.alloc(256 * 1024, 7);
+    changedSource[128 * 1024] = 8;
+    await writeFile(sourcePath, changedSource);
+    const changedIdentity = await createIdentity();
 
-		expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
-			createPersonCutoutCacheKey({ identity: objectIdentity })
-		);
-	});
+    expect(createPersonCutoutCacheKey({ identity: originalIdentity })).not.toBe(
+      createPersonCutoutCacheKey({ identity: changedIdentity }),
+    );
+  });
 
-	it("reuses content after the editor copies it to a new temporary path", async () => {
-		const originalIdentity = await createIdentity();
-		const copiedSourcePath = path.join(temporaryDirectory, "copied-source.mp4");
-		await copyFile(sourcePath, copiedSourcePath);
-		const copiedIdentity = await createPersonCutoutCacheIdentity({
-			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-			frameRate: 30,
-			height: 3,
-			modelName: "tt_matting_video_gru_v1.0.model",
-			modelSha256: "model-sha",
-			processorSha256: "processor-sha",
-			settings: {
-				edgeShift: 0,
-				feather: 0,
-				temporalSmoothing: 0,
-				threshold: 0.5,
-			},
-			sourcePath: copiedSourcePath,
-			width: 4,
-		});
+  it("never reuses a GRU mask for the saliency route", async () => {
+    const [portraitIdentity, saliencyIdentity] = await Promise.all([
+      createIdentity(),
+      createIdentity({ modelRoute: "saliency-script" }),
+    ]);
 
-		expect(createPersonCutoutCacheKey({ identity: copiedIdentity })).toBe(
-			createPersonCutoutCacheKey({ identity: originalIdentity })
-		);
-	});
+    expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
+      createPersonCutoutCacheKey({ identity: saliencyIdentity }),
+    );
+  });
+
+  it("never reuses a GRU mask for the video-object route", async () => {
+    const [portraitIdentity, objectIdentity] = await Promise.all([
+      createIdentity(),
+      createIdentity({ modelRoute: "video-object" }),
+    ]);
+
+    expect(objectIdentity.pipelineId).toBe(
+      "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+    );
+    expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
+      createPersonCutoutCacheKey({ identity: objectIdentity }),
+    );
+  });
+
+  it("separates GRU with Vision fusion from explicit GRU-only masks", async () => {
+    const [fusionIdentity, gruOnlyIdentity] = await Promise.all([
+      createIdentity({
+        pipelineDescriptor: GRU_VISION_PERSON_CUTOUT_PIPELINE,
+      }),
+      createIdentity({
+        pipelineDescriptor: GRU_ONLY_PERSON_CUTOUT_PIPELINE,
+      }),
+    ]);
+
+    expect(fusionIdentity.providerId).toBe("qcut-local-person-matting-v1");
+    expect(fusionIdentity.pipelineId).toBe("qcut-gru-vision-fusion-v1");
+    expect(gruOnlyIdentity.pipelineId).toBe("qcut-gru-only-v1");
+    expect(createPersonCutoutCacheKey({ identity: fusionIdentity })).not.toBe(
+      createPersonCutoutCacheKey({ identity: gruOnlyIdentity }),
+    );
+  });
+
+  it("separates the validated same-model path from interop experiments", () => {
+    expect(JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE).toMatchObject({
+      experimental: false,
+      pipelineId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+      providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+      refinementProvider: "vendor-v2-exact-no-qcut-refinement-v1",
+    });
+    expect(
+      JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+    ).toMatchObject({
+      experimental: true,
+      pipelineId: "qcut-jianying-video-object-bach-v2-refined-d634-v1",
+      providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+      refinementProvider: "qcut-alpha-refinement-after-vendor-v2-v1",
+    });
+    expect(VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE).toMatchObject({
+      experimental: false,
+      modelRoute: "video-object",
+      pipelineId: "qcut-video-object-same-model-coreml-v1",
+      providerId: "qcut-video-object-same-model-coreml-v1",
+    });
+    expect(VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE).toMatchObject({
+      experimental: true,
+      modelRoute: "video-object",
+      pipelineId: "qcut-video-object-interop-experimental-v1",
+      providerId: "qcut-video-object-interop-experimental-v1",
+    });
+    expect(SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE).toMatchObject({
+      experimental: true,
+      modelRoute: "saliency-script",
+      pipelineId: "qcut-saliency-script-interop-experimental-v1",
+      providerId: "qcut-saliency-interop-experimental-v1",
+    });
+  });
+
+  it("invalidates masks across exact, refined, and CoreML providers", async () => {
+    const [exactIdentity, refinedIdentity, coreMLIdentity] = await Promise.all([
+      createIdentity({
+        modelRoute: "video-object",
+        pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+      }),
+      createIdentity({
+        modelRoute: "video-object",
+        pipelineDescriptor:
+          JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+      }),
+      createIdentity({
+        modelRoute: "video-object",
+        pipelineDescriptor: VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+      }),
+    ]);
+    const cacheKeys = [exactIdentity, refinedIdentity, coreMLIdentity].map(
+      (identity) => createPersonCutoutCacheKey({ identity }),
+    );
+    expect(new Set(cacheKeys).size).toBe(3);
+  });
+
+  it("labels vendor V2 Bach as exact and advanced Bach as QCut-refined", () => {
+    const exact = selectVideoObjectPersonCutoutPipeline({
+      executionBackend: "jianying-bach-v2-exact-d634-v1",
+      settings: {
+        edgeShift: 0,
+        feather: 0,
+        temporalSmoothing: 0,
+        threshold: 0.5,
+      },
+    });
+    const refined = selectVideoObjectPersonCutoutPipeline({
+      executionBackend: "jianying-bach-v2-exact-d634-v1",
+      settings: {
+        edgeShift: 1,
+        feather: 0,
+        temporalSmoothing: 0,
+        threshold: 0.5,
+      },
+    });
+    const roundedExact = selectVideoObjectPersonCutoutPipeline({
+      executionBackend: "jianying-bach-v2-exact-d634-v1",
+      settings: {
+        edgeShift: 0,
+        feather: 0,
+        temporalSmoothing: 0,
+        threshold: 0.50000001,
+      },
+    });
+    const floatDistinctRefined = selectVideoObjectPersonCutoutPipeline({
+      executionBackend: "jianying-bach-v2-exact-d634-v1",
+      settings: {
+        edgeShift: 0,
+        feather: 0,
+        temporalSmoothing: 0,
+        threshold: 0.5000001,
+      },
+    });
+
+    expect(exact).toBe(JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE);
+    expect(roundedExact).toBe(
+      JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+    );
+    expect(refined).toBe(
+      JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+    );
+    expect(floatDistinctRefined).toBe(
+      JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+    );
+  });
+
+  it("rejects a pipeline descriptor for a different model route", async () => {
+    await expect(
+      createIdentity({
+        modelRoute: "video-object",
+        pipelineDescriptor: GRU_VISION_PERSON_CUTOUT_PIPELINE,
+      }),
+    ).rejects.toThrow("人物抠像管线与模型路线不一致");
+  });
+
+  it("shares pre-blend alpha between native and compatible compositors", async () => {
+    const [compatibleIdentity, nativeIdentity] = await Promise.all([
+      createIdentity(),
+      createIdentity({
+        blendImplementation: TEMATTING_NATIVE_METAL_CANARY,
+      }),
+    ]);
+
+    expect(createPersonCutoutCacheKey({ identity: compatibleIdentity })).toBe(
+      createPersonCutoutCacheKey({ identity: nativeIdentity }),
+    );
+    const build = await createPersonCutoutMaskCacheBuild({
+      identity: compatibleIdentity,
+    });
+    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+    const committed = await commitPersonCutoutMaskCache({
+      buildDirectory: build.directory,
+      frameCount: 2,
+      identity: compatibleIdentity,
+    });
+
+    expect(
+      await inspectPersonCutoutMaskCache({ identity: nativeIdentity }),
+    ).toEqual(committed);
+  });
+
+  it("reuses content after the editor copies it to a new temporary path", async () => {
+    const originalIdentity = await createIdentity();
+    const copiedSourcePath = path.join(temporaryDirectory, "copied-source.mp4");
+    await copyFile(sourcePath, copiedSourcePath);
+    const copiedIdentity = await createPersonCutoutCacheIdentity({
+      blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+      frameRate: 30,
+      height: 3,
+      modelName: "tt_matting_video_gru_v1.0.model",
+      modelSha256: "model-sha",
+      processorSha256: "processor-sha",
+      settings: {
+        edgeShift: 0,
+        feather: 0,
+        temporalSmoothing: 0,
+        threshold: 0.5,
+      },
+      sourcePath: copiedSourcePath,
+      width: 4,
+    });
+
+    expect(createPersonCutoutCacheKey({ identity: copiedIdentity })).toBe(
+      createPersonCutoutCacheKey({ identity: originalIdentity }),
+    );
+  });
 });

--- a/qcut/electron/__tests__/person-cutout-mask-cache.test.ts
+++ b/qcut/electron/__tests__/person-cutout-mask-cache.test.ts
@@ -3,417 +3,417 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  commitPersonCutoutMaskCache,
-  createPersonCutoutCacheIdentity,
-  createPersonCutoutCacheKey,
-  createPersonCutoutMaskCacheBuild,
-  discardPersonCutoutMaskCacheBuild,
-  inspectPersonCutoutMaskCache,
-  type PersonCutoutPipelineDescriptor,
+	commitPersonCutoutMaskCache,
+	createPersonCutoutCacheIdentity,
+	createPersonCutoutCacheKey,
+	createPersonCutoutMaskCacheBuild,
+	discardPersonCutoutMaskCacheBuild,
+	inspectPersonCutoutMaskCache,
+	type PersonCutoutPipelineDescriptor,
 } from "../jianying-person-cutout/mask-cache.js";
 import {
-  GRU_ONLY_PERSON_CUTOUT_PIPELINE,
-  GRU_VISION_PERSON_CUTOUT_PIPELINE,
-  JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-  JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
-  SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE,
-  selectVideoObjectPersonCutoutPipeline,
-  VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE,
-  VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+	GRU_ONLY_PERSON_CUTOUT_PIPELINE,
+	GRU_VISION_PERSON_CUTOUT_PIPELINE,
+	JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+	JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+	SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE,
+	selectVideoObjectPersonCutoutPipeline,
+	VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE,
+	VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
 } from "../jianying-person-cutout/pipeline-descriptor.js";
 import {
-  TEMATTING_COMPATIBLE_BLEND,
-  TEMATTING_NATIVE_METAL_CANARY,
-  type TemattingBlendImplementation,
+	TEMATTING_COMPATIBLE_BLEND,
+	TEMATTING_NATIVE_METAL_CANARY,
+	type TemattingBlendImplementation,
 } from "../jianying-person-cutout/tematting-blend.js";
 
 describe("person cutout mask cache", () => {
-  let temporaryDirectory = "";
-  let sourcePath = "";
-  const previousCacheRoot = process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT;
+	let temporaryDirectory = "";
+	let sourcePath = "";
+	const previousCacheRoot = process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT;
 
-  beforeEach(async () => {
-    temporaryDirectory = await mkdtemp(
-      path.join(os.tmpdir(), "qcut-person-cutout-cache-test-"),
-    );
-    process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = path.join(
-      temporaryDirectory,
-      "cache",
-    );
-    sourcePath = path.join(temporaryDirectory, "source.mp4");
-    await writeFile(sourcePath, Buffer.alloc(256 * 1024, 7));
-  });
+	beforeEach(async () => {
+		temporaryDirectory = await mkdtemp(
+			path.join(os.tmpdir(), "qcut-person-cutout-cache-test-")
+		);
+		process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = path.join(
+			temporaryDirectory,
+			"cache"
+		);
+		sourcePath = path.join(temporaryDirectory, "source.mp4");
+		await writeFile(sourcePath, Buffer.alloc(256 * 1024, 7));
+	});
 
-  afterEach(async () => {
-    if (previousCacheRoot === undefined) {
-      Reflect.deleteProperty(process.env, "QCUT_PERSON_CUTOUT_CACHE_ROOT");
-    } else {
-      process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = previousCacheRoot;
-    }
-    await rm(temporaryDirectory, { force: true, recursive: true });
-  });
+	afterEach(async () => {
+		if (previousCacheRoot === undefined) {
+			Reflect.deleteProperty(process.env, "QCUT_PERSON_CUTOUT_CACHE_ROOT");
+		} else {
+			process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT = previousCacheRoot;
+		}
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	});
 
-  async function createIdentity({
-    blendImplementation = TEMATTING_COMPATIBLE_BLEND,
-    modelRoute = "portrait-gru",
-    pipelineDescriptor,
-    processorSha256 = "processor-sha",
-    signal,
-    threshold = 0.5,
-  }: {
-    blendImplementation?: TemattingBlendImplementation;
-    modelRoute?: "portrait-gru" | "video-object" | "saliency-script";
-    pipelineDescriptor?: PersonCutoutPipelineDescriptor;
-    processorSha256?: string;
-    signal?: AbortSignal;
-    threshold?: number;
-  } = {}) {
-    return createPersonCutoutCacheIdentity({
-      blendImplementation,
-      frameRate: 30,
-      height: 3,
-      modelName: "tt_matting_video_gru_v1.0.model",
-      modelRoute,
-      modelSha256: "model-sha",
-      pipelineDescriptor,
-      processorSha256,
-      settings: {
-        edgeShift: 0,
-        feather: 0,
-        temporalSmoothing: 0,
-        threshold,
-      },
-      signal,
-      sourcePath,
-      width: 4,
-    });
-  }
+	async function createIdentity({
+		blendImplementation = TEMATTING_COMPATIBLE_BLEND,
+		modelRoute = "portrait-gru",
+		pipelineDescriptor,
+		processorSha256 = "processor-sha",
+		signal,
+		threshold = 0.5,
+	}: {
+		blendImplementation?: TemattingBlendImplementation;
+		modelRoute?: "portrait-gru" | "video-object" | "saliency-script";
+		pipelineDescriptor?: PersonCutoutPipelineDescriptor;
+		processorSha256?: string;
+		signal?: AbortSignal;
+		threshold?: number;
+	} = {}) {
+		return createPersonCutoutCacheIdentity({
+			blendImplementation,
+			frameRate: 30,
+			height: 3,
+			modelName: "tt_matting_video_gru_v1.0.model",
+			modelRoute,
+			modelSha256: "model-sha",
+			pipelineDescriptor,
+			processorSha256,
+			settings: {
+				edgeShift: 0,
+				feather: 0,
+				temporalSmoothing: 0,
+				threshold,
+			},
+			signal,
+			sourcePath,
+			width: 4,
+		});
+	}
 
-  it("commits only complete, frame-addressable alpha data", async () => {
-    const identity = await createIdentity();
-    const build = await createPersonCutoutMaskCacheBuild({ identity });
-    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
-    const committed = await commitPersonCutoutMaskCache({
-      buildDirectory: build.directory,
-      frameCount: 2,
-      identity,
-    });
+	it("commits only complete, frame-addressable alpha data", async () => {
+		const identity = await createIdentity();
+		const build = await createPersonCutoutMaskCacheBuild({ identity });
+		await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+		const committed = await commitPersonCutoutMaskCache({
+			buildDirectory: build.directory,
+			frameCount: 2,
+			identity,
+		});
 
-    expect(await inspectPersonCutoutMaskCache({ identity })).toEqual(committed);
-  });
+		expect(await inspectPersonCutoutMaskCache({ identity })).toEqual(committed);
+	});
 
-  it("rejects a cache whose alpha payload lost one byte", async () => {
-    const identity = await createIdentity();
-    const build = await createPersonCutoutMaskCacheBuild({ identity });
-    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
-    const committed = await commitPersonCutoutMaskCache({
-      buildDirectory: build.directory,
-      frameCount: 2,
-      identity,
-    });
-    await writeFile(committed.alphaPath, Buffer.alloc(23, 255));
+	it("rejects a cache whose alpha payload lost one byte", async () => {
+		const identity = await createIdentity();
+		const build = await createPersonCutoutMaskCacheBuild({ identity });
+		await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+		const committed = await commitPersonCutoutMaskCache({
+			buildDirectory: build.directory,
+			frameCount: 2,
+			identity,
+		});
+		await writeFile(committed.alphaPath, Buffer.alloc(23, 255));
 
-    expect(await inspectPersonCutoutMaskCache({ identity })).toBeNull();
-  });
+		expect(await inspectPersonCutoutMaskCache({ identity })).toBeNull();
+	});
 
-  it("rejects equal-size alpha corruption", async () => {
-    const identity = await createIdentity();
-    const build = await createPersonCutoutMaskCacheBuild({ identity });
-    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
-    const committed = await commitPersonCutoutMaskCache({
-      buildDirectory: build.directory,
-      frameCount: 2,
-      identity,
-    });
-    await writeFile(committed.alphaPath, Buffer.alloc(24, 0));
+	it("rejects equal-size alpha corruption", async () => {
+		const identity = await createIdentity();
+		const build = await createPersonCutoutMaskCacheBuild({ identity });
+		await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+		const committed = await commitPersonCutoutMaskCache({
+			buildDirectory: build.directory,
+			frameCount: 2,
+			identity,
+		});
+		await writeFile(committed.alphaPath, Buffer.alloc(24, 0));
 
-    expect(await inspectPersonCutoutMaskCache({ identity })).toBeNull();
-  });
+		expect(await inspectPersonCutoutMaskCache({ identity })).toBeNull();
+	});
 
-  it("does not swallow cancellation while hashing source or cached Alpha", async () => {
-    const sourceController = new AbortController();
-    sourceController.abort();
-    await expect(
-      createIdentity({ signal: sourceController.signal }),
-    ).rejects.toMatchObject({ name: "AbortError" });
+	it("does not swallow cancellation while hashing source or cached Alpha", async () => {
+		const sourceController = new AbortController();
+		sourceController.abort();
+		await expect(
+			createIdentity({ signal: sourceController.signal })
+		).rejects.toMatchObject({ name: "AbortError" });
 
-    const identity = await createIdentity();
-    const build = await createPersonCutoutMaskCacheBuild({ identity });
-    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
-    await commitPersonCutoutMaskCache({
-      buildDirectory: build.directory,
-      frameCount: 2,
-      identity,
-    });
-    const cacheController = new AbortController();
-    cacheController.abort();
-    await expect(
-      inspectPersonCutoutMaskCache({
-        identity,
-        signal: cacheController.signal,
-      }),
-    ).rejects.toMatchObject({ name: "AbortError" });
-  });
+		const identity = await createIdentity();
+		const build = await createPersonCutoutMaskCacheBuild({ identity });
+		await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+		await commitPersonCutoutMaskCache({
+			buildDirectory: build.directory,
+			frameCount: 2,
+			identity,
+		});
+		const cacheController = new AbortController();
+		cacheController.abort();
+		await expect(
+			inspectPersonCutoutMaskCache({
+				identity,
+				signal: cacheController.signal,
+			})
+		).rejects.toMatchObject({ name: "AbortError" });
+	});
 
-  it("does not publish an incomplete build", async () => {
-    const identity = await createIdentity();
-    const build = await createPersonCutoutMaskCacheBuild({ identity });
-    await writeFile(build.alphaPath, Buffer.alloc(23, 255));
+	it("does not publish an incomplete build", async () => {
+		const identity = await createIdentity();
+		const build = await createPersonCutoutMaskCacheBuild({ identity });
+		await writeFile(build.alphaPath, Buffer.alloc(23, 255));
 
-    await expect(
-      commitPersonCutoutMaskCache({
-        buildDirectory: build.directory,
-        frameCount: 2,
-        identity,
-      }),
-    ).rejects.toThrow("人物蒙版缓存不完整");
-    await discardPersonCutoutMaskCacheBuild({
-      buildDirectory: build.directory,
-    });
-  });
+		await expect(
+			commitPersonCutoutMaskCache({
+				buildDirectory: build.directory,
+				frameCount: 2,
+				identity,
+			})
+		).rejects.toThrow("人物蒙版缓存不完整");
+		await discardPersonCutoutMaskCacheBuild({
+			buildDirectory: build.directory,
+		});
+	});
 
-  it("invalidates the key when a mask-producing setting changes", async () => {
-    const [defaultIdentity, shiftedIdentity] = await Promise.all([
-      createIdentity(),
-      createIdentity({ threshold: 0.6 }),
-    ]);
+	it("invalidates the key when a mask-producing setting changes", async () => {
+		const [defaultIdentity, shiftedIdentity] = await Promise.all([
+			createIdentity(),
+			createIdentity({ threshold: 0.6 }),
+		]);
 
-    expect(createPersonCutoutCacheKey({ identity: defaultIdentity })).not.toBe(
-      createPersonCutoutCacheKey({ identity: shiftedIdentity }),
-    );
-  });
+		expect(createPersonCutoutCacheKey({ identity: defaultIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: shiftedIdentity })
+		);
+	});
 
-  it("invalidates the key when the native mask processor changes", async () => {
-    const [firstIdentity, updatedIdentity] = await Promise.all([
-      createIdentity(),
-      createIdentity({ processorSha256: "updated-processor-sha" }),
-    ]);
+	it("invalidates the key when the native mask processor changes", async () => {
+		const [firstIdentity, updatedIdentity] = await Promise.all([
+			createIdentity(),
+			createIdentity({ processorSha256: "updated-processor-sha" }),
+		]);
 
-    expect(createPersonCutoutCacheKey({ identity: firstIdentity })).not.toBe(
-      createPersonCutoutCacheKey({ identity: updatedIdentity }),
-    );
-  });
+		expect(createPersonCutoutCacheKey({ identity: firstIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: updatedIdentity })
+		);
+	});
 
-  it("invalidates the key when only the middle of source media changes", async () => {
-    const originalIdentity = await createIdentity();
-    const changedSource = Buffer.alloc(256 * 1024, 7);
-    changedSource[128 * 1024] = 8;
-    await writeFile(sourcePath, changedSource);
-    const changedIdentity = await createIdentity();
+	it("invalidates the key when only the middle of source media changes", async () => {
+		const originalIdentity = await createIdentity();
+		const changedSource = Buffer.alloc(256 * 1024, 7);
+		changedSource[128 * 1024] = 8;
+		await writeFile(sourcePath, changedSource);
+		const changedIdentity = await createIdentity();
 
-    expect(createPersonCutoutCacheKey({ identity: originalIdentity })).not.toBe(
-      createPersonCutoutCacheKey({ identity: changedIdentity }),
-    );
-  });
+		expect(createPersonCutoutCacheKey({ identity: originalIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: changedIdentity })
+		);
+	});
 
-  it("never reuses a GRU mask for the saliency route", async () => {
-    const [portraitIdentity, saliencyIdentity] = await Promise.all([
-      createIdentity(),
-      createIdentity({ modelRoute: "saliency-script" }),
-    ]);
+	it("never reuses a GRU mask for the saliency route", async () => {
+		const [portraitIdentity, saliencyIdentity] = await Promise.all([
+			createIdentity(),
+			createIdentity({ modelRoute: "saliency-script" }),
+		]);
 
-    expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
-      createPersonCutoutCacheKey({ identity: saliencyIdentity }),
-    );
-  });
+		expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: saliencyIdentity })
+		);
+	});
 
-  it("never reuses a GRU mask for the video-object route", async () => {
-    const [portraitIdentity, objectIdentity] = await Promise.all([
-      createIdentity(),
-      createIdentity({ modelRoute: "video-object" }),
-    ]);
+	it("never reuses a GRU mask for the video-object route", async () => {
+		const [portraitIdentity, objectIdentity] = await Promise.all([
+			createIdentity(),
+			createIdentity({ modelRoute: "video-object" }),
+		]);
 
-    expect(objectIdentity.pipelineId).toBe(
-      "qcut-jianying-video-object-bach-v2-exact-d634-v1",
-    );
-    expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
-      createPersonCutoutCacheKey({ identity: objectIdentity }),
-    );
-  });
+		expect(objectIdentity.pipelineId).toBe(
+			"qcut-jianying-video-object-bach-v2-exact-d634-v1"
+		);
+		expect(createPersonCutoutCacheKey({ identity: portraitIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: objectIdentity })
+		);
+	});
 
-  it("separates GRU with Vision fusion from explicit GRU-only masks", async () => {
-    const [fusionIdentity, gruOnlyIdentity] = await Promise.all([
-      createIdentity({
-        pipelineDescriptor: GRU_VISION_PERSON_CUTOUT_PIPELINE,
-      }),
-      createIdentity({
-        pipelineDescriptor: GRU_ONLY_PERSON_CUTOUT_PIPELINE,
-      }),
-    ]);
+	it("separates GRU with Vision fusion from explicit GRU-only masks", async () => {
+		const [fusionIdentity, gruOnlyIdentity] = await Promise.all([
+			createIdentity({
+				pipelineDescriptor: GRU_VISION_PERSON_CUTOUT_PIPELINE,
+			}),
+			createIdentity({
+				pipelineDescriptor: GRU_ONLY_PERSON_CUTOUT_PIPELINE,
+			}),
+		]);
 
-    expect(fusionIdentity.providerId).toBe("qcut-local-person-matting-v1");
-    expect(fusionIdentity.pipelineId).toBe("qcut-gru-vision-fusion-v1");
-    expect(gruOnlyIdentity.pipelineId).toBe("qcut-gru-only-v1");
-    expect(createPersonCutoutCacheKey({ identity: fusionIdentity })).not.toBe(
-      createPersonCutoutCacheKey({ identity: gruOnlyIdentity }),
-    );
-  });
+		expect(fusionIdentity.providerId).toBe("qcut-local-person-matting-v1");
+		expect(fusionIdentity.pipelineId).toBe("qcut-gru-vision-fusion-v1");
+		expect(gruOnlyIdentity.pipelineId).toBe("qcut-gru-only-v1");
+		expect(createPersonCutoutCacheKey({ identity: fusionIdentity })).not.toBe(
+			createPersonCutoutCacheKey({ identity: gruOnlyIdentity })
+		);
+	});
 
-  it("separates the validated same-model path from interop experiments", () => {
-    expect(JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE).toMatchObject({
-      experimental: false,
-      pipelineId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
-      providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
-      refinementProvider: "vendor-v2-exact-no-qcut-refinement-v1",
-    });
-    expect(
-      JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
-    ).toMatchObject({
-      experimental: true,
-      pipelineId: "qcut-jianying-video-object-bach-v2-refined-d634-v1",
-      providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
-      refinementProvider: "qcut-alpha-refinement-after-vendor-v2-v1",
-    });
-    expect(VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE).toMatchObject({
-      experimental: false,
-      modelRoute: "video-object",
-      pipelineId: "qcut-video-object-same-model-coreml-v1",
-      providerId: "qcut-video-object-same-model-coreml-v1",
-    });
-    expect(VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE).toMatchObject({
-      experimental: true,
-      modelRoute: "video-object",
-      pipelineId: "qcut-video-object-interop-experimental-v1",
-      providerId: "qcut-video-object-interop-experimental-v1",
-    });
-    expect(SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE).toMatchObject({
-      experimental: true,
-      modelRoute: "saliency-script",
-      pipelineId: "qcut-saliency-script-interop-experimental-v1",
-      providerId: "qcut-saliency-interop-experimental-v1",
-    });
-  });
+	it("separates the validated same-model path from interop experiments", () => {
+		expect(JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE).toMatchObject({
+			experimental: false,
+			pipelineId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+			providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+			refinementProvider: "vendor-v2-exact-no-qcut-refinement-v1",
+		});
+		expect(
+			JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE
+		).toMatchObject({
+			experimental: true,
+			pipelineId: "qcut-jianying-video-object-bach-v2-refined-d634-v1",
+			providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+			refinementProvider: "qcut-alpha-refinement-after-vendor-v2-v1",
+		});
+		expect(VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE).toMatchObject({
+			experimental: false,
+			modelRoute: "video-object",
+			pipelineId: "qcut-video-object-same-model-coreml-v1",
+			providerId: "qcut-video-object-same-model-coreml-v1",
+		});
+		expect(VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE).toMatchObject({
+			experimental: true,
+			modelRoute: "video-object",
+			pipelineId: "qcut-video-object-interop-experimental-v1",
+			providerId: "qcut-video-object-interop-experimental-v1",
+		});
+		expect(SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE).toMatchObject({
+			experimental: true,
+			modelRoute: "saliency-script",
+			pipelineId: "qcut-saliency-script-interop-experimental-v1",
+			providerId: "qcut-saliency-interop-experimental-v1",
+		});
+	});
 
-  it("invalidates masks across exact, refined, and CoreML providers", async () => {
-    const [exactIdentity, refinedIdentity, coreMLIdentity] = await Promise.all([
-      createIdentity({
-        modelRoute: "video-object",
-        pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-      }),
-      createIdentity({
-        modelRoute: "video-object",
-        pipelineDescriptor:
-          JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
-      }),
-      createIdentity({
-        modelRoute: "video-object",
-        pipelineDescriptor: VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-      }),
-    ]);
-    const cacheKeys = [exactIdentity, refinedIdentity, coreMLIdentity].map(
-      (identity) => createPersonCutoutCacheKey({ identity }),
-    );
-    expect(new Set(cacheKeys).size).toBe(3);
-  });
+	it("invalidates masks across exact, refined, and CoreML providers", async () => {
+		const [exactIdentity, refinedIdentity, coreMLIdentity] = await Promise.all([
+			createIdentity({
+				modelRoute: "video-object",
+				pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+			}),
+			createIdentity({
+				modelRoute: "video-object",
+				pipelineDescriptor:
+					JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+			}),
+			createIdentity({
+				modelRoute: "video-object",
+				pipelineDescriptor: VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+			}),
+		]);
+		const cacheKeys = [exactIdentity, refinedIdentity, coreMLIdentity].map(
+			(identity) => createPersonCutoutCacheKey({ identity })
+		);
+		expect(new Set(cacheKeys).size).toBe(3);
+	});
 
-  it("labels vendor V2 Bach as exact and advanced Bach as QCut-refined", () => {
-    const exact = selectVideoObjectPersonCutoutPipeline({
-      executionBackend: "jianying-bach-v2-exact-d634-v1",
-      settings: {
-        edgeShift: 0,
-        feather: 0,
-        temporalSmoothing: 0,
-        threshold: 0.5,
-      },
-    });
-    const refined = selectVideoObjectPersonCutoutPipeline({
-      executionBackend: "jianying-bach-v2-exact-d634-v1",
-      settings: {
-        edgeShift: 1,
-        feather: 0,
-        temporalSmoothing: 0,
-        threshold: 0.5,
-      },
-    });
-    const roundedExact = selectVideoObjectPersonCutoutPipeline({
-      executionBackend: "jianying-bach-v2-exact-d634-v1",
-      settings: {
-        edgeShift: 0,
-        feather: 0,
-        temporalSmoothing: 0,
-        threshold: 0.50000001,
-      },
-    });
-    const floatDistinctRefined = selectVideoObjectPersonCutoutPipeline({
-      executionBackend: "jianying-bach-v2-exact-d634-v1",
-      settings: {
-        edgeShift: 0,
-        feather: 0,
-        temporalSmoothing: 0,
-        threshold: 0.5000001,
-      },
-    });
+	it("labels vendor V2 Bach as exact and advanced Bach as QCut-refined", () => {
+		const exact = selectVideoObjectPersonCutoutPipeline({
+			executionBackend: "jianying-bach-v2-exact-d634-v1",
+			settings: {
+				edgeShift: 0,
+				feather: 0,
+				temporalSmoothing: 0,
+				threshold: 0.5,
+			},
+		});
+		const refined = selectVideoObjectPersonCutoutPipeline({
+			executionBackend: "jianying-bach-v2-exact-d634-v1",
+			settings: {
+				edgeShift: 1,
+				feather: 0,
+				temporalSmoothing: 0,
+				threshold: 0.5,
+			},
+		});
+		const roundedExact = selectVideoObjectPersonCutoutPipeline({
+			executionBackend: "jianying-bach-v2-exact-d634-v1",
+			settings: {
+				edgeShift: 0,
+				feather: 0,
+				temporalSmoothing: 0,
+				threshold: 0.50000001,
+			},
+		});
+		const floatDistinctRefined = selectVideoObjectPersonCutoutPipeline({
+			executionBackend: "jianying-bach-v2-exact-d634-v1",
+			settings: {
+				edgeShift: 0,
+				feather: 0,
+				temporalSmoothing: 0,
+				threshold: 0.5000001,
+			},
+		});
 
-    expect(exact).toBe(JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE);
-    expect(roundedExact).toBe(
-      JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-    );
-    expect(refined).toBe(
-      JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
-    );
-    expect(floatDistinctRefined).toBe(
-      JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
-    );
-  });
+		expect(exact).toBe(JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE);
+		expect(roundedExact).toBe(
+			JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
+		);
+		expect(refined).toBe(
+			JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE
+		);
+		expect(floatDistinctRefined).toBe(
+			JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE
+		);
+	});
 
-  it("rejects a pipeline descriptor for a different model route", async () => {
-    await expect(
-      createIdentity({
-        modelRoute: "video-object",
-        pipelineDescriptor: GRU_VISION_PERSON_CUTOUT_PIPELINE,
-      }),
-    ).rejects.toThrow("人物抠像管线与模型路线不一致");
-  });
+	it("rejects a pipeline descriptor for a different model route", async () => {
+		await expect(
+			createIdentity({
+				modelRoute: "video-object",
+				pipelineDescriptor: GRU_VISION_PERSON_CUTOUT_PIPELINE,
+			})
+		).rejects.toThrow("人物抠像管线与模型路线不一致");
+	});
 
-  it("shares pre-blend alpha between native and compatible compositors", async () => {
-    const [compatibleIdentity, nativeIdentity] = await Promise.all([
-      createIdentity(),
-      createIdentity({
-        blendImplementation: TEMATTING_NATIVE_METAL_CANARY,
-      }),
-    ]);
+	it("shares pre-blend alpha between native and compatible compositors", async () => {
+		const [compatibleIdentity, nativeIdentity] = await Promise.all([
+			createIdentity(),
+			createIdentity({
+				blendImplementation: TEMATTING_NATIVE_METAL_CANARY,
+			}),
+		]);
 
-    expect(createPersonCutoutCacheKey({ identity: compatibleIdentity })).toBe(
-      createPersonCutoutCacheKey({ identity: nativeIdentity }),
-    );
-    const build = await createPersonCutoutMaskCacheBuild({
-      identity: compatibleIdentity,
-    });
-    await writeFile(build.alphaPath, Buffer.alloc(24, 255));
-    const committed = await commitPersonCutoutMaskCache({
-      buildDirectory: build.directory,
-      frameCount: 2,
-      identity: compatibleIdentity,
-    });
+		expect(createPersonCutoutCacheKey({ identity: compatibleIdentity })).toBe(
+			createPersonCutoutCacheKey({ identity: nativeIdentity })
+		);
+		const build = await createPersonCutoutMaskCacheBuild({
+			identity: compatibleIdentity,
+		});
+		await writeFile(build.alphaPath, Buffer.alloc(24, 255));
+		const committed = await commitPersonCutoutMaskCache({
+			buildDirectory: build.directory,
+			frameCount: 2,
+			identity: compatibleIdentity,
+		});
 
-    expect(
-      await inspectPersonCutoutMaskCache({ identity: nativeIdentity }),
-    ).toEqual(committed);
-  });
+		expect(
+			await inspectPersonCutoutMaskCache({ identity: nativeIdentity })
+		).toEqual(committed);
+	});
 
-  it("reuses content after the editor copies it to a new temporary path", async () => {
-    const originalIdentity = await createIdentity();
-    const copiedSourcePath = path.join(temporaryDirectory, "copied-source.mp4");
-    await copyFile(sourcePath, copiedSourcePath);
-    const copiedIdentity = await createPersonCutoutCacheIdentity({
-      blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-      frameRate: 30,
-      height: 3,
-      modelName: "tt_matting_video_gru_v1.0.model",
-      modelSha256: "model-sha",
-      processorSha256: "processor-sha",
-      settings: {
-        edgeShift: 0,
-        feather: 0,
-        temporalSmoothing: 0,
-        threshold: 0.5,
-      },
-      sourcePath: copiedSourcePath,
-      width: 4,
-    });
+	it("reuses content after the editor copies it to a new temporary path", async () => {
+		const originalIdentity = await createIdentity();
+		const copiedSourcePath = path.join(temporaryDirectory, "copied-source.mp4");
+		await copyFile(sourcePath, copiedSourcePath);
+		const copiedIdentity = await createPersonCutoutCacheIdentity({
+			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+			frameRate: 30,
+			height: 3,
+			modelName: "tt_matting_video_gru_v1.0.model",
+			modelSha256: "model-sha",
+			processorSha256: "processor-sha",
+			settings: {
+				edgeShift: 0,
+				feather: 0,
+				temporalSmoothing: 0,
+				threshold: 0.5,
+			},
+			sourcePath: copiedSourcePath,
+			width: 4,
+		});
 
-    expect(createPersonCutoutCacheKey({ identity: copiedIdentity })).toBe(
-      createPersonCutoutCacheKey({ identity: originalIdentity }),
-    );
-  });
+		expect(createPersonCutoutCacheKey({ identity: copiedIdentity })).toBe(
+			createPersonCutoutCacheKey({ identity: originalIdentity })
+		);
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-metal-matting-blend.test.ts
+++ b/qcut/electron/__tests__/person-cutout-metal-matting-blend.test.ts
@@ -1,0 +1,49 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const describeOnMac = process.platform === "darwin" ? describe : describe.skip;
+let temporaryDirectory = "";
+
+describeOnMac("TEMattingBlendEffectV2 frame contract", () => {
+  beforeAll(async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(os.tmpdir(), "qcut-metal-matting-blend-test-"),
+    );
+  });
+
+  afterAll(async () => {
+    if (!temporaryDirectory) return;
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  });
+
+  it("accepts low-resolution Alpha and enforces source Alpha bounds", async () => {
+    const nativeDirectory = path.resolve(
+      "electron",
+      "jianying-person-cutout",
+      "native",
+    );
+    const executablePath = path.join(
+      temporaryDirectory,
+      "metal-matting-blend-test",
+    );
+    await execFileAsync("xcrun", [
+      "clang++",
+      "-std=c++20",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      path.join(nativeDirectory, "metal-matting-blend.cpp"),
+      path.join(nativeDirectory, "metal-matting-blend.test.cpp"),
+      "-framework",
+      "OpenGL",
+      "-o",
+      executablePath,
+    ]);
+    await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+  });
+});

--- a/qcut/electron/__tests__/person-cutout-metal-matting-blend.test.ts
+++ b/qcut/electron/__tests__/person-cutout-metal-matting-blend.test.ts
@@ -10,40 +10,40 @@ const describeOnMac = process.platform === "darwin" ? describe : describe.skip;
 let temporaryDirectory = "";
 
 describeOnMac("TEMattingBlendEffectV2 frame contract", () => {
-  beforeAll(async () => {
-    temporaryDirectory = await mkdtemp(
-      path.join(os.tmpdir(), "qcut-metal-matting-blend-test-"),
-    );
-  });
+	beforeAll(async () => {
+		temporaryDirectory = await mkdtemp(
+			path.join(os.tmpdir(), "qcut-metal-matting-blend-test-")
+		);
+	});
 
-  afterAll(async () => {
-    if (!temporaryDirectory) return;
-    await rm(temporaryDirectory, { force: true, recursive: true });
-  });
+	afterAll(async () => {
+		if (!temporaryDirectory) return;
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	});
 
-  it("accepts low-resolution Alpha and enforces source Alpha bounds", async () => {
-    const nativeDirectory = path.resolve(
-      "electron",
-      "jianying-person-cutout",
-      "native",
-    );
-    const executablePath = path.join(
-      temporaryDirectory,
-      "metal-matting-blend-test",
-    );
-    await execFileAsync("xcrun", [
-      "clang++",
-      "-std=c++20",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      path.join(nativeDirectory, "metal-matting-blend.cpp"),
-      path.join(nativeDirectory, "metal-matting-blend.test.cpp"),
-      "-framework",
-      "OpenGL",
-      "-o",
-      executablePath,
-    ]);
-    await expect(execFileAsync(executablePath)).resolves.toBeDefined();
-  });
+	it("accepts low-resolution Alpha and enforces source Alpha bounds", async () => {
+		const nativeDirectory = path.resolve(
+			"electron",
+			"jianying-person-cutout",
+			"native"
+		);
+		const executablePath = path.join(
+			temporaryDirectory,
+			"metal-matting-blend-test"
+		);
+		await execFileAsync("xcrun", [
+			"clang++",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			path.join(nativeDirectory, "metal-matting-blend.cpp"),
+			path.join(nativeDirectory, "metal-matting-blend.test.cpp"),
+			"-framework",
+			"OpenGL",
+			"-o",
+			executablePath,
+		]);
+		await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-model-route-fallback.test.ts
+++ b/qcut/electron/__tests__/person-cutout-model-route-fallback.test.ts
@@ -1,74 +1,225 @@
 import { describe, expect, it, vi } from "vitest";
 import { executePersonCutoutRouteWithFallback } from "../jianying-person-cutout/model-route-fallback.js";
+import {
+  VIDEO_OBJECT_ALPHA_QUALITY_FAILURE,
+  VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE,
+  VideoObjectRuntimeCircuitBreaker,
+} from "../jianying-person-cutout/video-object-circuit-breaker.js";
+import {
+  JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+  VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+} from "../jianying-person-cutout/pipeline-descriptor.js";
 
 const portraitRuntime = { modelRoute: "portrait-gru" as const };
-const videoObjectRuntime = { modelRoute: "video-object" as const };
+const videoObjectRuntime = {
+  modelRoute: "video-object" as const,
+  provider: "bach",
+};
+const coreMLRuntime = {
+  modelRoute: "video-object" as const,
+  provider: "coreml",
+};
+const hostRuntime = {
+  modelRoute: "video-object" as const,
+  provider: "legacy-host",
+};
 
 describe("person cutout model-route fallback", () => {
-	it("keeps a successful selected route", async () => {
-		const execute = vi.fn().mockResolvedValue("object-alpha");
-		await expect(
-			executePersonCutoutRouteWithFallback({
-				execute,
-				portraitRuntime,
-				selectedRuntime: videoObjectRuntime,
-			})
-		).resolves.toEqual({
-			didFallback: false,
-			result: "object-alpha",
-			runtime: videoObjectRuntime,
-		});
-		expect(execute).toHaveBeenCalledOnce();
-	});
+  it("keeps a successful selected route", async () => {
+    const execute = vi.fn().mockResolvedValue("object-alpha");
+    await expect(
+      executePersonCutoutRouteWithFallback({
+        execute,
+        portraitRuntime,
+        selectedRuntime: videoObjectRuntime,
+      }),
+    ).resolves.toEqual({
+      didFallback: false,
+      result: "object-alpha",
+      runtime: videoObjectRuntime,
+    });
+    expect(execute).toHaveBeenCalledOnce();
+  });
 
-	it("retries an uncalibrated advanced route with portrait GRU", async () => {
-		const failure = new Error("host Metal context is unavailable");
-		const execute = vi
-			.fn()
-			.mockRejectedValueOnce(failure)
-			.mockResolvedValueOnce("portrait-alpha");
-		const onFallback = vi.fn();
-		await expect(
-			executePersonCutoutRouteWithFallback({
-				execute,
-				onFallback,
-				portraitRuntime,
-				selectedRuntime: videoObjectRuntime,
-			})
-		).resolves.toEqual({
-			didFallback: true,
-			result: "portrait-alpha",
-			runtime: portraitRuntime,
-		});
-		expect(execute).toHaveBeenNthCalledWith(1, videoObjectRuntime);
-		expect(execute).toHaveBeenNthCalledWith(2, portraitRuntime);
-		expect(onFallback).toHaveBeenCalledWith(failure);
-	});
+  it("retries an uncalibrated advanced route with portrait GRU", async () => {
+    const failure = new Error("host Metal context is unavailable");
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce("portrait-alpha");
+    const onFallback = vi.fn();
+    await expect(
+      executePersonCutoutRouteWithFallback({
+        execute,
+        onFallback,
+        portraitRuntime,
+        selectedRuntime: videoObjectRuntime,
+      }),
+    ).resolves.toEqual({
+      didFallback: true,
+      result: "portrait-alpha",
+      runtime: portraitRuntime,
+    });
+    expect(execute).toHaveBeenNthCalledWith(1, videoObjectRuntime);
+    expect(execute).toHaveBeenNthCalledWith(2, portraitRuntime);
+    expect(onFallback).toHaveBeenCalledWith({
+      error: failure,
+      failedRuntime: videoObjectRuntime,
+      nextRuntime: portraitRuntime,
+    });
+  });
 
-	it("does not hide a portrait GRU failure", async () => {
-		const failure = new Error("GRU failed");
-		const execute = vi.fn().mockRejectedValue(failure);
-		await expect(
-			executePersonCutoutRouteWithFallback({
-				execute,
-				portraitRuntime,
-				selectedRuntime: portraitRuntime,
-			})
-		).rejects.toBe(failure);
-		expect(execute).toHaveBeenCalledOnce();
-	});
+  it("falls back in Bach, direct CoreML, legacy host, GRU order", async () => {
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Bach unavailable"))
+      .mockRejectedValueOnce(new Error("CoreML unavailable"))
+      .mockRejectedValueOnce(new Error("host unavailable"))
+      .mockResolvedValueOnce("gru-alpha");
+    const onFallback = vi.fn();
 
-	it("does not retry cancellation", async () => {
-		const cancelled = new Error("cancelled");
-		cancelled.name = "AbortError";
-		const execute = vi.fn().mockRejectedValue(cancelled);
-		await expect(
-			executePersonCutoutRouteWithFallback({
-				execute,
-				portraitRuntime,
-				selectedRuntime: videoObjectRuntime,
-			})
-		).rejects.toBe(cancelled);
-		expect(execute).toHaveBeenCalledOnce();
-	});
+    await expect(
+      executePersonCutoutRouteWithFallback({
+        execute,
+        fallbackRuntimes: [coreMLRuntime, hostRuntime],
+        onFallback,
+        portraitRuntime,
+        selectedRuntime: videoObjectRuntime,
+      }),
+    ).resolves.toEqual({
+      didFallback: true,
+      result: "gru-alpha",
+      runtime: portraitRuntime,
+    });
+    expect(execute.mock.calls.map(([runtime]) => runtime)).toEqual([
+      videoObjectRuntime,
+      coreMLRuntime,
+      hostRuntime,
+      portraitRuntime,
+    ]);
+    expect(onFallback).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops at the first successful fallback provider", async () => {
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Bach unavailable"))
+      .mockResolvedValueOnce("coreml-alpha");
+
+    await expect(
+      executePersonCutoutRouteWithFallback({
+        execute,
+        fallbackRuntimes: [coreMLRuntime, hostRuntime],
+        portraitRuntime,
+        selectedRuntime: videoObjectRuntime,
+      }),
+    ).resolves.toEqual({
+      didFallback: true,
+      result: "coreml-alpha",
+      runtime: coreMLRuntime,
+    });
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports direct CoreML after exact Bach fails and opens only the failed capability", async () => {
+    const exact = {
+      capabilitySha256: "exact-capability",
+      modelRoute: "video-object" as const,
+      pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+    };
+    const direct = {
+      capabilitySha256: "coreml-capability",
+      modelRoute: "video-object" as const,
+      pipelineDescriptor: VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+    };
+    const gru = {
+      capabilitySha256: "gru-capability",
+      modelRoute: "portrait-gru" as const,
+      pipelineDescriptor: undefined,
+    };
+    const circuitBreaker = new VideoObjectRuntimeCircuitBreaker();
+    const exactFailure = new Error(
+      `${VIDEO_OBJECT_ALPHA_QUALITY_FAILURE}: ${VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE}`,
+    );
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(exactFailure)
+      .mockResolvedValueOnce("coreml-alpha");
+
+    const attempt = await executePersonCutoutRouteWithFallback({
+      execute,
+      fallbackRuntimes: [direct],
+      onFallback: ({ error, failedRuntime }) => {
+        circuitBreaker.reject({
+          capabilitySha256: failedRuntime.capabilitySha256,
+          error,
+        });
+      },
+      portraitRuntime: gru,
+      selectedRuntime: exact,
+    });
+
+    expect(attempt).toMatchObject({
+      didFallback: true,
+      result: "coreml-alpha",
+      runtime: {
+        pipelineDescriptor: VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+      },
+    });
+    expect(
+      circuitBreaker.isOpen({ capabilitySha256: "exact-capability" }),
+    ).toBe(true);
+    expect(
+      circuitBreaker.isOpen({ capabilitySha256: "coreml-capability" }),
+    ).toBe(false);
+  });
+
+  it("fails closed when an object candidate rejects its Alpha output", async () => {
+    const badAlpha = new Error(
+      "video-object graph returned an empty alpha mask",
+    );
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(badAlpha)
+      .mockResolvedValueOnce("portrait-alpha");
+
+    await expect(
+      executePersonCutoutRouteWithFallback({
+        execute,
+        portraitRuntime,
+        selectedRuntime: videoObjectRuntime,
+      }),
+    ).resolves.toMatchObject({
+      didFallback: true,
+      result: "portrait-alpha",
+      runtime: portraitRuntime,
+    });
+  });
+
+  it("does not hide a portrait GRU failure", async () => {
+    const failure = new Error("GRU failed");
+    const execute = vi.fn().mockRejectedValue(failure);
+    await expect(
+      executePersonCutoutRouteWithFallback({
+        execute,
+        portraitRuntime,
+        selectedRuntime: portraitRuntime,
+      }),
+    ).rejects.toBe(failure);
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry cancellation", async () => {
+    const cancelled = new Error("cancelled");
+    cancelled.name = "AbortError";
+    const execute = vi.fn().mockRejectedValue(cancelled);
+    await expect(
+      executePersonCutoutRouteWithFallback({
+        execute,
+        portraitRuntime,
+        selectedRuntime: videoObjectRuntime,
+      }),
+    ).rejects.toBe(cancelled);
+    expect(execute).toHaveBeenCalledOnce();
+  });
 });

--- a/qcut/electron/__tests__/person-cutout-model-route-fallback.test.ts
+++ b/qcut/electron/__tests__/person-cutout-model-route-fallback.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { executePersonCutoutRouteWithFallback } from "../jianying-person-cutout/model-route-fallback.js";
+
+const portraitRuntime = { modelRoute: "portrait-gru" as const };
+const videoObjectRuntime = { modelRoute: "video-object" as const };
+
+describe("person cutout model-route fallback", () => {
+	it("keeps a successful selected route", async () => {
+		const execute = vi.fn().mockResolvedValue("object-alpha");
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				portraitRuntime,
+				selectedRuntime: videoObjectRuntime,
+			})
+		).resolves.toEqual({
+			didFallback: false,
+			result: "object-alpha",
+			runtime: videoObjectRuntime,
+		});
+		expect(execute).toHaveBeenCalledOnce();
+	});
+
+	it("retries an uncalibrated advanced route with portrait GRU", async () => {
+		const failure = new Error("host Metal context is unavailable");
+		const execute = vi
+			.fn()
+			.mockRejectedValueOnce(failure)
+			.mockResolvedValueOnce("portrait-alpha");
+		const onFallback = vi.fn();
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				onFallback,
+				portraitRuntime,
+				selectedRuntime: videoObjectRuntime,
+			})
+		).resolves.toEqual({
+			didFallback: true,
+			result: "portrait-alpha",
+			runtime: portraitRuntime,
+		});
+		expect(execute).toHaveBeenNthCalledWith(1, videoObjectRuntime);
+		expect(execute).toHaveBeenNthCalledWith(2, portraitRuntime);
+		expect(onFallback).toHaveBeenCalledWith(failure);
+	});
+
+	it("does not hide a portrait GRU failure", async () => {
+		const failure = new Error("GRU failed");
+		const execute = vi.fn().mockRejectedValue(failure);
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				portraitRuntime,
+				selectedRuntime: portraitRuntime,
+			})
+		).rejects.toBe(failure);
+		expect(execute).toHaveBeenCalledOnce();
+	});
+
+	it("does not retry cancellation", async () => {
+		const cancelled = new Error("cancelled");
+		cancelled.name = "AbortError";
+		const execute = vi.fn().mockRejectedValue(cancelled);
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				portraitRuntime,
+				selectedRuntime: videoObjectRuntime,
+			})
+		).rejects.toBe(cancelled);
+		expect(execute).toHaveBeenCalledOnce();
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-model-route-fallback.test.ts
+++ b/qcut/electron/__tests__/person-cutout-model-route-fallback.test.ts
@@ -1,225 +1,225 @@
 import { describe, expect, it, vi } from "vitest";
 import { executePersonCutoutRouteWithFallback } from "../jianying-person-cutout/model-route-fallback.js";
 import {
-  VIDEO_OBJECT_ALPHA_QUALITY_FAILURE,
-  VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE,
-  VideoObjectRuntimeCircuitBreaker,
+	VIDEO_OBJECT_ALPHA_QUALITY_FAILURE,
+	VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE,
+	VideoObjectRuntimeCircuitBreaker,
 } from "../jianying-person-cutout/video-object-circuit-breaker.js";
 import {
-  JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-  VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+	JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+	VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
 } from "../jianying-person-cutout/pipeline-descriptor.js";
 
 const portraitRuntime = { modelRoute: "portrait-gru" as const };
 const videoObjectRuntime = {
-  modelRoute: "video-object" as const,
-  provider: "bach",
+	modelRoute: "video-object" as const,
+	provider: "bach",
 };
 const coreMLRuntime = {
-  modelRoute: "video-object" as const,
-  provider: "coreml",
+	modelRoute: "video-object" as const,
+	provider: "coreml",
 };
 const hostRuntime = {
-  modelRoute: "video-object" as const,
-  provider: "legacy-host",
+	modelRoute: "video-object" as const,
+	provider: "legacy-host",
 };
 
 describe("person cutout model-route fallback", () => {
-  it("keeps a successful selected route", async () => {
-    const execute = vi.fn().mockResolvedValue("object-alpha");
-    await expect(
-      executePersonCutoutRouteWithFallback({
-        execute,
-        portraitRuntime,
-        selectedRuntime: videoObjectRuntime,
-      }),
-    ).resolves.toEqual({
-      didFallback: false,
-      result: "object-alpha",
-      runtime: videoObjectRuntime,
-    });
-    expect(execute).toHaveBeenCalledOnce();
-  });
+	it("keeps a successful selected route", async () => {
+		const execute = vi.fn().mockResolvedValue("object-alpha");
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				portraitRuntime,
+				selectedRuntime: videoObjectRuntime,
+			})
+		).resolves.toEqual({
+			didFallback: false,
+			result: "object-alpha",
+			runtime: videoObjectRuntime,
+		});
+		expect(execute).toHaveBeenCalledOnce();
+	});
 
-  it("retries an uncalibrated advanced route with portrait GRU", async () => {
-    const failure = new Error("host Metal context is unavailable");
-    const execute = vi
-      .fn()
-      .mockRejectedValueOnce(failure)
-      .mockResolvedValueOnce("portrait-alpha");
-    const onFallback = vi.fn();
-    await expect(
-      executePersonCutoutRouteWithFallback({
-        execute,
-        onFallback,
-        portraitRuntime,
-        selectedRuntime: videoObjectRuntime,
-      }),
-    ).resolves.toEqual({
-      didFallback: true,
-      result: "portrait-alpha",
-      runtime: portraitRuntime,
-    });
-    expect(execute).toHaveBeenNthCalledWith(1, videoObjectRuntime);
-    expect(execute).toHaveBeenNthCalledWith(2, portraitRuntime);
-    expect(onFallback).toHaveBeenCalledWith({
-      error: failure,
-      failedRuntime: videoObjectRuntime,
-      nextRuntime: portraitRuntime,
-    });
-  });
+	it("retries an uncalibrated advanced route with portrait GRU", async () => {
+		const failure = new Error("host Metal context is unavailable");
+		const execute = vi
+			.fn()
+			.mockRejectedValueOnce(failure)
+			.mockResolvedValueOnce("portrait-alpha");
+		const onFallback = vi.fn();
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				onFallback,
+				portraitRuntime,
+				selectedRuntime: videoObjectRuntime,
+			})
+		).resolves.toEqual({
+			didFallback: true,
+			result: "portrait-alpha",
+			runtime: portraitRuntime,
+		});
+		expect(execute).toHaveBeenNthCalledWith(1, videoObjectRuntime);
+		expect(execute).toHaveBeenNthCalledWith(2, portraitRuntime);
+		expect(onFallback).toHaveBeenCalledWith({
+			error: failure,
+			failedRuntime: videoObjectRuntime,
+			nextRuntime: portraitRuntime,
+		});
+	});
 
-  it("falls back in Bach, direct CoreML, legacy host, GRU order", async () => {
-    const execute = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("Bach unavailable"))
-      .mockRejectedValueOnce(new Error("CoreML unavailable"))
-      .mockRejectedValueOnce(new Error("host unavailable"))
-      .mockResolvedValueOnce("gru-alpha");
-    const onFallback = vi.fn();
+	it("falls back in Bach, direct CoreML, legacy host, GRU order", async () => {
+		const execute = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Bach unavailable"))
+			.mockRejectedValueOnce(new Error("CoreML unavailable"))
+			.mockRejectedValueOnce(new Error("host unavailable"))
+			.mockResolvedValueOnce("gru-alpha");
+		const onFallback = vi.fn();
 
-    await expect(
-      executePersonCutoutRouteWithFallback({
-        execute,
-        fallbackRuntimes: [coreMLRuntime, hostRuntime],
-        onFallback,
-        portraitRuntime,
-        selectedRuntime: videoObjectRuntime,
-      }),
-    ).resolves.toEqual({
-      didFallback: true,
-      result: "gru-alpha",
-      runtime: portraitRuntime,
-    });
-    expect(execute.mock.calls.map(([runtime]) => runtime)).toEqual([
-      videoObjectRuntime,
-      coreMLRuntime,
-      hostRuntime,
-      portraitRuntime,
-    ]);
-    expect(onFallback).toHaveBeenCalledTimes(3);
-  });
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				fallbackRuntimes: [coreMLRuntime, hostRuntime],
+				onFallback,
+				portraitRuntime,
+				selectedRuntime: videoObjectRuntime,
+			})
+		).resolves.toEqual({
+			didFallback: true,
+			result: "gru-alpha",
+			runtime: portraitRuntime,
+		});
+		expect(execute.mock.calls.map(([runtime]) => runtime)).toEqual([
+			videoObjectRuntime,
+			coreMLRuntime,
+			hostRuntime,
+			portraitRuntime,
+		]);
+		expect(onFallback).toHaveBeenCalledTimes(3);
+	});
 
-  it("stops at the first successful fallback provider", async () => {
-    const execute = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("Bach unavailable"))
-      .mockResolvedValueOnce("coreml-alpha");
+	it("stops at the first successful fallback provider", async () => {
+		const execute = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Bach unavailable"))
+			.mockResolvedValueOnce("coreml-alpha");
 
-    await expect(
-      executePersonCutoutRouteWithFallback({
-        execute,
-        fallbackRuntimes: [coreMLRuntime, hostRuntime],
-        portraitRuntime,
-        selectedRuntime: videoObjectRuntime,
-      }),
-    ).resolves.toEqual({
-      didFallback: true,
-      result: "coreml-alpha",
-      runtime: coreMLRuntime,
-    });
-    expect(execute).toHaveBeenCalledTimes(2);
-  });
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				fallbackRuntimes: [coreMLRuntime, hostRuntime],
+				portraitRuntime,
+				selectedRuntime: videoObjectRuntime,
+			})
+		).resolves.toEqual({
+			didFallback: true,
+			result: "coreml-alpha",
+			runtime: coreMLRuntime,
+		});
+		expect(execute).toHaveBeenCalledTimes(2);
+	});
 
-  it("reports direct CoreML after exact Bach fails and opens only the failed capability", async () => {
-    const exact = {
-      capabilitySha256: "exact-capability",
-      modelRoute: "video-object" as const,
-      pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-    };
-    const direct = {
-      capabilitySha256: "coreml-capability",
-      modelRoute: "video-object" as const,
-      pipelineDescriptor: VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-    };
-    const gru = {
-      capabilitySha256: "gru-capability",
-      modelRoute: "portrait-gru" as const,
-      pipelineDescriptor: undefined,
-    };
-    const circuitBreaker = new VideoObjectRuntimeCircuitBreaker();
-    const exactFailure = new Error(
-      `${VIDEO_OBJECT_ALPHA_QUALITY_FAILURE}: ${VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE}`,
-    );
-    const execute = vi
-      .fn()
-      .mockRejectedValueOnce(exactFailure)
-      .mockResolvedValueOnce("coreml-alpha");
+	it("reports direct CoreML after exact Bach fails and opens only the failed capability", async () => {
+		const exact = {
+			capabilitySha256: "exact-capability",
+			modelRoute: "video-object" as const,
+			pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+		};
+		const direct = {
+			capabilitySha256: "coreml-capability",
+			modelRoute: "video-object" as const,
+			pipelineDescriptor: VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+		};
+		const gru = {
+			capabilitySha256: "gru-capability",
+			modelRoute: "portrait-gru" as const,
+			pipelineDescriptor: undefined,
+		};
+		const circuitBreaker = new VideoObjectRuntimeCircuitBreaker();
+		const exactFailure = new Error(
+			`${VIDEO_OBJECT_ALPHA_QUALITY_FAILURE}: ${VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE}`
+		);
+		const execute = vi
+			.fn()
+			.mockRejectedValueOnce(exactFailure)
+			.mockResolvedValueOnce("coreml-alpha");
 
-    const attempt = await executePersonCutoutRouteWithFallback({
-      execute,
-      fallbackRuntimes: [direct],
-      onFallback: ({ error, failedRuntime }) => {
-        circuitBreaker.reject({
-          capabilitySha256: failedRuntime.capabilitySha256,
-          error,
-        });
-      },
-      portraitRuntime: gru,
-      selectedRuntime: exact,
-    });
+		const attempt = await executePersonCutoutRouteWithFallback({
+			execute,
+			fallbackRuntimes: [direct],
+			onFallback: ({ error, failedRuntime }) => {
+				circuitBreaker.reject({
+					capabilitySha256: failedRuntime.capabilitySha256,
+					error,
+				});
+			},
+			portraitRuntime: gru,
+			selectedRuntime: exact,
+		});
 
-    expect(attempt).toMatchObject({
-      didFallback: true,
-      result: "coreml-alpha",
-      runtime: {
-        pipelineDescriptor: VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-      },
-    });
-    expect(
-      circuitBreaker.isOpen({ capabilitySha256: "exact-capability" }),
-    ).toBe(true);
-    expect(
-      circuitBreaker.isOpen({ capabilitySha256: "coreml-capability" }),
-    ).toBe(false);
-  });
+		expect(attempt).toMatchObject({
+			didFallback: true,
+			result: "coreml-alpha",
+			runtime: {
+				pipelineDescriptor: VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+			},
+		});
+		expect(
+			circuitBreaker.isOpen({ capabilitySha256: "exact-capability" })
+		).toBe(true);
+		expect(
+			circuitBreaker.isOpen({ capabilitySha256: "coreml-capability" })
+		).toBe(false);
+	});
 
-  it("fails closed when an object candidate rejects its Alpha output", async () => {
-    const badAlpha = new Error(
-      "video-object graph returned an empty alpha mask",
-    );
-    const execute = vi
-      .fn()
-      .mockRejectedValueOnce(badAlpha)
-      .mockResolvedValueOnce("portrait-alpha");
+	it("fails closed when an object candidate rejects its Alpha output", async () => {
+		const badAlpha = new Error(
+			"video-object graph returned an empty alpha mask"
+		);
+		const execute = vi
+			.fn()
+			.mockRejectedValueOnce(badAlpha)
+			.mockResolvedValueOnce("portrait-alpha");
 
-    await expect(
-      executePersonCutoutRouteWithFallback({
-        execute,
-        portraitRuntime,
-        selectedRuntime: videoObjectRuntime,
-      }),
-    ).resolves.toMatchObject({
-      didFallback: true,
-      result: "portrait-alpha",
-      runtime: portraitRuntime,
-    });
-  });
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				portraitRuntime,
+				selectedRuntime: videoObjectRuntime,
+			})
+		).resolves.toMatchObject({
+			didFallback: true,
+			result: "portrait-alpha",
+			runtime: portraitRuntime,
+		});
+	});
 
-  it("does not hide a portrait GRU failure", async () => {
-    const failure = new Error("GRU failed");
-    const execute = vi.fn().mockRejectedValue(failure);
-    await expect(
-      executePersonCutoutRouteWithFallback({
-        execute,
-        portraitRuntime,
-        selectedRuntime: portraitRuntime,
-      }),
-    ).rejects.toBe(failure);
-    expect(execute).toHaveBeenCalledOnce();
-  });
+	it("does not hide a portrait GRU failure", async () => {
+		const failure = new Error("GRU failed");
+		const execute = vi.fn().mockRejectedValue(failure);
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				portraitRuntime,
+				selectedRuntime: portraitRuntime,
+			})
+		).rejects.toBe(failure);
+		expect(execute).toHaveBeenCalledOnce();
+	});
 
-  it("does not retry cancellation", async () => {
-    const cancelled = new Error("cancelled");
-    cancelled.name = "AbortError";
-    const execute = vi.fn().mockRejectedValue(cancelled);
-    await expect(
-      executePersonCutoutRouteWithFallback({
-        execute,
-        portraitRuntime,
-        selectedRuntime: videoObjectRuntime,
-      }),
-    ).rejects.toBe(cancelled);
-    expect(execute).toHaveBeenCalledOnce();
-  });
+	it("does not retry cancellation", async () => {
+		const cancelled = new Error("cancelled");
+		cancelled.name = "AbortError";
+		const execute = vi.fn().mockRejectedValue(cancelled);
+		await expect(
+			executePersonCutoutRouteWithFallback({
+				execute,
+				portraitRuntime,
+				selectedRuntime: videoObjectRuntime,
+			})
+		).rejects.toBe(cancelled);
+		expect(execute).toHaveBeenCalledOnce();
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-model-router.test.ts
+++ b/qcut/electron/__tests__/person-cutout-model-router.test.ts
@@ -1,8 +1,119 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+	detectPersonCutoutModelRoute,
+	JIANYING_FACE_SAMPLE_RATIO_THRESHOLD,
+	type PersonCutoutModelRouterDependencies,
 	resolvePersonCutoutRoutingMode,
 	selectPersonCutoutRoute,
 } from "../jianying-person-cutout/model-router.js";
+
+const WIDTH = 2;
+const HEIGHT = 2;
+const FRAME_BYTES = WIDTH * HEIGHT * 4;
+
+function createRouterHarness({
+	cleanupFails = false,
+	detectionFailureIndexes = new Set<number>(),
+	extractionFailureIndexes = new Set<number>(),
+	faceResults = [false, false, false],
+	shortSampleIndexes = new Set<number>(),
+	warningFails = false,
+}: {
+	cleanupFails?: boolean;
+	detectionFailureIndexes?: Set<number>;
+	extractionFailureIndexes?: Set<number>;
+	faceResults?: boolean[];
+	shortSampleIndexes?: Set<number>;
+	warningFails?: boolean;
+} = {}) {
+	let detectionIndex = 0;
+	const clear = cleanupFails
+		? vi.fn().mockRejectedValue(new Error("clear failed"))
+		: vi.fn().mockResolvedValue(undefined);
+	const detectFace = vi.fn(async () => {
+		const currentIndex = detectionIndex;
+		detectionIndex += 1;
+		if (detectionFailureIndexes.has(currentIndex)) {
+			throw new Error(`detection ${currentIndex} failed`);
+		}
+		return faceResults[currentIndex] ?? false;
+	});
+	const createFaceDetector = vi.fn(() => ({ clear, detectFace }));
+	const createTemporaryDirectory = vi
+		.fn()
+		.mockResolvedValue("/tmp/router-test");
+	const extractSample = vi.fn(
+		async ({ sampleIndex }: { sampleIndex: number }) => {
+			if (extractionFailureIndexes.has(sampleIndex)) {
+				throw new Error(`extraction ${sampleIndex} failed`);
+			}
+		}
+	);
+	const readSample = vi.fn(async ({ filePath }: { filePath: string }) => {
+		const match = /sample-(\d+)\.rgba$/.exec(filePath);
+		const sampleIndex = Number(match?.[1] ?? -1);
+		return new Uint8Array(
+			shortSampleIndexes.has(sampleIndex) ? FRAME_BYTES - 1 : FRAME_BYTES
+		);
+	});
+	const removeTemporaryDirectory = cleanupFails
+		? vi.fn().mockRejectedValue(new Error("remove failed"))
+		: vi.fn().mockResolvedValue(undefined);
+	const warn = warningFails
+		? vi.fn(() => {
+				throw new Error("warning failed");
+			})
+		: vi.fn();
+	const dependencies: PersonCutoutModelRouterDependencies = {
+		createFaceDetector,
+		createTemporaryDirectory,
+		extractSample,
+		readSample,
+		removeTemporaryDirectory,
+		warn,
+	};
+	return {
+		clear,
+		createFaceDetector,
+		createTemporaryDirectory,
+		dependencies,
+		detectFace,
+		extractSample,
+		readSample,
+		removeTemporaryDirectory,
+		warn,
+	};
+}
+
+function detectionRequest({
+	dependencies,
+	duration = 2,
+	frameRate = 30,
+	height = HEIGHT,
+	signal,
+	videoObjectCandidateAvailable = true,
+	width = WIDTH,
+}: {
+	dependencies: PersonCutoutModelRouterDependencies;
+	duration?: number;
+	frameRate?: number;
+	height?: number;
+	signal?: AbortSignal;
+	videoObjectCandidateAvailable?: boolean;
+	width?: number;
+}) {
+	return detectPersonCutoutModelRoute({
+		dependencies,
+		duration,
+		ffmpegPath: "/ffmpeg",
+		frameRate,
+		height,
+		signal,
+		sourcePath: "/source.mp4",
+		videoObjectCandidateAvailable,
+		width,
+	});
+}
 
 describe("person cutout model routing", () => {
 	it("keeps the user-facing person cutout on portrait GRU by default", () => {
@@ -36,69 +147,216 @@ describe("person cutout model routing", () => {
 		).toBe("portrait-gru");
 	});
 
-	it("keeps portrait GRU when at least half of sampled frames have a face", () => {
+	it("matches Jianying's confirmed 0.5 face-frame ratio boundary", () => {
+		expect(JIANYING_FACE_SAMPLE_RATIO_THRESHOLD).toBe(0.5);
 		expect(
 			selectPersonCutoutRoute({
-				facePositiveSampleCount: 2,
-				personPositiveSampleCount: 2,
-				personValidSampleCount: 3,
-				validSampleCount: 3,
-				videoObjectAvailable: true,
+				expectedSampleCount: 2,
+				facePositiveSampleCount: 0,
+				validSampleCount: 2,
+				videoObjectCandidateAvailable: true,
 			})
-		).toBe("portrait-gru");
+		).toMatchObject({
+			confidence: "sampled-face-ratio",
+			faceSampleRatio: 0,
+			reason: "face-ratio-below-threshold",
+			route: "video-object",
+		});
 		expect(
 			selectPersonCutoutRoute({
-				facePositiveSampleCount: 2,
-				personPositiveSampleCount: 2,
-				personValidSampleCount: 4,
-				validSampleCount: 4,
-				videoObjectAvailable: true,
+				expectedSampleCount: 2,
+				facePositiveSampleCount: 1,
+				validSampleCount: 2,
+				videoObjectCandidateAvailable: true,
 			})
-		).toBe("portrait-gru");
+		).toMatchObject({
+			confidence: "sampled-face-ratio",
+			faceSampleRatio: 0.5,
+			reason: "face-ratio-at-or-above-threshold",
+			route: "portrait-gru",
+		});
 	});
 
-	it("does not treat missing faces as proof that a person is absent", () => {
-		expect(
-			selectPersonCutoutRoute({
-				facePositiveSampleCount: 0,
-				personPositiveSampleCount: 0,
-				personValidSampleCount: 0,
-				validSampleCount: 3,
-				videoObjectAvailable: true,
-			})
-		).toBe("portrait-gru");
+	it("uses the complete sample ratio rather than exiting after the first face", async () => {
+		const harness = createRouterHarness({
+			faceResults: [true, false, false],
+		});
+
+		await expect(
+			detectionRequest({ dependencies: harness.dependencies })
+		).resolves.toMatchObject({
+			confidence: "sampled-face-ratio",
+			expectedSampleCount: 3,
+			facePositiveSampleCount: 1,
+			faceSampleRatio: 1 / 3,
+			reason: "face-ratio-below-threshold",
+			route: "video-object",
+			validSampleCount: 3,
+		});
+		expect(harness.detectFace).toHaveBeenCalledTimes(3);
+		expect(harness.clear).toHaveBeenCalledOnce();
+		expect(harness.removeTemporaryDirectory).toHaveBeenCalledOnce();
 	});
 
-	it("uses video-object only after an independent non-person classification", () => {
-		expect(
-			selectPersonCutoutRoute({
-				facePositiveSampleCount: 0,
-				personPositiveSampleCount: 0,
-				personValidSampleCount: 3,
-				validSampleCount: 3,
-				videoObjectAvailable: true,
-			})
-		).toBe("video-object");
+	it("fails closed when any extracted or detected sample is invalid", async () => {
+		for (const harness of [
+			createRouterHarness({ extractionFailureIndexes: new Set([1]) }),
+			createRouterHarness({ shortSampleIndexes: new Set([1]) }),
+			createRouterHarness({ detectionFailureIndexes: new Set([1]) }),
+		]) {
+			await expect(
+				detectionRequest({ dependencies: harness.dependencies })
+			).resolves.toMatchObject({
+				confidence: "fail-closed",
+				faceSampleRatio: null,
+				reason: "incomplete-face-samples",
+				route: "portrait-gru",
+				validSampleCount: 2,
+			});
+		}
 	});
 
-	it("fails closed to GRU when sampling or video-object is unavailable", () => {
-		expect(
-			selectPersonCutoutRoute({
+	it("fails closed for zero, partial, and impossible sample counts", () => {
+		for (const counts of [
+			{
+				expectedSampleCount: 0,
 				facePositiveSampleCount: 0,
-				personPositiveSampleCount: 0,
-				personValidSampleCount: 0,
 				validSampleCount: 0,
-				videoObjectAvailable: true,
-			})
-		).toBe("portrait-gru");
-		expect(
-			selectPersonCutoutRoute({
+			},
+			{
+				expectedSampleCount: 3,
 				facePositiveSampleCount: 0,
-				personPositiveSampleCount: 0,
-				personValidSampleCount: 3,
+				validSampleCount: 2,
+			},
+			{
+				expectedSampleCount: 3,
+				facePositiveSampleCount: 3,
+				validSampleCount: 2,
+			},
+			{
+				expectedSampleCount: 3,
+				facePositiveSampleCount: -1,
 				validSampleCount: 3,
-				videoObjectAvailable: false,
+			},
+		]) {
+			const decision = selectPersonCutoutRoute({
+				...counts,
+				videoObjectCandidateAvailable: true,
+			});
+			expect(decision.route).toBe("portrait-gru");
+			expect(decision.confidence).toBe("fail-closed");
+			expect(decision.faceSampleRatio).toBeNull();
+		}
+	});
+
+	it("skips sampling when video-object is unavailable", async () => {
+		const harness = createRouterHarness();
+
+		await expect(
+			detectionRequest({
+				dependencies: harness.dependencies,
+				videoObjectCandidateAvailable: false,
 			})
-		).toBe("portrait-gru");
+		).resolves.toMatchObject({
+			confidence: "fail-closed",
+			reason: "video-object-unavailable",
+			route: "portrait-gru",
+		});
+		expect(harness.createTemporaryDirectory).not.toHaveBeenCalled();
+		expect(harness.createFaceDetector).not.toHaveBeenCalled();
+	});
+
+	it("fails closed before sampling invalid video metadata", async () => {
+		const harness = createRouterHarness();
+
+		await expect(
+			detectionRequest({
+				dependencies: harness.dependencies,
+				duration: 0,
+			})
+		).resolves.toMatchObject({
+			confidence: "fail-closed",
+			reason: "invalid-video-metadata",
+			route: "portrait-gru",
+		});
+		expect(harness.createTemporaryDirectory).not.toHaveBeenCalled();
+	});
+
+	it("cancels before creating routing resources", async () => {
+		const harness = createRouterHarness();
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			detectionRequest({
+				dependencies: harness.dependencies,
+				signal: controller.signal,
+			})
+		).rejects.toMatchObject({ name: "AbortError" });
+		expect(harness.createTemporaryDirectory).not.toHaveBeenCalled();
+		expect(harness.createFaceDetector).not.toHaveBeenCalled();
+	});
+
+	it("stops before the next face sample after cancellation", async () => {
+		const harness = createRouterHarness();
+		const controller = new AbortController();
+		harness.detectFace.mockImplementationOnce(async () => {
+			controller.abort();
+			return false;
+		});
+
+		await expect(
+			detectionRequest({
+				dependencies: harness.dependencies,
+				signal: controller.signal,
+			})
+		).rejects.toMatchObject({ name: "AbortError" });
+		expect(harness.detectFace).toHaveBeenCalledOnce();
+		expect(harness.clear).toHaveBeenCalledOnce();
+		expect(harness.removeTemporaryDirectory).toHaveBeenCalledOnce();
+	});
+
+	it("passes cancellation to every FFmpeg extraction", async () => {
+		const harness = createRouterHarness();
+		const controller = new AbortController();
+		harness.extractSample.mockImplementation(
+			async ({ sampleIndex }: { sampleIndex: number }) => {
+				if (sampleIndex !== 0) return;
+				controller.abort();
+				throw new Error("extraction aborted");
+			}
+		);
+
+		await expect(
+			detectionRequest({
+				dependencies: harness.dependencies,
+				signal: controller.signal,
+			})
+		).rejects.toMatchObject({ name: "AbortError" });
+		for (const call of harness.extractSample.mock.calls) {
+			expect(call[0].signal).toBe(controller.signal);
+		}
+		expect(harness.detectFace).not.toHaveBeenCalled();
+		expect(harness.clear).toHaveBeenCalledOnce();
+		expect(harness.removeTemporaryDirectory).toHaveBeenCalledOnce();
+	});
+
+	it("does not let cleanup or diagnostic failures override fallback", async () => {
+		const harness = createRouterHarness({
+			cleanupFails: true,
+			extractionFailureIndexes: new Set([1]),
+			warningFails: true,
+		});
+
+		await expect(
+			detectionRequest({ dependencies: harness.dependencies })
+		).resolves.toMatchObject({
+			confidence: "fail-closed",
+			reason: "incomplete-face-samples",
+			route: "portrait-gru",
+		});
+		expect(harness.clear).toHaveBeenCalledOnce();
+		expect(harness.removeTemporaryDirectory).toHaveBeenCalledOnce();
+		expect(harness.warn).toHaveBeenCalledTimes(2);
 	});
 });

--- a/qcut/electron/__tests__/person-cutout-model-router.test.ts
+++ b/qcut/electron/__tests__/person-cutout-model-router.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+	resolvePersonCutoutRoutingMode,
+	selectPersonCutoutRoute,
+} from "../jianying-person-cutout/model-router.js";
+
+describe("person cutout model routing", () => {
+	it("keeps the user-facing person cutout on portrait GRU by default", () => {
+		expect(
+			resolvePersonCutoutRoutingMode({
+				automaticRoutingEnabled: false,
+			})
+		).toBe("portrait-gru");
+	});
+
+	it("allows an explicit advanced model route", () => {
+		expect(
+			resolvePersonCutoutRoutingMode({
+				automaticRoutingEnabled: false,
+				requestedRoute: "video-object",
+			})
+		).toBe("video-object");
+	});
+
+	it("uses face-based routing only when the experiment is enabled", () => {
+		expect(
+			resolvePersonCutoutRoutingMode({
+				automaticRoutingEnabled: true,
+			})
+		).toBe("auto");
+		expect(
+			resolvePersonCutoutRoutingMode({
+				automaticRoutingEnabled: true,
+				requestedRoute: "portrait-gru",
+			})
+		).toBe("portrait-gru");
+	});
+
+	it("keeps portrait GRU when at least half of sampled frames have a face", () => {
+		expect(
+			selectPersonCutoutRoute({
+				facePositiveSampleCount: 2,
+				personPositiveSampleCount: 2,
+				personValidSampleCount: 3,
+				validSampleCount: 3,
+				videoObjectAvailable: true,
+			})
+		).toBe("portrait-gru");
+		expect(
+			selectPersonCutoutRoute({
+				facePositiveSampleCount: 2,
+				personPositiveSampleCount: 2,
+				personValidSampleCount: 4,
+				validSampleCount: 4,
+				videoObjectAvailable: true,
+			})
+		).toBe("portrait-gru");
+	});
+
+	it("does not treat missing faces as proof that a person is absent", () => {
+		expect(
+			selectPersonCutoutRoute({
+				facePositiveSampleCount: 0,
+				personPositiveSampleCount: 0,
+				personValidSampleCount: 0,
+				validSampleCount: 3,
+				videoObjectAvailable: true,
+			})
+		).toBe("portrait-gru");
+	});
+
+	it("uses video-object only after an independent non-person classification", () => {
+		expect(
+			selectPersonCutoutRoute({
+				facePositiveSampleCount: 0,
+				personPositiveSampleCount: 0,
+				personValidSampleCount: 3,
+				validSampleCount: 3,
+				videoObjectAvailable: true,
+			})
+		).toBe("video-object");
+	});
+
+	it("fails closed to GRU when sampling or video-object is unavailable", () => {
+		expect(
+			selectPersonCutoutRoute({
+				facePositiveSampleCount: 0,
+				personPositiveSampleCount: 0,
+				personValidSampleCount: 0,
+				validSampleCount: 0,
+				videoObjectAvailable: true,
+			})
+		).toBe("portrait-gru");
+		expect(
+			selectPersonCutoutRoute({
+				facePositiveSampleCount: 0,
+				personPositiveSampleCount: 0,
+				personValidSampleCount: 3,
+				validSampleCount: 3,
+				videoObjectAvailable: false,
+			})
+		).toBe("portrait-gru");
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-process-inactivity-watchdog.test.ts
+++ b/qcut/electron/__tests__/person-cutout-process-inactivity-watchdog.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createProcessInactivityWatchdog } from "../jianying-person-cutout/process-inactivity-watchdog.js";
+
+describe("person cutout process inactivity watchdog", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("fires only after a complete inactive interval", () => {
+		vi.useFakeTimers();
+		const onTimeout = vi.fn();
+		const watchdog = createProcessInactivityWatchdog({
+			onTimeout,
+			timeoutMs: 1000,
+		});
+
+		watchdog.reset();
+		vi.advanceTimersByTime(900);
+		watchdog.reset();
+		vi.advanceTimersByTime(900);
+		expect(onTimeout).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(100);
+		expect(onTimeout).toHaveBeenCalledOnce();
+	});
+
+	it("cancels a pending timeout after process completion", () => {
+		vi.useFakeTimers();
+		const onTimeout = vi.fn();
+		const watchdog = createProcessInactivityWatchdog({
+			onTimeout,
+			timeoutMs: 1000,
+		});
+
+		watchdog.reset();
+		watchdog.clear();
+		vi.runAllTimers();
+		expect(onTimeout).not.toHaveBeenCalled();
+	});
+
+	it("rejects invalid timeout values", () => {
+		expect(() =>
+			createProcessInactivityWatchdog({ onTimeout: vi.fn(), timeoutMs: 0 })
+		).toThrow("进程无响应超时时间无效");
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-process-pipeline.test.ts
+++ b/qcut/electron/__tests__/person-cutout-process-pipeline.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+import { spawn } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import {
+  connectPersonCutoutProcessPipe,
+  createPersonCutoutRgbaDecoderArguments,
+  waitForPersonCutoutProcesses,
+} from "../jianying-person-cutout/process-pipeline.js";
+
+function spawnScript({ source }: { source: string }) {
+  return spawn(process.execPath, ["-e", source], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+describe("person cutout streaming process pipeline", () => {
+  it("decodes RGBA to stdout without creating a full-frame temporary file", () => {
+    expect(
+      createPersonCutoutRgbaDecoderArguments({
+        sourcePath: "/media/source.mp4",
+      }),
+    ).toEqual([
+      "-v",
+      "error",
+      "-i",
+      "/media/source.mp4",
+      "-map",
+      "0:v:0",
+      "-pix_fmt",
+      "rgba",
+      "-f",
+      "rawvideo",
+      "pipe:1",
+    ]);
+  });
+
+  it("surfaces a decoder failure and terminates the bridge", async () => {
+    const decoder = spawnScript({
+      source: 'process.stderr.write("decode failed\\n"); process.exit(7)',
+    });
+    const bridge = spawnScript({
+      source: "process.stdin.resume(); setInterval(() => {}, 1000)",
+    });
+    connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
+
+    await expect(
+      waitForPersonCutoutProcesses({
+        processes: [
+          { child: decoder, label: "视频解码" },
+          { child: bridge, label: "剪映主体分析" },
+        ],
+      }),
+    ).rejects.toThrow(/视频解码失败.*decode failed/s);
+  });
+
+  it("surfaces a bridge failure without leaking an EPIPE error", async () => {
+    const decoder = spawnScript({
+      source:
+        "const chunk = Buffer.alloc(65536); setInterval(() => process.stdout.write(chunk), 1)",
+    });
+    const bridge = spawnScript({
+      source: 'process.stderr.write("bridge failed\\n"); process.exit(9)',
+    });
+    connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
+
+    await expect(
+      waitForPersonCutoutProcesses({
+        processes: [
+          { child: decoder, label: "视频解码" },
+          { child: bridge, label: "剪映主体分析" },
+        ],
+      }),
+    ).rejects.toThrow(/剪映主体分析失败.*bridge failed/s);
+  });
+
+  it("terminates both sides when the caller aborts", async () => {
+    const controller = new AbortController();
+    const decoder = spawnScript({
+      source: "setInterval(() => process.stdout.write('frame'), 10)",
+    });
+    const bridge = spawnScript({
+      source: "process.stdin.resume(); setInterval(() => {}, 1000)",
+    });
+    connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
+    const pending = waitForPersonCutoutProcesses({
+      processes: [
+        { child: decoder, label: "视频解码" },
+        { child: bridge, label: "剪映主体分析" },
+      ],
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/qcut/electron/__tests__/person-cutout-process-pipeline.test.ts
+++ b/qcut/electron/__tests__/person-cutout-process-pipeline.test.ts
@@ -2,95 +2,95 @@
 import { spawn } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
-  connectPersonCutoutProcessPipe,
-  createPersonCutoutRgbaDecoderArguments,
-  waitForPersonCutoutProcesses,
+	connectPersonCutoutProcessPipe,
+	createPersonCutoutRgbaDecoderArguments,
+	waitForPersonCutoutProcesses,
 } from "../jianying-person-cutout/process-pipeline.js";
 
 function spawnScript({ source }: { source: string }) {
-  return spawn(process.execPath, ["-e", source], {
-    stdio: ["pipe", "pipe", "pipe"],
-  });
+	return spawn(process.execPath, ["-e", source], {
+		stdio: ["pipe", "pipe", "pipe"],
+	});
 }
 
 describe("person cutout streaming process pipeline", () => {
-  it("decodes RGBA to stdout without creating a full-frame temporary file", () => {
-    expect(
-      createPersonCutoutRgbaDecoderArguments({
-        sourcePath: "/media/source.mp4",
-      }),
-    ).toEqual([
-      "-v",
-      "error",
-      "-i",
-      "/media/source.mp4",
-      "-map",
-      "0:v:0",
-      "-pix_fmt",
-      "rgba",
-      "-f",
-      "rawvideo",
-      "pipe:1",
-    ]);
-  });
+	it("decodes RGBA to stdout without creating a full-frame temporary file", () => {
+		expect(
+			createPersonCutoutRgbaDecoderArguments({
+				sourcePath: "/media/source.mp4",
+			})
+		).toEqual([
+			"-v",
+			"error",
+			"-i",
+			"/media/source.mp4",
+			"-map",
+			"0:v:0",
+			"-pix_fmt",
+			"rgba",
+			"-f",
+			"rawvideo",
+			"pipe:1",
+		]);
+	});
 
-  it("surfaces a decoder failure and terminates the bridge", async () => {
-    const decoder = spawnScript({
-      source: 'process.stderr.write("decode failed\\n"); process.exit(7)',
-    });
-    const bridge = spawnScript({
-      source: "process.stdin.resume(); setInterval(() => {}, 1000)",
-    });
-    connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
+	it("surfaces a decoder failure and terminates the bridge", async () => {
+		const decoder = spawnScript({
+			source: 'process.stderr.write("decode failed\\n"); process.exit(7)',
+		});
+		const bridge = spawnScript({
+			source: "process.stdin.resume(); setInterval(() => {}, 1000)",
+		});
+		connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
 
-    await expect(
-      waitForPersonCutoutProcesses({
-        processes: [
-          { child: decoder, label: "视频解码" },
-          { child: bridge, label: "剪映主体分析" },
-        ],
-      }),
-    ).rejects.toThrow(/视频解码失败.*decode failed/s);
-  });
+		await expect(
+			waitForPersonCutoutProcesses({
+				processes: [
+					{ child: decoder, label: "视频解码" },
+					{ child: bridge, label: "剪映主体分析" },
+				],
+			})
+		).rejects.toThrow(/视频解码失败.*decode failed/s);
+	});
 
-  it("surfaces a bridge failure without leaking an EPIPE error", async () => {
-    const decoder = spawnScript({
-      source:
-        "const chunk = Buffer.alloc(65536); setInterval(() => process.stdout.write(chunk), 1)",
-    });
-    const bridge = spawnScript({
-      source: 'process.stderr.write("bridge failed\\n"); process.exit(9)',
-    });
-    connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
+	it("surfaces a bridge failure without leaking an EPIPE error", async () => {
+		const decoder = spawnScript({
+			source:
+				"const chunk = Buffer.alloc(65536); setInterval(() => process.stdout.write(chunk), 1)",
+		});
+		const bridge = spawnScript({
+			source: 'process.stderr.write("bridge failed\\n"); process.exit(9)',
+		});
+		connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
 
-    await expect(
-      waitForPersonCutoutProcesses({
-        processes: [
-          { child: decoder, label: "视频解码" },
-          { child: bridge, label: "剪映主体分析" },
-        ],
-      }),
-    ).rejects.toThrow(/剪映主体分析失败.*bridge failed/s);
-  });
+		await expect(
+			waitForPersonCutoutProcesses({
+				processes: [
+					{ child: decoder, label: "视频解码" },
+					{ child: bridge, label: "剪映主体分析" },
+				],
+			})
+		).rejects.toThrow(/剪映主体分析失败.*bridge failed/s);
+	});
 
-  it("terminates both sides when the caller aborts", async () => {
-    const controller = new AbortController();
-    const decoder = spawnScript({
-      source: "setInterval(() => process.stdout.write('frame'), 10)",
-    });
-    const bridge = spawnScript({
-      source: "process.stdin.resume(); setInterval(() => {}, 1000)",
-    });
-    connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
-    const pending = waitForPersonCutoutProcesses({
-      processes: [
-        { child: decoder, label: "视频解码" },
-        { child: bridge, label: "剪映主体分析" },
-      ],
-      signal: controller.signal,
-    });
-    controller.abort();
+	it("terminates both sides when the caller aborts", async () => {
+		const controller = new AbortController();
+		const decoder = spawnScript({
+			source: "setInterval(() => process.stdout.write('frame'), 10)",
+		});
+		const bridge = spawnScript({
+			source: "process.stdin.resume(); setInterval(() => {}, 1000)",
+		});
+		connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
+		const pending = waitForPersonCutoutProcesses({
+			processes: [
+				{ child: decoder, label: "视频解码" },
+				{ child: bridge, label: "剪映主体分析" },
+			],
+			signal: controller.signal,
+		});
+		controller.abort();
 
-    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
-  });
+		await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-runtime-capability.test.ts
+++ b/qcut/electron/__tests__/person-cutout-runtime-capability.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	executeTemattingWithFallback,
+	NATIVE_METAL_LIBRARY_SHA256,
+	selectTemattingBlendImplementation,
+} from "../jianying-person-cutout/runtime-capability.js";
+import {
+	TEMATTING_COMPATIBLE_BLEND,
+	TEMATTING_NATIVE_METAL_BLEND,
+} from "../jianying-person-cutout/tematting-blend.js";
+
+describe("person cutout native Metal capability", () => {
+	it("selects native Metal only for the verified arm64 runtime", () => {
+		expect(
+			selectTemattingBlendImplementation({
+				arch: "arm64",
+				disabled: false,
+				librarySha256: NATIVE_METAL_LIBRARY_SHA256,
+				platform: "darwin",
+			})
+		).toBe(TEMATTING_NATIVE_METAL_BLEND);
+		for (const candidate of [
+			{ arch: "x64", disabled: false, hash: NATIVE_METAL_LIBRARY_SHA256 },
+			{ arch: "arm64", disabled: true, hash: NATIVE_METAL_LIBRARY_SHA256 },
+			{ arch: "arm64", disabled: false, hash: "unknown" },
+		]) {
+			expect(
+				selectTemattingBlendImplementation({
+					arch: candidate.arch,
+					disabled: candidate.disabled,
+					librarySha256: candidate.hash,
+					platform: "darwin",
+				})
+			).toBe(TEMATTING_COMPATIBLE_BLEND);
+		}
+	});
+
+	it("retries the complete compatible path after a native failure", async () => {
+		const execute = vi.fn(async (implementation) => {
+			if (implementation === TEMATTING_NATIVE_METAL_BLEND) {
+				throw new Error("unsupported ABI");
+			}
+		});
+		const onFallback = vi.fn();
+
+		await expect(
+			executeTemattingWithFallback({
+				execute,
+				onFallback,
+				preferred: TEMATTING_NATIVE_METAL_BLEND,
+			})
+		).resolves.toBe(TEMATTING_COMPATIBLE_BLEND);
+		expect(
+			execute.mock.calls.map(([implementation]) => implementation)
+		).toEqual([TEMATTING_NATIVE_METAL_BLEND, TEMATTING_COMPATIBLE_BLEND]);
+		expect(onFallback).toHaveBeenCalledOnce();
+	});
+
+	it("does not hide a compatible-path failure", async () => {
+		const failure = new Error("model failed");
+		const execute = vi.fn().mockRejectedValue(failure);
+		await expect(
+			executeTemattingWithFallback({
+				execute,
+				preferred: TEMATTING_COMPATIBLE_BLEND,
+			})
+		).rejects.toBe(failure);
+		expect(execute).toHaveBeenCalledOnce();
+	});
+
+	it("does not retry a cancelled native render", async () => {
+		const cancelled = new Error("cancelled");
+		cancelled.name = "AbortError";
+		const execute = vi.fn().mockRejectedValue(cancelled);
+
+		await expect(
+			executeTemattingWithFallback({
+				execute,
+				preferred: TEMATTING_NATIVE_METAL_BLEND,
+			})
+		).rejects.toBe(cancelled);
+		expect(execute).toHaveBeenCalledOnce();
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-runtime-capability.test.ts
+++ b/qcut/electron/__tests__/person-cutout-runtime-capability.test.ts
@@ -6,11 +6,11 @@ import {
 } from "../jianying-person-cutout/runtime-capability.js";
 import {
 	TEMATTING_COMPATIBLE_BLEND,
-	TEMATTING_NATIVE_METAL_BLEND,
+	TEMATTING_NATIVE_METAL_CANARY,
 } from "../jianying-person-cutout/tematting-blend.js";
 
 describe("person cutout native Metal capability", () => {
-	it("selects native Metal only for the verified arm64 runtime", () => {
+	it("selects the Metal canary only for the verified arm64 runtime", () => {
 		expect(
 			selectTemattingBlendImplementation({
 				arch: "arm64",
@@ -18,7 +18,7 @@ describe("person cutout native Metal capability", () => {
 				librarySha256: NATIVE_METAL_LIBRARY_SHA256,
 				platform: "darwin",
 			})
-		).toBe(TEMATTING_NATIVE_METAL_BLEND);
+		).toBe(TEMATTING_NATIVE_METAL_CANARY);
 		for (const candidate of [
 			{ arch: "x64", disabled: false, hash: NATIVE_METAL_LIBRARY_SHA256 },
 			{ arch: "arm64", disabled: true, hash: NATIVE_METAL_LIBRARY_SHA256 },
@@ -35,9 +35,9 @@ describe("person cutout native Metal capability", () => {
 		}
 	});
 
-	it("retries the complete compatible path after a native failure", async () => {
+	it("retries the complete compatible path after a canary failure", async () => {
 		const execute = vi.fn(async (implementation) => {
-			if (implementation === TEMATTING_NATIVE_METAL_BLEND) {
+			if (implementation === TEMATTING_NATIVE_METAL_CANARY) {
 				throw new Error("unsupported ABI");
 			}
 		});
@@ -47,12 +47,12 @@ describe("person cutout native Metal capability", () => {
 			executeTemattingWithFallback({
 				execute,
 				onFallback,
-				preferred: TEMATTING_NATIVE_METAL_BLEND,
+				preferred: TEMATTING_NATIVE_METAL_CANARY,
 			})
 		).resolves.toBe(TEMATTING_COMPATIBLE_BLEND);
 		expect(
 			execute.mock.calls.map(([implementation]) => implementation)
-		).toEqual([TEMATTING_NATIVE_METAL_BLEND, TEMATTING_COMPATIBLE_BLEND]);
+		).toEqual([TEMATTING_NATIVE_METAL_CANARY, TEMATTING_COMPATIBLE_BLEND]);
 		expect(onFallback).toHaveBeenCalledOnce();
 	});
 
@@ -68,7 +68,7 @@ describe("person cutout native Metal capability", () => {
 		expect(execute).toHaveBeenCalledOnce();
 	});
 
-	it("does not retry a cancelled native render", async () => {
+	it("does not retry a cancelled canary render", async () => {
 		const cancelled = new Error("cancelled");
 		cancelled.name = "AbortError";
 		const execute = vi.fn().mockRejectedValue(cancelled);
@@ -76,7 +76,7 @@ describe("person cutout native Metal capability", () => {
 		await expect(
 			executeTemattingWithFallback({
 				execute,
-				preferred: TEMATTING_NATIVE_METAL_BLEND,
+				preferred: TEMATTING_NATIVE_METAL_CANARY,
 			})
 		).rejects.toBe(cancelled);
 		expect(execute).toHaveBeenCalledOnce();

--- a/qcut/electron/__tests__/person-cutout-runtime-environment.test.ts
+++ b/qcut/electron/__tests__/person-cutout-runtime-environment.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { createPersonCutoutBridgeEnvironment } from "../jianying-person-cutout/runtime.js";
+
+describe("person-cutout child environment", () => {
+  it("never inherits the diagnostic video-object reset probe", () => {
+    const directCoreML = createPersonCutoutBridgeEnvironment({
+      frameworkDirectory: null,
+      sourceEnvironment: { QCUT_VIDEO_OBJECT_RESET_FRAMES: "30" },
+    });
+    const hostInterop = createPersonCutoutBridgeEnvironment({
+      frameworkDirectory: "/private/frameworks",
+      sourceEnvironment: { QCUT_VIDEO_OBJECT_RESET_FRAMES: "30" },
+    });
+
+    expect(directCoreML.QCUT_VIDEO_OBJECT_RESET_FRAMES).toBeUndefined();
+    expect(hostInterop.QCUT_VIDEO_OBJECT_RESET_FRAMES).toBeUndefined();
+    expect(hostInterop.DYLD_LIBRARY_PATH).toBe("/private/frameworks");
+  });
+
+  it("removes every DYLD override and restores only the audited framework path", () => {
+    const sourceEnvironment = {
+      DYLD_FALLBACK_LIBRARY_PATH: "/untrusted/fallback",
+      DYLD_FRAMEWORK_PATH: "/untrusted/frameworks",
+      DYLD_INSERT_LIBRARIES: "/untrusted/injected.dylib",
+      DYLD_LIBRARY_PATH: "/untrusted/libraries",
+      DYLD_PRIVATE_OVERRIDE: "untrusted",
+      QCUT_SAFE_SETTING: "preserved",
+    };
+
+    const environment = createPersonCutoutBridgeEnvironment({
+      frameworkDirectory: "/audited/frameworks",
+      sourceEnvironment,
+    });
+
+    expect(environment).toMatchObject({
+      DYLD_LIBRARY_PATH: "/audited/frameworks",
+      QCUT_SAFE_SETTING: "preserved",
+    });
+    expect(environment.DYLD_FALLBACK_LIBRARY_PATH).toBeUndefined();
+    expect(environment.DYLD_FRAMEWORK_PATH).toBeUndefined();
+    expect(environment.DYLD_INSERT_LIBRARIES).toBeUndefined();
+    expect(environment.DYLD_PRIVATE_OVERRIDE).toBeUndefined();
+    expect(sourceEnvironment.DYLD_INSERT_LIBRARIES).toBe(
+      "/untrusted/injected.dylib",
+    );
+  });
+});

--- a/qcut/electron/__tests__/person-cutout-runtime-environment.test.ts
+++ b/qcut/electron/__tests__/person-cutout-runtime-environment.test.ts
@@ -3,46 +3,46 @@ import { describe, expect, it } from "vitest";
 import { createPersonCutoutBridgeEnvironment } from "../jianying-person-cutout/runtime.js";
 
 describe("person-cutout child environment", () => {
-  it("never inherits the diagnostic video-object reset probe", () => {
-    const directCoreML = createPersonCutoutBridgeEnvironment({
-      frameworkDirectory: null,
-      sourceEnvironment: { QCUT_VIDEO_OBJECT_RESET_FRAMES: "30" },
-    });
-    const hostInterop = createPersonCutoutBridgeEnvironment({
-      frameworkDirectory: "/private/frameworks",
-      sourceEnvironment: { QCUT_VIDEO_OBJECT_RESET_FRAMES: "30" },
-    });
+	it("never inherits the diagnostic video-object reset probe", () => {
+		const directCoreML = createPersonCutoutBridgeEnvironment({
+			frameworkDirectory: null,
+			sourceEnvironment: { QCUT_VIDEO_OBJECT_RESET_FRAMES: "30" },
+		});
+		const hostInterop = createPersonCutoutBridgeEnvironment({
+			frameworkDirectory: "/private/frameworks",
+			sourceEnvironment: { QCUT_VIDEO_OBJECT_RESET_FRAMES: "30" },
+		});
 
-    expect(directCoreML.QCUT_VIDEO_OBJECT_RESET_FRAMES).toBeUndefined();
-    expect(hostInterop.QCUT_VIDEO_OBJECT_RESET_FRAMES).toBeUndefined();
-    expect(hostInterop.DYLD_LIBRARY_PATH).toBe("/private/frameworks");
-  });
+		expect(directCoreML.QCUT_VIDEO_OBJECT_RESET_FRAMES).toBeUndefined();
+		expect(hostInterop.QCUT_VIDEO_OBJECT_RESET_FRAMES).toBeUndefined();
+		expect(hostInterop.DYLD_LIBRARY_PATH).toBe("/private/frameworks");
+	});
 
-  it("removes every DYLD override and restores only the audited framework path", () => {
-    const sourceEnvironment = {
-      DYLD_FALLBACK_LIBRARY_PATH: "/untrusted/fallback",
-      DYLD_FRAMEWORK_PATH: "/untrusted/frameworks",
-      DYLD_INSERT_LIBRARIES: "/untrusted/injected.dylib",
-      DYLD_LIBRARY_PATH: "/untrusted/libraries",
-      DYLD_PRIVATE_OVERRIDE: "untrusted",
-      QCUT_SAFE_SETTING: "preserved",
-    };
+	it("removes every DYLD override and restores only the audited framework path", () => {
+		const sourceEnvironment = {
+			DYLD_FALLBACK_LIBRARY_PATH: "/untrusted/fallback",
+			DYLD_FRAMEWORK_PATH: "/untrusted/frameworks",
+			DYLD_INSERT_LIBRARIES: "/untrusted/injected.dylib",
+			DYLD_LIBRARY_PATH: "/untrusted/libraries",
+			DYLD_PRIVATE_OVERRIDE: "untrusted",
+			QCUT_SAFE_SETTING: "preserved",
+		};
 
-    const environment = createPersonCutoutBridgeEnvironment({
-      frameworkDirectory: "/audited/frameworks",
-      sourceEnvironment,
-    });
+		const environment = createPersonCutoutBridgeEnvironment({
+			frameworkDirectory: "/audited/frameworks",
+			sourceEnvironment,
+		});
 
-    expect(environment).toMatchObject({
-      DYLD_LIBRARY_PATH: "/audited/frameworks",
-      QCUT_SAFE_SETTING: "preserved",
-    });
-    expect(environment.DYLD_FALLBACK_LIBRARY_PATH).toBeUndefined();
-    expect(environment.DYLD_FRAMEWORK_PATH).toBeUndefined();
-    expect(environment.DYLD_INSERT_LIBRARIES).toBeUndefined();
-    expect(environment.DYLD_PRIVATE_OVERRIDE).toBeUndefined();
-    expect(sourceEnvironment.DYLD_INSERT_LIBRARIES).toBe(
-      "/untrusted/injected.dylib",
-    );
-  });
+		expect(environment).toMatchObject({
+			DYLD_LIBRARY_PATH: "/audited/frameworks",
+			QCUT_SAFE_SETTING: "preserved",
+		});
+		expect(environment.DYLD_FALLBACK_LIBRARY_PATH).toBeUndefined();
+		expect(environment.DYLD_FRAMEWORK_PATH).toBeUndefined();
+		expect(environment.DYLD_INSERT_LIBRARIES).toBeUndefined();
+		expect(environment.DYLD_PRIVATE_OVERRIDE).toBeUndefined();
+		expect(sourceEnvironment.DYLD_INSERT_LIBRARIES).toBe(
+			"/untrusted/injected.dylib"
+		);
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-temporal-stabilizer.test.ts
+++ b/qcut/electron/__tests__/person-cutout-temporal-stabilizer.test.ts
@@ -1,0 +1,44 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const describeOnMac = process.platform === "darwin" ? describe : describe.skip;
+let temporaryDirectory = "";
+
+describeOnMac("person cutout temporal foreground stabilizer", () => {
+	beforeAll(async () => {
+		temporaryDirectory = await mkdtemp(
+			path.join(os.tmpdir(), "qcut-temporal-stabilizer-test-")
+		);
+	});
+
+	afterAll(async () => {
+		if (!temporaryDirectory) return;
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	});
+
+	it("holds stable-color foreground confidence without retaining background", async () => {
+		const nativeDirectory = path.resolve(
+			"electron",
+			"jianying-person-cutout",
+			"native"
+		);
+		const executablePath = path.join(temporaryDirectory, "stabilizer-test");
+		await execFileAsync("xcrun", [
+			"clang++",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			path.join(nativeDirectory, "alpha-temporal-stabilizer.cpp"),
+			path.join(nativeDirectory, "alpha-temporal-stabilizer.test.cpp"),
+			"-o",
+			executablePath,
+		]);
+		await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-video-display-dimensions.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-display-dimensions.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveAutorotatedVideoDimensions } from "../jianying-person-cutout/video-display-dimensions.js";
+
+describe("person cutout autorotated video dimensions", () => {
+	it.each([
+		{ expected: { height: 1080, width: 1920 }, rotation: 0 },
+		{ expected: { height: 1920, width: 1080 }, rotation: 90 },
+		{ expected: { height: 1920, width: 1080 }, rotation: -90 },
+		{ expected: { height: 1080, width: 1920 }, rotation: 180 },
+	])("resolves display-matrix rotation $rotation", ({ expected, rotation }) => {
+		expect(
+			resolveAutorotatedVideoDimensions({
+				height: 1080,
+				sideDataList: [{ rotation }],
+				width: 1920,
+			})
+		).toEqual(expected);
+	});
+
+	it("falls back to the legacy rotate tag", () => {
+		expect(
+			resolveAutorotatedVideoDimensions({
+				height: 1080,
+				tags: { rotate: "90" },
+				width: 1920,
+			})
+		).toEqual({ height: 1920, width: 1080 });
+	});
+
+	it("prefers display-matrix rotation over the legacy tag", () => {
+		expect(
+			resolveAutorotatedVideoDimensions({
+				height: 1080,
+				sideDataList: [{ rotation: 0 }],
+				tags: { rotate: "90" },
+				width: 1920,
+			})
+		).toEqual({ height: 1080, width: 1920 });
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-video-object-alpha-quality.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-alpha-quality.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const describeOnMac = process.platform === "darwin" ? describe : describe.skip;
+let temporaryDirectory = "";
+
+describeOnMac("video-object alpha quality gate", () => {
+	beforeAll(async () => {
+		temporaryDirectory = await mkdtemp(
+			path.join(os.tmpdir(), "qcut-video-object-alpha-quality-test-")
+		);
+	});
+
+	afterAll(async () => {
+		if (!temporaryDirectory) return;
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	});
+
+	it("rejects the zero-texture 0/1/2 fingerprint before cache commit", async () => {
+		const nativeDirectory = path.resolve(
+			"electron",
+			"jianying-person-cutout",
+			"native"
+		);
+		const executablePath = path.join(
+			temporaryDirectory,
+			"video-object-alpha-quality-test"
+		);
+		await execFileAsync("xcrun", [
+			"clang++",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			path.join(nativeDirectory, "video-object-alpha-quality.cpp"),
+			path.join(nativeDirectory, "video-object-alpha-quality.test.cpp"),
+			"-o",
+			executablePath,
+		]);
+		await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-video-object-alpha-quality.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-alpha-quality.test.ts
@@ -22,7 +22,7 @@ describeOnMac("video-object alpha quality gate", () => {
 		await rm(temporaryDirectory, { force: true, recursive: true });
 	});
 
-	it("rejects the zero-texture 0/1/2 fingerprint before cache commit", async () => {
+	it("checks complete streams without rejecting empty prefixes or all-zero masks", async () => {
 		const nativeDirectory = path.resolve(
 			"electron",
 			"jianying-person-cutout",

--- a/qcut/electron/__tests__/person-cutout-video-object-bach-bridge-resolver.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-bach-bridge-resolver.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment node
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME } from "../jianying-person-cutout/atomic-publish-lock.js";
+import {
+  VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
+  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+} from "../jianying-person-cutout/video-object-runtime-closure.js";
+import {
+  compileVideoObjectBachBridge,
+  isValidVideoObjectBachBridge,
+  VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS,
+} from "../jianying-person-cutout/video-object-bach-bridge-resolver.js";
+
+const temporaryDirectories: string[] = [];
+const originalPath = process.env.PATH;
+
+describe("video-object Bach native closure contract", () => {
+  it("keeps every native framework SHA and aggregate marker aligned with TypeScript", async () => {
+    const source = await readFile(
+      path.resolve(
+        process.cwd(),
+        "electron/jianying-person-cutout/native/video-object-bach-bridge.mm",
+      ),
+      "utf8",
+    );
+    const mainSha = source.match(
+      /kExpectedLibrarySha256\s*=\s*"([a-f0-9]{64})"/,
+    )?.[1];
+    const nativeDependencies = Array.from(
+      source.matchAll(/\{"(lib[^"/]+\.dylib)",\s*"([a-f0-9]{64})"\}/g),
+      ([, fileName, sha256]) => [fileName, sha256] as const,
+    );
+    expect(mainSha).toBeDefined();
+    nativeDependencies.push(["libcccreator.dylib", mainSha ?? ""]);
+    const compareFileNames = (
+      [left]: readonly string[],
+      [right]: readonly string[],
+    ) => (left < right ? -1 : left > right ? 1 : 0);
+    nativeDependencies.sort(compareFileNames);
+    const expectedDependencies =
+      VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.map(
+        ([dependencyPath, sha256]) =>
+          [path.basename(dependencyPath), sha256] as const,
+      ).sort(compareFileNames);
+    expect(nativeDependencies).toEqual(expectedDependencies);
+
+    const canonicalClosure = nativeDependencies
+      .map(([fileName, sha256]) => `${fileName}=${sha256}\n`)
+      .join("");
+    expect(createHash("sha256").update(canonicalClosure).digest("hex")).toBe(
+      VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+    );
+    const markerFragments = source.match(
+      /kRuntimeFrameworkClosureId\s*=\s*"([^"]+)"\s*"([a-f0-9]{64})"/,
+    );
+    expect(`${markerFragments?.[1]}${markerFragments?.[2]}`).toBe(
+      VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+    );
+  });
+});
+
+async function createTemporaryDirectory() {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "qcut-bach-bridge-resolver-test-"),
+  );
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function installFakeCompiler({ directory }: { directory: string }) {
+  const binDirectory = path.join(directory, "fake-bin");
+  const xcrunPath = path.join(binDirectory, "xcrun");
+  await mkdir(binDirectory, { recursive: true });
+  await writeFile(
+    xcrunPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const outputPath = args[args.lastIndexOf("-o") + 1];
+const image = Buffer.alloc(process.env.QCUT_FAKE_TRUNCATED_BRIDGE === "1" ? 16 : 4096);
+Buffer.from([0xcf, 0xfa, 0xed, 0xfe]).copy(image);
+const markers = ${JSON.stringify(VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS)};
+Buffer.from(markers.join("\\0")).copy(image, 64);
+setTimeout(() => {
+  fs.writeFileSync(outputPath, image);
+  fs.chmodSync(outputPath, 0o755);
+}, Number(process.env.QCUT_FAKE_COMPILER_DELAY_MS || 0));
+`,
+    "utf8",
+  );
+  await chmod(xcrunPath, 0o755);
+  process.env.PATH = `${binDirectory}:${originalPath ?? ""}`;
+}
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  Reflect.deleteProperty(process.env, "QCUT_FAKE_COMPILER_DELAY_MS");
+  Reflect.deleteProperty(process.env, "QCUT_FAKE_TRUNCATED_BRIDGE");
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe.runIf(process.platform === "darwin")(
+  "video-object Bach bridge resolver",
+  () => {
+    it("rejects a bridge that omits a pinned capability marker", async () => {
+      const directory = await createTemporaryDirectory();
+      const bridgePath = path.join(directory, "bridge");
+      const image = Buffer.alloc(4096);
+      Buffer.from([0xcf, 0xfa, 0xed, 0xfe]).copy(image);
+      Buffer.from(
+        VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.slice(0, -1).join("\0"),
+      ).copy(image, 64);
+      await writeFile(bridgePath, image);
+      await chmod(bridgePath, 0o755);
+
+      await expect(
+        isValidVideoObjectBachBridge({ filePath: bridgePath }),
+      ).resolves.toBe(false);
+    });
+
+    it("rejects a stale bridge that lacks exact and advanced refinement markers", async () => {
+      const directory = await createTemporaryDirectory();
+      const bridgePath = path.join(directory, "bridge");
+      const image = Buffer.alloc(4096);
+      Buffer.from([0xcf, 0xfa, 0xed, 0xfe]).copy(image);
+      const staleMarkers = VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.filter(
+        (marker) => !marker.includes("refinement"),
+      );
+      Buffer.from(staleMarkers.join("\0")).copy(image, 64);
+      await writeFile(bridgePath, image);
+      await chmod(bridgePath, 0o755);
+
+      await expect(
+        isValidVideoObjectBachBridge({ filePath: bridgePath }),
+      ).resolves.toBe(false);
+    });
+
+    it("repairs a truncated bridge through an atomic publication", async () => {
+      const directory = await createTemporaryDirectory();
+      await installFakeCompiler({ directory });
+      const outputPath = path.join(directory, "cache", "bridge");
+      await mkdir(path.dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, Buffer.from("truncated"));
+      await chmod(outputPath, 0o755);
+
+      await expect(
+        compileVideoObjectBachBridge({ outputPath, projectRoot: directory }),
+      ).resolves.toBe(outputPath);
+      await expect(
+        isValidVideoObjectBachBridge({ filePath: outputPath }),
+      ).resolves.toBe(true);
+      expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
+    });
+
+    it("publishes one immutable bridge during concurrent compilation", async () => {
+      const directory = await createTemporaryDirectory();
+      await installFakeCompiler({ directory });
+      process.env.QCUT_FAKE_COMPILER_DELAY_MS = "20";
+      const outputPath = path.join(directory, "cache", "bridge");
+      const calls = Array.from({ length: 6 }, () =>
+        compileVideoObjectBachBridge({ outputPath, projectRoot: directory }),
+      );
+
+      const winner = await Promise.race(calls);
+      const winnerStat = await stat(winner);
+      const winnerHandle = await open(winner, "r");
+      try {
+        expect(new Set(await Promise.all(calls))).toEqual(
+          new Set([outputPath]),
+        );
+        expect((await stat(winner)).ino).toBe(winnerStat.ino);
+        const magic = Buffer.alloc(4);
+        await winnerHandle.read(magic, 0, magic.length, 0);
+        expect(magic).toEqual(Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+      } finally {
+        await winnerHandle.close();
+      }
+      expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
+    });
+
+    it("never steals a live compiler publication lock", async () => {
+      const directory = await createTemporaryDirectory();
+      await installFakeCompiler({ directory });
+      const outputPath = path.join(directory, "cache", "bridge");
+      const lockPath = `${outputPath}.publish-lock`;
+      await mkdir(lockPath, { recursive: true });
+      await writeFile(
+        path.join(lockPath, ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME),
+        JSON.stringify({ createdAt: 0, pid: process.pid }),
+        "utf8",
+      );
+
+      await expect(
+        compileVideoObjectBachBridge({
+          lockTiming: { retryMs: 1, waitMs: 5 },
+          outputPath,
+          projectRoot: directory,
+        }),
+      ).rejects.toThrow("Timed out waiting for cache publication lock");
+      expect((await stat(lockPath)).isDirectory()).toBe(true);
+    });
+  },
+);

--- a/qcut/electron/__tests__/person-cutout-video-object-bach-bridge-resolver.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-bach-bridge-resolver.test.ts
@@ -1,94 +1,94 @@
 // @vitest-environment node
 import { createHash } from "node:crypto";
 import {
-  chmod,
-  mkdir,
-  mkdtemp,
-  open,
-  readFile,
-  readdir,
-  rm,
-  stat,
-  writeFile,
+	chmod,
+	mkdir,
+	mkdtemp,
+	open,
+	readFile,
+	readdir,
+	rm,
+	stat,
+	writeFile,
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME } from "../jianying-person-cutout/atomic-publish-lock.js";
 import {
-  VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
-  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+	VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
+	VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+	VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
 } from "../jianying-person-cutout/video-object-runtime-closure.js";
 import {
-  compileVideoObjectBachBridge,
-  isValidVideoObjectBachBridge,
-  VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS,
+	compileVideoObjectBachBridge,
+	isValidVideoObjectBachBridge,
+	VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS,
 } from "../jianying-person-cutout/video-object-bach-bridge-resolver.js";
 
 const temporaryDirectories: string[] = [];
 const originalPath = process.env.PATH;
 
 describe("video-object Bach native closure contract", () => {
-  it("keeps every native framework SHA and aggregate marker aligned with TypeScript", async () => {
-    const source = await readFile(
-      path.resolve(
-        process.cwd(),
-        "electron/jianying-person-cutout/native/video-object-bach-bridge.mm",
-      ),
-      "utf8",
-    );
-    const mainSha = source.match(
-      /kExpectedLibrarySha256\s*=\s*"([a-f0-9]{64})"/,
-    )?.[1];
-    const nativeDependencies = Array.from(
-      source.matchAll(/\{"(lib[^"/]+\.dylib)",\s*"([a-f0-9]{64})"\}/g),
-      ([, fileName, sha256]) => [fileName, sha256] as const,
-    );
-    expect(mainSha).toBeDefined();
-    nativeDependencies.push(["libcccreator.dylib", mainSha ?? ""]);
-    const compareFileNames = (
-      [left]: readonly string[],
-      [right]: readonly string[],
-    ) => (left < right ? -1 : left > right ? 1 : 0);
-    nativeDependencies.sort(compareFileNames);
-    const expectedDependencies =
-      VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.map(
-        ([dependencyPath, sha256]) =>
-          [path.basename(dependencyPath), sha256] as const,
-      ).sort(compareFileNames);
-    expect(nativeDependencies).toEqual(expectedDependencies);
+	it("keeps every native framework SHA and aggregate marker aligned with TypeScript", async () => {
+		const source = await readFile(
+			path.resolve(
+				process.cwd(),
+				"electron/jianying-person-cutout/native/video-object-bach-bridge.mm"
+			),
+			"utf8"
+		);
+		const mainSha = source.match(
+			/kExpectedLibrarySha256\s*=\s*"([a-f0-9]{64})"/
+		)?.[1];
+		const nativeDependencies = Array.from(
+			source.matchAll(/\{"(lib[^"/]+\.dylib)",\s*"([a-f0-9]{64})"\}/g),
+			([, fileName, sha256]) => [fileName, sha256] as const
+		);
+		expect(mainSha).toBeDefined();
+		nativeDependencies.push(["libcccreator.dylib", mainSha ?? ""]);
+		const compareFileNames = (
+			[left]: readonly string[],
+			[right]: readonly string[]
+		) => (left < right ? -1 : left > right ? 1 : 0);
+		nativeDependencies.sort(compareFileNames);
+		const expectedDependencies =
+			VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.map(
+				([dependencyPath, sha256]) =>
+					[path.basename(dependencyPath), sha256] as const
+			).sort(compareFileNames);
+		expect(nativeDependencies).toEqual(expectedDependencies);
 
-    const canonicalClosure = nativeDependencies
-      .map(([fileName, sha256]) => `${fileName}=${sha256}\n`)
-      .join("");
-    expect(createHash("sha256").update(canonicalClosure).digest("hex")).toBe(
-      VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
-    );
-    const markerFragments = source.match(
-      /kRuntimeFrameworkClosureId\s*=\s*"([^"]+)"\s*"([a-f0-9]{64})"/,
-    );
-    expect(`${markerFragments?.[1]}${markerFragments?.[2]}`).toBe(
-      VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-    );
-  });
+		const canonicalClosure = nativeDependencies
+			.map(([fileName, sha256]) => `${fileName}=${sha256}\n`)
+			.join("");
+		expect(createHash("sha256").update(canonicalClosure).digest("hex")).toBe(
+			VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256
+		);
+		const markerFragments = source.match(
+			/kRuntimeFrameworkClosureId\s*=\s*"([^"]+)"\s*"([a-f0-9]{64})"/
+		);
+		expect(`${markerFragments?.[1]}${markerFragments?.[2]}`).toBe(
+			VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER
+		);
+	});
 });
 
 async function createTemporaryDirectory() {
-  const directory = await mkdtemp(
-    path.join(os.tmpdir(), "qcut-bach-bridge-resolver-test-"),
-  );
-  temporaryDirectories.push(directory);
-  return directory;
+	const directory = await mkdtemp(
+		path.join(os.tmpdir(), "qcut-bach-bridge-resolver-test-")
+	);
+	temporaryDirectories.push(directory);
+	return directory;
 }
 
 async function installFakeCompiler({ directory }: { directory: string }) {
-  const binDirectory = path.join(directory, "fake-bin");
-  const xcrunPath = path.join(binDirectory, "xcrun");
-  await mkdir(binDirectory, { recursive: true });
-  await writeFile(
-    xcrunPath,
-    `#!/usr/bin/env node
+	const binDirectory = path.join(directory, "fake-bin");
+	const xcrunPath = path.join(binDirectory, "xcrun");
+	await mkdir(binDirectory, { recursive: true });
+	await writeFile(
+		xcrunPath,
+		`#!/usr/bin/env node
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 const outputPath = args[args.lastIndexOf("-o") + 1];
@@ -101,122 +101,122 @@ setTimeout(() => {
   fs.chmodSync(outputPath, 0o755);
 }, Number(process.env.QCUT_FAKE_COMPILER_DELAY_MS || 0));
 `,
-    "utf8",
-  );
-  await chmod(xcrunPath, 0o755);
-  process.env.PATH = `${binDirectory}:${originalPath ?? ""}`;
+		"utf8"
+	);
+	await chmod(xcrunPath, 0o755);
+	process.env.PATH = `${binDirectory}:${originalPath ?? ""}`;
 }
 
 afterEach(async () => {
-  process.env.PATH = originalPath;
-  Reflect.deleteProperty(process.env, "QCUT_FAKE_COMPILER_DELAY_MS");
-  Reflect.deleteProperty(process.env, "QCUT_FAKE_TRUNCATED_BRIDGE");
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { force: true, recursive: true })),
-  );
+	process.env.PATH = originalPath;
+	Reflect.deleteProperty(process.env, "QCUT_FAKE_COMPILER_DELAY_MS");
+	Reflect.deleteProperty(process.env, "QCUT_FAKE_TRUNCATED_BRIDGE");
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { force: true, recursive: true }))
+	);
 });
 
 describe.runIf(process.platform === "darwin")(
-  "video-object Bach bridge resolver",
-  () => {
-    it("rejects a bridge that omits a pinned capability marker", async () => {
-      const directory = await createTemporaryDirectory();
-      const bridgePath = path.join(directory, "bridge");
-      const image = Buffer.alloc(4096);
-      Buffer.from([0xcf, 0xfa, 0xed, 0xfe]).copy(image);
-      Buffer.from(
-        VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.slice(0, -1).join("\0"),
-      ).copy(image, 64);
-      await writeFile(bridgePath, image);
-      await chmod(bridgePath, 0o755);
+	"video-object Bach bridge resolver",
+	() => {
+		it("rejects a bridge that omits a pinned capability marker", async () => {
+			const directory = await createTemporaryDirectory();
+			const bridgePath = path.join(directory, "bridge");
+			const image = Buffer.alloc(4096);
+			Buffer.from([0xcf, 0xfa, 0xed, 0xfe]).copy(image);
+			Buffer.from(
+				VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.slice(0, -1).join("\0")
+			).copy(image, 64);
+			await writeFile(bridgePath, image);
+			await chmod(bridgePath, 0o755);
 
-      await expect(
-        isValidVideoObjectBachBridge({ filePath: bridgePath }),
-      ).resolves.toBe(false);
-    });
+			await expect(
+				isValidVideoObjectBachBridge({ filePath: bridgePath })
+			).resolves.toBe(false);
+		});
 
-    it("rejects a stale bridge that lacks exact and advanced refinement markers", async () => {
-      const directory = await createTemporaryDirectory();
-      const bridgePath = path.join(directory, "bridge");
-      const image = Buffer.alloc(4096);
-      Buffer.from([0xcf, 0xfa, 0xed, 0xfe]).copy(image);
-      const staleMarkers = VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.filter(
-        (marker) => !marker.includes("refinement"),
-      );
-      Buffer.from(staleMarkers.join("\0")).copy(image, 64);
-      await writeFile(bridgePath, image);
-      await chmod(bridgePath, 0o755);
+		it("rejects a stale bridge that lacks exact and advanced refinement markers", async () => {
+			const directory = await createTemporaryDirectory();
+			const bridgePath = path.join(directory, "bridge");
+			const image = Buffer.alloc(4096);
+			Buffer.from([0xcf, 0xfa, 0xed, 0xfe]).copy(image);
+			const staleMarkers = VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.filter(
+				(marker) => !marker.includes("refinement")
+			);
+			Buffer.from(staleMarkers.join("\0")).copy(image, 64);
+			await writeFile(bridgePath, image);
+			await chmod(bridgePath, 0o755);
 
-      await expect(
-        isValidVideoObjectBachBridge({ filePath: bridgePath }),
-      ).resolves.toBe(false);
-    });
+			await expect(
+				isValidVideoObjectBachBridge({ filePath: bridgePath })
+			).resolves.toBe(false);
+		});
 
-    it("repairs a truncated bridge through an atomic publication", async () => {
-      const directory = await createTemporaryDirectory();
-      await installFakeCompiler({ directory });
-      const outputPath = path.join(directory, "cache", "bridge");
-      await mkdir(path.dirname(outputPath), { recursive: true });
-      await writeFile(outputPath, Buffer.from("truncated"));
-      await chmod(outputPath, 0o755);
+		it("repairs a truncated bridge through an atomic publication", async () => {
+			const directory = await createTemporaryDirectory();
+			await installFakeCompiler({ directory });
+			const outputPath = path.join(directory, "cache", "bridge");
+			await mkdir(path.dirname(outputPath), { recursive: true });
+			await writeFile(outputPath, Buffer.from("truncated"));
+			await chmod(outputPath, 0o755);
 
-      await expect(
-        compileVideoObjectBachBridge({ outputPath, projectRoot: directory }),
-      ).resolves.toBe(outputPath);
-      await expect(
-        isValidVideoObjectBachBridge({ filePath: outputPath }),
-      ).resolves.toBe(true);
-      expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
-    });
+			await expect(
+				compileVideoObjectBachBridge({ outputPath, projectRoot: directory })
+			).resolves.toBe(outputPath);
+			await expect(
+				isValidVideoObjectBachBridge({ filePath: outputPath })
+			).resolves.toBe(true);
+			expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
+		});
 
-    it("publishes one immutable bridge during concurrent compilation", async () => {
-      const directory = await createTemporaryDirectory();
-      await installFakeCompiler({ directory });
-      process.env.QCUT_FAKE_COMPILER_DELAY_MS = "20";
-      const outputPath = path.join(directory, "cache", "bridge");
-      const calls = Array.from({ length: 6 }, () =>
-        compileVideoObjectBachBridge({ outputPath, projectRoot: directory }),
-      );
+		it("publishes one immutable bridge during concurrent compilation", async () => {
+			const directory = await createTemporaryDirectory();
+			await installFakeCompiler({ directory });
+			process.env.QCUT_FAKE_COMPILER_DELAY_MS = "20";
+			const outputPath = path.join(directory, "cache", "bridge");
+			const calls = Array.from({ length: 6 }, () =>
+				compileVideoObjectBachBridge({ outputPath, projectRoot: directory })
+			);
 
-      const winner = await Promise.race(calls);
-      const winnerStat = await stat(winner);
-      const winnerHandle = await open(winner, "r");
-      try {
-        expect(new Set(await Promise.all(calls))).toEqual(
-          new Set([outputPath]),
-        );
-        expect((await stat(winner)).ino).toBe(winnerStat.ino);
-        const magic = Buffer.alloc(4);
-        await winnerHandle.read(magic, 0, magic.length, 0);
-        expect(magic).toEqual(Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
-      } finally {
-        await winnerHandle.close();
-      }
-      expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
-    });
+			const winner = await Promise.race(calls);
+			const winnerStat = await stat(winner);
+			const winnerHandle = await open(winner, "r");
+			try {
+				expect(new Set(await Promise.all(calls))).toEqual(
+					new Set([outputPath])
+				);
+				expect((await stat(winner)).ino).toBe(winnerStat.ino);
+				const magic = Buffer.alloc(4);
+				await winnerHandle.read(magic, 0, magic.length, 0);
+				expect(magic).toEqual(Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+			} finally {
+				await winnerHandle.close();
+			}
+			expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
+		});
 
-    it("never steals a live compiler publication lock", async () => {
-      const directory = await createTemporaryDirectory();
-      await installFakeCompiler({ directory });
-      const outputPath = path.join(directory, "cache", "bridge");
-      const lockPath = `${outputPath}.publish-lock`;
-      await mkdir(lockPath, { recursive: true });
-      await writeFile(
-        path.join(lockPath, ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME),
-        JSON.stringify({ createdAt: 0, pid: process.pid }),
-        "utf8",
-      );
+		it("never steals a live compiler publication lock", async () => {
+			const directory = await createTemporaryDirectory();
+			await installFakeCompiler({ directory });
+			const outputPath = path.join(directory, "cache", "bridge");
+			const lockPath = `${outputPath}.publish-lock`;
+			await mkdir(lockPath, { recursive: true });
+			await writeFile(
+				path.join(lockPath, ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME),
+				JSON.stringify({ createdAt: 0, pid: process.pid }),
+				"utf8"
+			);
 
-      await expect(
-        compileVideoObjectBachBridge({
-          lockTiming: { retryMs: 1, waitMs: 5 },
-          outputPath,
-          projectRoot: directory,
-        }),
-      ).rejects.toThrow("Timed out waiting for cache publication lock");
-      expect((await stat(lockPath)).isDirectory()).toBe(true);
-    });
-  },
+			await expect(
+				compileVideoObjectBachBridge({
+					lockTiming: { retryMs: 1, waitMs: 5 },
+					outputPath,
+					projectRoot: directory,
+				})
+			).rejects.toThrow("Timed out waiting for cache publication lock");
+			expect((await stat(lockPath)).isDirectory()).toBe(true);
+		});
+	}
 );

--- a/qcut/electron/__tests__/person-cutout-video-object-bridge-arguments.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-bridge-arguments.test.ts
@@ -1,142 +1,142 @@
 import { describe, expect, it } from "vitest";
 import { createVideoObjectBridgeArguments } from "../jianying-person-cutout/video-object-bridge-arguments.js";
 import {
-  VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY,
-  VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
-  VIDEO_OBJECT_PROVIDER_CAPABILITY,
-  type JianyingVideoObjectRuntimeCandidate,
+	VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY,
+	VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
+	VIDEO_OBJECT_PROVIDER_CAPABILITY,
+	type JianyingVideoObjectRuntimeCandidate,
 } from "../jianying-person-cutout/video-object-runtime.js";
 
 const settings = {
-  edgeShift: 2,
-  feather: 3,
-  temporalSmoothing: 0.25,
-  threshold: 0.6,
+	edgeShift: 2,
+	feather: 3,
+	temporalSmoothing: 0.25,
+	threshold: 0.6,
 };
 
 function candidate({
-  executionBackend,
+	executionBackend,
 }: {
-  executionBackend: JianyingVideoObjectRuntimeCandidate["executionBackend"];
+	executionBackend: JianyingVideoObjectRuntimeCandidate["executionBackend"];
 }): JianyingVideoObjectRuntimeCandidate {
-  const isBach = executionBackend === "jianying-bach-v2-exact-d634-v1";
-  const isCoreML = executionBackend === "same-model-coreml-v1";
-  return {
-    bridgePath: "/bridge",
-    capabilitySha256: "capability",
-    coreMLModelPath: isCoreML ? "/model.mlmodelc" : null,
-    dependencyClosureSha256: isBach ? "dependency-closure" : null,
-    effectDirectory: isBach || isCoreML ? null : "/effect",
-    executionBackend,
-    frameworkDirectory: isCoreML ? null : "/frameworks",
-    graphDirectory: isBach ? "/graph" : null,
-    libraryPath: isCoreML ? null : "/frameworks/libcccreator.dylib",
-    modelDirectory: "/models",
-    modelPath: "/models/video-object.model",
-    modelSha256: "model",
-    processorSha256: "processor",
-    providerCapability: isBach
-      ? VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY
-      : isCoreML
-        ? VIDEO_OBJECT_PROVIDER_CAPABILITY
-        : VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
-    readiness: isBach
-      ? VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY.readiness
-      : isCoreML
-        ? VIDEO_OBJECT_PROVIDER_CAPABILITY.readiness
-        : VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY.readiness,
-  };
+	const isBach = executionBackend === "jianying-bach-v2-exact-d634-v1";
+	const isCoreML = executionBackend === "same-model-coreml-v1";
+	return {
+		bridgePath: "/bridge",
+		capabilitySha256: "capability",
+		coreMLModelPath: isCoreML ? "/model.mlmodelc" : null,
+		dependencyClosureSha256: isBach ? "dependency-closure" : null,
+		effectDirectory: isBach || isCoreML ? null : "/effect",
+		executionBackend,
+		frameworkDirectory: isCoreML ? null : "/frameworks",
+		graphDirectory: isBach ? "/graph" : null,
+		libraryPath: isCoreML ? null : "/frameworks/libcccreator.dylib",
+		modelDirectory: "/models",
+		modelPath: "/models/video-object.model",
+		modelSha256: "model",
+		processorSha256: "processor",
+		providerCapability: isBach
+			? VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY
+			: isCoreML
+				? VIDEO_OBJECT_PROVIDER_CAPABILITY
+				: VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
+		readiness: isBach
+			? VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY.readiness
+			: isCoreML
+				? VIDEO_OBJECT_PROVIDER_CAPABILITY.readiness
+				: VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY.readiness,
+	};
 }
 
 function args({
-  executionBackend,
-  inputPath = "/source.rgba",
+	executionBackend,
+	inputPath = "/source.rgba",
 }: {
-  executionBackend: JianyingVideoObjectRuntimeCandidate["executionBackend"];
-  inputPath?: string;
+	executionBackend: JianyingVideoObjectRuntimeCandidate["executionBackend"];
+	inputPath?: string;
 }) {
-  return createVideoObjectBridgeArguments({
-    height: 640,
-    inputPath,
-    outputPath: "/alpha.gray",
-    settings,
-    videoObject: candidate({ executionBackend }),
-    width: 360,
-  });
+	return createVideoObjectBridgeArguments({
+		height: 640,
+		inputPath,
+		outputPath: "/alpha.gray",
+		settings,
+		videoObject: candidate({ executionBackend }),
+		width: 360,
+	});
 }
 
 describe("video-object bridge arguments", () => {
-  it("streams decoded frames through stdin for every provider", () => {
-    for (const executionBackend of [
-      "jianying-bach-v2-exact-d634-v1",
-      "same-model-coreml-v1",
-      "effect-host-interop-v1",
-    ] as const) {
-      expect(args({ executionBackend, inputPath: "-" })).toContain("-");
-    }
-  });
+	it("streams decoded frames through stdin for every provider", () => {
+		for (const executionBackend of [
+			"jianying-bach-v2-exact-d634-v1",
+			"same-model-coreml-v1",
+			"effect-host-interop-v1",
+		] as const) {
+			expect(args({ executionBackend, inputPath: "-" })).toContain("-");
+		}
+	});
 
-  it("passes the pinned runtime, graph, packed model, and refinement to Bach", () => {
-    expect(
-      args({ executionBackend: "jianying-bach-v2-exact-d634-v1" }),
-    ).toEqual([
-      "/frameworks/libcccreator.dylib",
-      "/graph",
-      "/models/video-object.model",
-      "/source.rgba",
-      "360",
-      "640",
-      "/alpha.gray",
-      "0.6",
-      "0.25",
-      "2",
-      "3",
-    ]);
-  });
+	it("passes the pinned runtime, graph, packed model, and refinement to Bach", () => {
+		expect(
+			args({ executionBackend: "jianying-bach-v2-exact-d634-v1" })
+		).toEqual([
+			"/frameworks/libcccreator.dylib",
+			"/graph",
+			"/models/video-object.model",
+			"/source.rgba",
+			"360",
+			"640",
+			"/alpha.gray",
+			"0.6",
+			"0.25",
+			"2",
+			"3",
+		]);
+	});
 
-  it("keeps direct CoreML and legacy host contracts distinct", () => {
-    expect(args({ executionBackend: "same-model-coreml-v1" })).toEqual([
-      "/model.mlmodelc",
-      "/source.rgba",
-      "360",
-      "640",
-      "/alpha.gray",
-      "0.6",
-      "0.25",
-      "2",
-      "3",
-    ]);
-    expect(args({ executionBackend: "effect-host-interop-v1" })).toEqual([
-      "/frameworks/libcccreator.dylib",
-      "/models",
-      "/effect",
-      "/source.rgba",
-      "360",
-      "640",
-      "/alpha.gray",
-      "0.6",
-      "0.25",
-      "2",
-      "3",
-      "--route",
-      "video-object",
-    ]);
-  });
+	it("keeps direct CoreML and legacy host contracts distinct", () => {
+		expect(args({ executionBackend: "same-model-coreml-v1" })).toEqual([
+			"/model.mlmodelc",
+			"/source.rgba",
+			"360",
+			"640",
+			"/alpha.gray",
+			"0.6",
+			"0.25",
+			"2",
+			"3",
+		]);
+		expect(args({ executionBackend: "effect-host-interop-v1" })).toEqual([
+			"/frameworks/libcccreator.dylib",
+			"/models",
+			"/effect",
+			"/source.rgba",
+			"360",
+			"640",
+			"/alpha.gray",
+			"0.6",
+			"0.25",
+			"2",
+			"3",
+			"--route",
+			"video-object",
+		]);
+	});
 
-  it("fails closed when a backend-specific pinned asset is absent", () => {
-    const bach = candidate({
-      executionBackend: "jianying-bach-v2-exact-d634-v1",
-    });
-    bach.graphDirectory = null;
-    expect(() =>
-      createVideoObjectBridgeArguments({
-        height: 640,
-        inputPath: "/source.rgba",
-        outputPath: "/alpha.gray",
-        settings,
-        videoObject: bach,
-        width: 360,
-      }),
-    ).toThrow("Bach 物体抠像运行时不完整");
-  });
+	it("fails closed when a backend-specific pinned asset is absent", () => {
+		const bach = candidate({
+			executionBackend: "jianying-bach-v2-exact-d634-v1",
+		});
+		bach.graphDirectory = null;
+		expect(() =>
+			createVideoObjectBridgeArguments({
+				height: 640,
+				inputPath: "/source.rgba",
+				outputPath: "/alpha.gray",
+				settings,
+				videoObject: bach,
+				width: 360,
+			})
+		).toThrow("Bach 物体抠像运行时不完整");
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-video-object-bridge-arguments.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-bridge-arguments.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { createVideoObjectBridgeArguments } from "../jianying-person-cutout/video-object-bridge-arguments.js";
+import {
+  VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY,
+  VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
+  VIDEO_OBJECT_PROVIDER_CAPABILITY,
+  type JianyingVideoObjectRuntimeCandidate,
+} from "../jianying-person-cutout/video-object-runtime.js";
+
+const settings = {
+  edgeShift: 2,
+  feather: 3,
+  temporalSmoothing: 0.25,
+  threshold: 0.6,
+};
+
+function candidate({
+  executionBackend,
+}: {
+  executionBackend: JianyingVideoObjectRuntimeCandidate["executionBackend"];
+}): JianyingVideoObjectRuntimeCandidate {
+  const isBach = executionBackend === "jianying-bach-v2-exact-d634-v1";
+  const isCoreML = executionBackend === "same-model-coreml-v1";
+  return {
+    bridgePath: "/bridge",
+    capabilitySha256: "capability",
+    coreMLModelPath: isCoreML ? "/model.mlmodelc" : null,
+    dependencyClosureSha256: isBach ? "dependency-closure" : null,
+    effectDirectory: isBach || isCoreML ? null : "/effect",
+    executionBackend,
+    frameworkDirectory: isCoreML ? null : "/frameworks",
+    graphDirectory: isBach ? "/graph" : null,
+    libraryPath: isCoreML ? null : "/frameworks/libcccreator.dylib",
+    modelDirectory: "/models",
+    modelPath: "/models/video-object.model",
+    modelSha256: "model",
+    processorSha256: "processor",
+    providerCapability: isBach
+      ? VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY
+      : isCoreML
+        ? VIDEO_OBJECT_PROVIDER_CAPABILITY
+        : VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
+    readiness: isBach
+      ? VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY.readiness
+      : isCoreML
+        ? VIDEO_OBJECT_PROVIDER_CAPABILITY.readiness
+        : VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY.readiness,
+  };
+}
+
+function args({
+  executionBackend,
+  inputPath = "/source.rgba",
+}: {
+  executionBackend: JianyingVideoObjectRuntimeCandidate["executionBackend"];
+  inputPath?: string;
+}) {
+  return createVideoObjectBridgeArguments({
+    height: 640,
+    inputPath,
+    outputPath: "/alpha.gray",
+    settings,
+    videoObject: candidate({ executionBackend }),
+    width: 360,
+  });
+}
+
+describe("video-object bridge arguments", () => {
+  it("streams decoded frames through stdin for every provider", () => {
+    for (const executionBackend of [
+      "jianying-bach-v2-exact-d634-v1",
+      "same-model-coreml-v1",
+      "effect-host-interop-v1",
+    ] as const) {
+      expect(args({ executionBackend, inputPath: "-" })).toContain("-");
+    }
+  });
+
+  it("passes the pinned runtime, graph, packed model, and refinement to Bach", () => {
+    expect(
+      args({ executionBackend: "jianying-bach-v2-exact-d634-v1" }),
+    ).toEqual([
+      "/frameworks/libcccreator.dylib",
+      "/graph",
+      "/models/video-object.model",
+      "/source.rgba",
+      "360",
+      "640",
+      "/alpha.gray",
+      "0.6",
+      "0.25",
+      "2",
+      "3",
+    ]);
+  });
+
+  it("keeps direct CoreML and legacy host contracts distinct", () => {
+    expect(args({ executionBackend: "same-model-coreml-v1" })).toEqual([
+      "/model.mlmodelc",
+      "/source.rgba",
+      "360",
+      "640",
+      "/alpha.gray",
+      "0.6",
+      "0.25",
+      "2",
+      "3",
+    ]);
+    expect(args({ executionBackend: "effect-host-interop-v1" })).toEqual([
+      "/frameworks/libcccreator.dylib",
+      "/models",
+      "/effect",
+      "/source.rgba",
+      "360",
+      "640",
+      "/alpha.gray",
+      "0.6",
+      "0.25",
+      "2",
+      "3",
+      "--route",
+      "video-object",
+    ]);
+  });
+
+  it("fails closed when a backend-specific pinned asset is absent", () => {
+    const bach = candidate({
+      executionBackend: "jianying-bach-v2-exact-d634-v1",
+    });
+    bach.graphDirectory = null;
+    expect(() =>
+      createVideoObjectBridgeArguments({
+        height: 640,
+        inputPath: "/source.rgba",
+        outputPath: "/alpha.gray",
+        settings,
+        videoObject: bach,
+        width: 360,
+      }),
+    ).toThrow("Bach 物体抠像运行时不完整");
+  });
+});

--- a/qcut/electron/__tests__/person-cutout-video-object-circuit-breaker.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-circuit-breaker.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+	VIDEO_OBJECT_ALPHA_QUALITY_FAILURE,
+	VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE,
+	VideoObjectRuntimeCircuitBreaker,
+} from "../jianying-person-cutout/video-object-circuit-breaker.js";
+
+describe("video-object runtime circuit breaker", () => {
+	it("opens only for the calibrated Alpha quality failure", () => {
+		const circuitBreaker = new VideoObjectRuntimeCircuitBreaker();
+		expect(
+			circuitBreaker.reject({
+				capabilitySha256: "capability-a",
+				error: new Error(
+					`${VIDEO_OBJECT_ALPHA_QUALITY_FAILURE}: ${VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE}; fall back to portrait GRU`
+				),
+			})
+		).toBe(true);
+		expect(circuitBreaker.isOpen({ capabilitySha256: "capability-a" })).toBe(
+			true
+		);
+		expect(circuitBreaker.isOpen({ capabilitySha256: "capability-b" })).toBe(
+			false
+		);
+	});
+
+	it("keeps transient and unrelated failures retryable", () => {
+		const circuitBreaker = new VideoObjectRuntimeCircuitBreaker();
+		for (const error of [
+			new Error("encoder failed"),
+			new Error("video-object process was cancelled"),
+			new Error(`${VIDEO_OBJECT_ALPHA_QUALITY_FAILURE}: invalid Alpha`),
+			new Error(VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE),
+			"not an Error",
+		]) {
+			expect(
+				circuitBreaker.reject({
+					capabilitySha256: "capability-a",
+					error,
+				})
+			).toBe(false);
+		}
+		expect(circuitBreaker.isOpen({ capabilitySha256: "capability-a" })).toBe(
+			false
+		);
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-video-object-coreml-bridge-resolver.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-coreml-bridge-resolver.test.ts
@@ -1,41 +1,41 @@
 // @vitest-environment node
 import {
-  chmod,
-  mkdir,
-  mkdtemp,
-  open,
-  readdir,
-  rm,
-  stat,
-  writeFile,
+	chmod,
+	mkdir,
+	mkdtemp,
+	open,
+	readdir,
+	rm,
+	stat,
+	writeFile,
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME } from "../jianying-person-cutout/atomic-publish-lock.js";
 import {
-  compileVideoObjectCoreMLBridge,
-  isValidVideoObjectCoreMLBridge,
+	compileVideoObjectCoreMLBridge,
+	isValidVideoObjectCoreMLBridge,
 } from "../jianying-person-cutout/video-object-coreml-bridge-resolver.js";
 
 const temporaryDirectories: string[] = [];
 const originalPath = process.env.PATH;
 
 async function createTemporaryDirectory() {
-  const directory = await mkdtemp(
-    path.join(os.tmpdir(), "qcut-coreml-bridge-resolver-test-"),
-  );
-  temporaryDirectories.push(directory);
-  return directory;
+	const directory = await mkdtemp(
+		path.join(os.tmpdir(), "qcut-coreml-bridge-resolver-test-")
+	);
+	temporaryDirectories.push(directory);
+	return directory;
 }
 
 async function installFakeCompiler({ directory }: { directory: string }) {
-  const binDirectory = path.join(directory, "fake-bin");
-  const xcrunPath = path.join(binDirectory, "xcrun");
-  await mkdir(binDirectory, { recursive: true });
-  await writeFile(
-    xcrunPath,
-    `#!/usr/bin/env node
+	const binDirectory = path.join(directory, "fake-bin");
+	const xcrunPath = path.join(binDirectory, "xcrun");
+	await mkdir(binDirectory, { recursive: true });
+	await writeFile(
+		xcrunPath,
+		`#!/usr/bin/env node
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 const outputPath = args[args.lastIndexOf("-o") + 1];
@@ -47,121 +47,121 @@ setTimeout(() => {
   fs.chmodSync(outputPath, 0o755);
 }, Number(process.env.QCUT_FAKE_COMPILER_DELAY_MS || 0));
 `,
-    "utf8",
-  );
-  await chmod(xcrunPath, 0o755);
-  process.env.PATH = `${binDirectory}:${originalPath ?? ""}`;
+		"utf8"
+	);
+	await chmod(xcrunPath, 0o755);
+	process.env.PATH = `${binDirectory}:${originalPath ?? ""}`;
 }
 
 afterEach(async () => {
-  process.env.PATH = originalPath;
-  Reflect.deleteProperty(process.env, "QCUT_FAKE_COMPILER_DELAY_MS");
-  Reflect.deleteProperty(process.env, "QCUT_FAKE_TRUNCATED_BRIDGE");
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { force: true, recursive: true })),
-  );
+	process.env.PATH = originalPath;
+	Reflect.deleteProperty(process.env, "QCUT_FAKE_COMPILER_DELAY_MS");
+	Reflect.deleteProperty(process.env, "QCUT_FAKE_TRUNCATED_BRIDGE");
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { force: true, recursive: true }))
+	);
 });
 
 describe.runIf(process.platform === "darwin")(
-  "video-object CoreML bridge resolver",
-  () => {
-    it("rejects an executable but truncated cached bridge", async () => {
-      const directory = await createTemporaryDirectory();
-      const bridgePath = path.join(directory, "bridge");
-      await writeFile(bridgePath, Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
-      await chmod(bridgePath, 0o755);
+	"video-object CoreML bridge resolver",
+	() => {
+		it("rejects an executable but truncated cached bridge", async () => {
+			const directory = await createTemporaryDirectory();
+			const bridgePath = path.join(directory, "bridge");
+			await writeFile(bridgePath, Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+			await chmod(bridgePath, 0o755);
 
-      await expect(
-        isValidVideoObjectCoreMLBridge({ filePath: bridgePath }),
-      ).resolves.toBe(false);
-    });
+			await expect(
+				isValidVideoObjectCoreMLBridge({ filePath: bridgePath })
+			).resolves.toBe(false);
+		});
 
-    it("repairs a truncated cache through a unique temporary output", async () => {
-      const directory = await createTemporaryDirectory();
-      await installFakeCompiler({ directory });
-      const outputPath = path.join(directory, "cache", "bridge");
-      await mkdir(path.dirname(outputPath), { recursive: true });
-      await writeFile(outputPath, Buffer.from("truncated"));
-      await chmod(outputPath, 0o755);
+		it("repairs a truncated cache through a unique temporary output", async () => {
+			const directory = await createTemporaryDirectory();
+			await installFakeCompiler({ directory });
+			const outputPath = path.join(directory, "cache", "bridge");
+			await mkdir(path.dirname(outputPath), { recursive: true });
+			await writeFile(outputPath, Buffer.from("truncated"));
+			await chmod(outputPath, 0o755);
 
-      await expect(
-        compileVideoObjectCoreMLBridge({ outputPath, projectRoot: directory }),
-      ).resolves.toBe(outputPath);
-      await expect(
-        isValidVideoObjectCoreMLBridge({ filePath: outputPath }),
-      ).resolves.toBe(true);
-      expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
-    });
+			await expect(
+				compileVideoObjectCoreMLBridge({ outputPath, projectRoot: directory })
+			).resolves.toBe(outputPath);
+			await expect(
+				isValidVideoObjectCoreMLBridge({ filePath: outputPath })
+			).resolves.toBe(true);
+			expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
+		});
 
-    it("publishes one immutable bridge during concurrent compilation", async () => {
-      const directory = await createTemporaryDirectory();
-      await installFakeCompiler({ directory });
-      process.env.QCUT_FAKE_COMPILER_DELAY_MS = "20";
-      const outputPath = path.join(directory, "cache", "bridge");
-      const calls = Array.from({ length: 6 }, () =>
-        compileVideoObjectCoreMLBridge({
-          outputPath,
-          projectRoot: directory,
-        }),
-      );
+		it("publishes one immutable bridge during concurrent compilation", async () => {
+			const directory = await createTemporaryDirectory();
+			await installFakeCompiler({ directory });
+			process.env.QCUT_FAKE_COMPILER_DELAY_MS = "20";
+			const outputPath = path.join(directory, "cache", "bridge");
+			const calls = Array.from({ length: 6 }, () =>
+				compileVideoObjectCoreMLBridge({
+					outputPath,
+					projectRoot: directory,
+				})
+			);
 
-      const winner = await Promise.race(calls);
-      const winnerStat = await stat(winner);
-      const winnerHandle = await open(winner, "r");
-      try {
-        expect(new Set(await Promise.all(calls))).toEqual(
-          new Set([outputPath]),
-        );
-        expect((await stat(winner)).ino).toBe(winnerStat.ino);
-        const magic = Buffer.alloc(4);
-        await winnerHandle.read(magic, 0, magic.length, 0);
-        expect(magic).toEqual(Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
-      } finally {
-        await winnerHandle.close();
-      }
-      expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
-    });
+			const winner = await Promise.race(calls);
+			const winnerStat = await stat(winner);
+			const winnerHandle = await open(winner, "r");
+			try {
+				expect(new Set(await Promise.all(calls))).toEqual(
+					new Set([outputPath])
+				);
+				expect((await stat(winner)).ino).toBe(winnerStat.ino);
+				const magic = Buffer.alloc(4);
+				await winnerHandle.read(magic, 0, magic.length, 0);
+				expect(magic).toEqual(Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+			} finally {
+				await winnerHandle.close();
+			}
+			expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
+		});
 
-    it("cleans a truncated compiler output without publishing it", async () => {
-      const directory = await createTemporaryDirectory();
-      await installFakeCompiler({ directory });
-      process.env.QCUT_FAKE_TRUNCATED_BRIDGE = "1";
-      const outputPath = path.join(directory, "cache", "bridge");
+		it("cleans a truncated compiler output without publishing it", async () => {
+			const directory = await createTemporaryDirectory();
+			await installFakeCompiler({ directory });
+			process.env.QCUT_FAKE_TRUNCATED_BRIDGE = "1";
+			const outputPath = path.join(directory, "cache", "bridge");
 
-      await expect(
-        compileVideoObjectCoreMLBridge({ outputPath, projectRoot: directory }),
-      ).rejects.toThrow("构建产物无效");
-      await expect(
-        isValidVideoObjectCoreMLBridge({ filePath: outputPath }),
-      ).resolves.toBe(false);
-      expect(await readdir(path.dirname(outputPath))).toEqual([]);
-    });
+			await expect(
+				compileVideoObjectCoreMLBridge({ outputPath, projectRoot: directory })
+			).rejects.toThrow("构建产物无效");
+			await expect(
+				isValidVideoObjectCoreMLBridge({ filePath: outputPath })
+			).resolves.toBe(false);
+			expect(await readdir(path.dirname(outputPath))).toEqual([]);
+		});
 
-    it("never steals an old publish lock owned by a live compiler", async () => {
-      const directory = await createTemporaryDirectory();
-      await installFakeCompiler({ directory });
-      const outputPath = path.join(directory, "cache", "bridge");
-      const lockPath = `${outputPath}.publish-lock`;
-      await mkdir(lockPath, { recursive: true });
-      await writeFile(
-        path.join(lockPath, ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME),
-        JSON.stringify({ createdAt: 0, pid: process.pid }),
-        "utf8",
-      );
+		it("never steals an old publish lock owned by a live compiler", async () => {
+			const directory = await createTemporaryDirectory();
+			await installFakeCompiler({ directory });
+			const outputPath = path.join(directory, "cache", "bridge");
+			const lockPath = `${outputPath}.publish-lock`;
+			await mkdir(lockPath, { recursive: true });
+			await writeFile(
+				path.join(lockPath, ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME),
+				JSON.stringify({ createdAt: 0, pid: process.pid }),
+				"utf8"
+			);
 
-      await expect(
-        compileVideoObjectCoreMLBridge({
-          lockTiming: { retryMs: 1, waitMs: 5 },
-          outputPath,
-          projectRoot: directory,
-        }),
-      ).rejects.toThrow("Timed out waiting for cache publication lock");
-      expect((await stat(lockPath)).isDirectory()).toBe(true);
-      expect(await readdir(path.dirname(outputPath))).toEqual([
-        "bridge.publish-lock",
-      ]);
-    });
-  },
+			await expect(
+				compileVideoObjectCoreMLBridge({
+					lockTiming: { retryMs: 1, waitMs: 5 },
+					outputPath,
+					projectRoot: directory,
+				})
+			).rejects.toThrow("Timed out waiting for cache publication lock");
+			expect((await stat(lockPath)).isDirectory()).toBe(true);
+			expect(await readdir(path.dirname(outputPath))).toEqual([
+				"bridge.publish-lock",
+			]);
+		});
+	}
 );

--- a/qcut/electron/__tests__/person-cutout-video-object-coreml-bridge-resolver.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-coreml-bridge-resolver.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME } from "../jianying-person-cutout/atomic-publish-lock.js";
+import {
+  compileVideoObjectCoreMLBridge,
+  isValidVideoObjectCoreMLBridge,
+} from "../jianying-person-cutout/video-object-coreml-bridge-resolver.js";
+
+const temporaryDirectories: string[] = [];
+const originalPath = process.env.PATH;
+
+async function createTemporaryDirectory() {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "qcut-coreml-bridge-resolver-test-"),
+  );
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function installFakeCompiler({ directory }: { directory: string }) {
+  const binDirectory = path.join(directory, "fake-bin");
+  const xcrunPath = path.join(binDirectory, "xcrun");
+  await mkdir(binDirectory, { recursive: true });
+  await writeFile(
+    xcrunPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const outputPath = args[args.lastIndexOf("-o") + 1];
+const image = Buffer.alloc(process.env.QCUT_FAKE_TRUNCATED_BRIDGE === "1" ? 16 : 4096);
+Buffer.from([0xcf, 0xfa, 0xed, 0xfe]).copy(image);
+Buffer.from("video-object-same-model-coreml-v1").copy(image, 64);
+setTimeout(() => {
+  fs.writeFileSync(outputPath, image);
+  fs.chmodSync(outputPath, 0o755);
+}, Number(process.env.QCUT_FAKE_COMPILER_DELAY_MS || 0));
+`,
+    "utf8",
+  );
+  await chmod(xcrunPath, 0o755);
+  process.env.PATH = `${binDirectory}:${originalPath ?? ""}`;
+}
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  Reflect.deleteProperty(process.env, "QCUT_FAKE_COMPILER_DELAY_MS");
+  Reflect.deleteProperty(process.env, "QCUT_FAKE_TRUNCATED_BRIDGE");
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe.runIf(process.platform === "darwin")(
+  "video-object CoreML bridge resolver",
+  () => {
+    it("rejects an executable but truncated cached bridge", async () => {
+      const directory = await createTemporaryDirectory();
+      const bridgePath = path.join(directory, "bridge");
+      await writeFile(bridgePath, Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+      await chmod(bridgePath, 0o755);
+
+      await expect(
+        isValidVideoObjectCoreMLBridge({ filePath: bridgePath }),
+      ).resolves.toBe(false);
+    });
+
+    it("repairs a truncated cache through a unique temporary output", async () => {
+      const directory = await createTemporaryDirectory();
+      await installFakeCompiler({ directory });
+      const outputPath = path.join(directory, "cache", "bridge");
+      await mkdir(path.dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, Buffer.from("truncated"));
+      await chmod(outputPath, 0o755);
+
+      await expect(
+        compileVideoObjectCoreMLBridge({ outputPath, projectRoot: directory }),
+      ).resolves.toBe(outputPath);
+      await expect(
+        isValidVideoObjectCoreMLBridge({ filePath: outputPath }),
+      ).resolves.toBe(true);
+      expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
+    });
+
+    it("publishes one immutable bridge during concurrent compilation", async () => {
+      const directory = await createTemporaryDirectory();
+      await installFakeCompiler({ directory });
+      process.env.QCUT_FAKE_COMPILER_DELAY_MS = "20";
+      const outputPath = path.join(directory, "cache", "bridge");
+      const calls = Array.from({ length: 6 }, () =>
+        compileVideoObjectCoreMLBridge({
+          outputPath,
+          projectRoot: directory,
+        }),
+      );
+
+      const winner = await Promise.race(calls);
+      const winnerStat = await stat(winner);
+      const winnerHandle = await open(winner, "r");
+      try {
+        expect(new Set(await Promise.all(calls))).toEqual(
+          new Set([outputPath]),
+        );
+        expect((await stat(winner)).ino).toBe(winnerStat.ino);
+        const magic = Buffer.alloc(4);
+        await winnerHandle.read(magic, 0, magic.length, 0);
+        expect(magic).toEqual(Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+      } finally {
+        await winnerHandle.close();
+      }
+      expect(await readdir(path.dirname(outputPath))).toEqual(["bridge"]);
+    });
+
+    it("cleans a truncated compiler output without publishing it", async () => {
+      const directory = await createTemporaryDirectory();
+      await installFakeCompiler({ directory });
+      process.env.QCUT_FAKE_TRUNCATED_BRIDGE = "1";
+      const outputPath = path.join(directory, "cache", "bridge");
+
+      await expect(
+        compileVideoObjectCoreMLBridge({ outputPath, projectRoot: directory }),
+      ).rejects.toThrow("构建产物无效");
+      await expect(
+        isValidVideoObjectCoreMLBridge({ filePath: outputPath }),
+      ).resolves.toBe(false);
+      expect(await readdir(path.dirname(outputPath))).toEqual([]);
+    });
+
+    it("never steals an old publish lock owned by a live compiler", async () => {
+      const directory = await createTemporaryDirectory();
+      await installFakeCompiler({ directory });
+      const outputPath = path.join(directory, "cache", "bridge");
+      const lockPath = `${outputPath}.publish-lock`;
+      await mkdir(lockPath, { recursive: true });
+      await writeFile(
+        path.join(lockPath, ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME),
+        JSON.stringify({ createdAt: 0, pid: process.pid }),
+        "utf8",
+      );
+
+      await expect(
+        compileVideoObjectCoreMLBridge({
+          lockTiming: { retryMs: 1, waitMs: 5 },
+          outputPath,
+          projectRoot: directory,
+        }),
+      ).rejects.toThrow("Timed out waiting for cache publication lock");
+      expect((await stat(lockPath)).isDirectory()).toBe(true);
+      expect(await readdir(path.dirname(outputPath))).toEqual([
+        "bridge.publish-lock",
+      ]);
+    });
+  },
+);

--- a/qcut/electron/__tests__/person-cutout-video-object-coreml-preprocess.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-coreml-preprocess.test.ts
@@ -11,39 +11,39 @@ const describeOnMac = process.platform === "darwin" ? describe : describe.skip;
 let temporaryDirectory = "";
 
 describeOnMac("video-object CoreML tensor preprocessing", () => {
-  beforeAll(async () => {
-    temporaryDirectory = await mkdtemp(
-      path.join(os.tmpdir(), "qcut-video-object-coreml-preprocess-test-"),
-    );
-  });
+	beforeAll(async () => {
+		temporaryDirectory = await mkdtemp(
+			path.join(os.tmpdir(), "qcut-video-object-coreml-preprocess-test-")
+		);
+	});
 
-  afterAll(async () => {
-    if (!temporaryDirectory) return;
-    await rm(temporaryDirectory, { force: true, recursive: true });
-  });
+	afterAll(async () => {
+		if (!temporaryDirectory) return;
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	});
 
-  it("compiles and verifies color, temporal-state, reset, and raw Alpha contracts", async () => {
-    const nativeDirectory = path.resolve(
-      "electron",
-      "jianying-person-cutout",
-      "native",
-    );
-    const executablePath = path.join(
-      temporaryDirectory,
-      "video-object-coreml-preprocess-test",
-    );
-    await execFileAsync("xcrun", [
-      "clang++",
-      "-std=c++20",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      path.join(nativeDirectory, "alpha-resize.cpp"),
-      path.join(nativeDirectory, "video-object-coreml-preprocess.cpp"),
-      path.join(nativeDirectory, "video-object-coreml-preprocess.test.cpp"),
-      "-o",
-      executablePath,
-    ]);
-    await expect(execFileAsync(executablePath)).resolves.toBeDefined();
-  });
+	it("compiles and verifies color, temporal-state, reset, and raw Alpha contracts", async () => {
+		const nativeDirectory = path.resolve(
+			"electron",
+			"jianying-person-cutout",
+			"native"
+		);
+		const executablePath = path.join(
+			temporaryDirectory,
+			"video-object-coreml-preprocess-test"
+		);
+		await execFileAsync("xcrun", [
+			"clang++",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			path.join(nativeDirectory, "alpha-resize.cpp"),
+			path.join(nativeDirectory, "video-object-coreml-preprocess.cpp"),
+			path.join(nativeDirectory, "video-object-coreml-preprocess.test.cpp"),
+			"-o",
+			executablePath,
+		]);
+		await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-video-object-coreml-preprocess.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-coreml-preprocess.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const describeOnMac = process.platform === "darwin" ? describe : describe.skip;
+let temporaryDirectory = "";
+
+describeOnMac("video-object CoreML tensor preprocessing", () => {
+  beforeAll(async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(os.tmpdir(), "qcut-video-object-coreml-preprocess-test-"),
+    );
+  });
+
+  afterAll(async () => {
+    if (!temporaryDirectory) return;
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  });
+
+  it("compiles and verifies color, temporal-state, reset, and raw Alpha contracts", async () => {
+    const nativeDirectory = path.resolve(
+      "electron",
+      "jianying-person-cutout",
+      "native",
+    );
+    const executablePath = path.join(
+      temporaryDirectory,
+      "video-object-coreml-preprocess-test",
+    );
+    await execFileAsync("xcrun", [
+      "clang++",
+      "-std=c++20",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      path.join(nativeDirectory, "alpha-resize.cpp"),
+      path.join(nativeDirectory, "video-object-coreml-preprocess.cpp"),
+      path.join(nativeDirectory, "video-object-coreml-preprocess.test.cpp"),
+      "-o",
+      executablePath,
+    ]);
+    await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+  });
+});

--- a/qcut/electron/__tests__/person-cutout-video-object-coreml-runtime.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-coreml-runtime.test.ts
@@ -1,0 +1,332 @@
+// @vitest-environment node
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME } from "../jianying-person-cutout/atomic-publish-lock.js";
+import {
+  COREML_BUNDLE_MANIFEST_FILE_NAME,
+  createVideoObjectCoreMLCache,
+  findPackedCoreMLArchiveOffset,
+  type CoreMLBundleManifest,
+} from "../jianying-person-cutout/video-object-coreml-runtime.js";
+
+const execFileAsync = promisify(execFile);
+const bundleName = "20440.3_sod_fp16.mlmodelc";
+const validMetadata = [
+  {
+    inputSchema: [
+      { name: "data", shape: "[1, 3, 256, 256]" },
+      { name: "prev_img", shape: "[1, 3, 256, 256]" },
+      { name: "prev_mask", shape: "[1, 1, 256, 256]" },
+    ],
+    outputSchema: [{ name: "nn_3", shape: "[]" }],
+  },
+];
+const fixtureFiles = new Map<string, Buffer>([
+  ["metadata.json", Buffer.from(JSON.stringify(validMetadata))],
+  ["model.espresso.net", Buffer.from("verified-network")],
+  ["model.espresso.weights", Buffer.from("verified-weights-content")],
+  ["model/coremldata.bin", Buffer.from("verified-model-data")],
+]);
+const fixtureManifest: CoreMLBundleManifest = {
+  bundleName,
+  packedModelSha256: "model-sha",
+  version: 1,
+  files: [...fixtureFiles.entries()].map(([filePath, contents]) => ({
+    path: filePath,
+    sha256: createHash("sha256").update(contents).digest("hex"),
+    size: contents.length,
+  })),
+};
+const fixtureCache = createVideoObjectCoreMLCache({
+  expectedManifest: fixtureManifest,
+});
+const temporaryDirectories: string[] = [];
+
+function fixtureManifestContents() {
+  return `${JSON.stringify(
+    {
+      ...fixtureManifest,
+      files: [...fixtureManifest.files].sort((left, right) =>
+        left.path.localeCompare(right.path),
+      ),
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+async function createTemporaryDirectory() {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "qcut-video-object-coreml-test-"),
+  );
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function writeBundle({
+  bundlePath,
+  overrides = new Map(),
+}: {
+  bundlePath: string;
+  overrides?: ReadonlyMap<string, Buffer>;
+}) {
+  await Promise.all(
+    [...fixtureFiles.entries()].map(async ([relativePath, defaultContents]) => {
+      const filePath = path.join(bundlePath, ...relativePath.split("/"));
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, overrides.get(relativePath) ?? defaultContents);
+    }),
+  );
+}
+
+async function writePublishedCache({
+  cacheDirectory,
+  overrides,
+}: {
+  cacheDirectory: string;
+  overrides?: ReadonlyMap<string, Buffer>;
+}) {
+  await writeBundle({
+    bundlePath: path.join(cacheDirectory, bundleName),
+    overrides,
+  });
+  await writeFile(
+    path.join(cacheDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
+    fixtureManifestContents(),
+    "utf8",
+  );
+}
+
+async function createPackedModel({ directory }: { directory: string }) {
+  const sourceDirectory = path.join(directory, "packed-source");
+  const bundlePath = path.join(sourceDirectory, bundleName);
+  const archivePath = path.join(sourceDirectory, "network.zip");
+  await writeBundle({ bundlePath });
+  await execFileAsync("/usr/bin/ditto", [
+    "-c",
+    "-k",
+    "--keepParent",
+    bundlePath,
+    archivePath,
+  ]);
+  const modelPath = path.join(directory, "video-object.model");
+  await writeFile(
+    modelPath,
+    Buffer.concat([
+      Buffer.from("packed-graph-header"),
+      await readFile(archivePath),
+    ]),
+  );
+  return modelPath;
+}
+
+function configureCache({ directory }: { directory: string }) {
+  const cacheRoot = path.join(directory, "cache");
+  process.env.QCUT_VIDEO_OBJECT_COREML_CACHE_ROOT = cacheRoot;
+  return {
+    cacheDirectory: path.join(cacheRoot, fixtureManifest.packedModelSha256),
+    cacheRoot,
+  };
+}
+
+afterEach(async () => {
+  Reflect.deleteProperty(process.env, "QCUT_VIDEO_OBJECT_COREML_CACHE_ROOT");
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("packed video-object CoreML model", () => {
+  it("finds the embedded ZIP after the private graph header", () => {
+    const prefix = Buffer.from("packed-graph");
+    const modelContents = Buffer.concat([
+      prefix,
+      Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x01]),
+    ]);
+    expect(findPackedCoreMLArchiveOffset({ modelContents })).toBe(
+      prefix.length,
+    );
+  });
+
+  it("rejects a missing or unprefixed CoreML archive", () => {
+    expect(() =>
+      findPackedCoreMLArchiveOffset({
+        modelContents: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+      }),
+    ).toThrow("不包含可读取的 CoreML 网络");
+    expect(() =>
+      findPackedCoreMLArchiveOffset({ modelContents: Buffer.from("graph") }),
+    ).toThrow("不包含可读取的 CoreML 网络");
+  });
+
+  it("rejects a published bundle whose tensor contract changed", async () => {
+    const directory = await createTemporaryDirectory();
+    const { cacheDirectory } = configureCache({ directory });
+    await writePublishedCache({
+      cacheDirectory,
+      overrides: new Map([
+        [
+          "metadata.json",
+          Buffer.from(
+            JSON.stringify([
+              {
+                ...validMetadata[0],
+                outputSchema: [{ name: "unexpected", shape: "[]" }],
+              },
+            ]),
+          ),
+        ],
+      ]),
+    });
+    await expect(
+      fixtureCache.isReadable({
+        modelPath: path.join(cacheDirectory, bundleName),
+      }),
+    ).resolves.toBe(false);
+  });
+});
+
+describe.runIf(process.platform === "darwin")(
+  "video-object CoreML cache",
+  () => {
+    it("uses a fully validated cache without reopening the packed model", async () => {
+      const directory = await createTemporaryDirectory();
+      const { cacheDirectory } = configureCache({ directory });
+      await writePublishedCache({ cacheDirectory });
+      const cachedBundle = path.join(cacheDirectory, bundleName);
+
+      await expect(
+        fixtureCache.prepare({
+          modelPath: path.join(directory, "does-not-exist.model"),
+          modelSha256: fixtureManifest.packedModelSha256,
+        }),
+      ).resolves.toBe(cachedBundle);
+    });
+
+    it.each([
+      {
+        name: "missing weights",
+        corrupt: async (cacheDirectory: string) =>
+          rm(path.join(cacheDirectory, bundleName, "model.espresso.weights")),
+      },
+      {
+        name: "truncated weights",
+        corrupt: async (cacheDirectory: string) =>
+          writeFile(
+            path.join(cacheDirectory, bundleName, "model.espresso.weights"),
+            Buffer.from("truncated"),
+          ),
+      },
+      {
+        name: "damaged manifest",
+        corrupt: async (cacheDirectory: string) =>
+          writeFile(
+            path.join(cacheDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
+            "{damaged",
+            "utf8",
+          ),
+      },
+    ])("atomically repairs $name", async ({ corrupt }) => {
+      const directory = await createTemporaryDirectory();
+      const { cacheDirectory } = configureCache({ directory });
+      await writePublishedCache({ cacheDirectory });
+      await corrupt(cacheDirectory);
+      const modelPath = await createPackedModel({ directory });
+
+      const result = await fixtureCache.prepare({
+        modelPath,
+        modelSha256: fixtureManifest.packedModelSha256,
+      });
+
+      await expect(
+        fixtureCache.isReadable({ modelPath: result }),
+      ).resolves.toBe(true);
+      expect(
+        await readFile(path.join(result, "model.espresso.weights")),
+      ).toEqual(fixtureFiles.get("model.espresso.weights"));
+    });
+
+    it("publishes one immutable winner during concurrent repair", async () => {
+      const directory = await createTemporaryDirectory();
+      const { cacheDirectory, cacheRoot } = configureCache({ directory });
+      await writePublishedCache({ cacheDirectory });
+      await writeFile(
+        path.join(cacheDirectory, bundleName, "model.espresso.weights"),
+        Buffer.from("truncated"),
+      );
+      const modelPath = await createPackedModel({ directory });
+      const calls = Array.from({ length: 6 }, () =>
+        fixtureCache.prepare({
+          modelPath,
+          modelSha256: fixtureManifest.packedModelSha256,
+        }),
+      );
+
+      const winner = await Promise.race(calls);
+      const winnerDirectory = path.dirname(winner);
+      const winnerStat = await stat(winnerDirectory);
+      const weightsHandle = await open(
+        path.join(winner, "model.espresso.weights"),
+        "r",
+      );
+      try {
+        const results = await Promise.all(calls);
+        expect(new Set(results)).toEqual(new Set([winner]));
+        expect((await stat(winnerDirectory)).ino).toBe(winnerStat.ino);
+        const probe = Buffer.alloc(8);
+        await weightsHandle.read(probe, 0, probe.length, 0);
+        expect(probe).toEqual(
+          fixtureFiles.get("model.espresso.weights")?.subarray(0, probe.length),
+        );
+      } finally {
+        await weightsHandle.close();
+      }
+      expect((await readdir(cacheRoot)).sort()).toEqual([
+        fixtureManifest.packedModelSha256,
+      ]);
+    });
+
+    it("never steals an old lock owned by a live process", async () => {
+      const directory = await createTemporaryDirectory();
+      const { cacheRoot } = configureCache({ directory });
+      const lockPath = path.join(
+        cacheRoot,
+        `${fixtureManifest.packedModelSha256}.publish-lock`,
+      );
+      await mkdir(lockPath, { recursive: true });
+      await writeFile(
+        path.join(lockPath, ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME),
+        JSON.stringify({ createdAt: 0, pid: process.pid }),
+        "utf8",
+      );
+      const shortWaitCache = createVideoObjectCoreMLCache({
+        expectedManifest: fixtureManifest,
+        lockTiming: { retryMs: 1, waitMs: 5 },
+      });
+
+      await expect(
+        shortWaitCache.prepare({
+          modelPath: path.join(directory, "not-read.model"),
+          modelSha256: fixtureManifest.packedModelSha256,
+        }),
+      ).rejects.toThrow("Timed out waiting for cache publication lock");
+      expect((await stat(lockPath)).isDirectory()).toBe(true);
+    });
+  },
+);

--- a/qcut/electron/__tests__/person-cutout-video-object-coreml-runtime.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-coreml-runtime.test.ts
@@ -2,14 +2,14 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-  mkdir,
-  mkdtemp,
-  open,
-  readFile,
-  readdir,
-  rm,
-  stat,
-  writeFile,
+	mkdir,
+	mkdtemp,
+	open,
+	readFile,
+	readdir,
+	rm,
+	stat,
+	writeFile,
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -17,316 +17,316 @@ import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import { ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME } from "../jianying-person-cutout/atomic-publish-lock.js";
 import {
-  COREML_BUNDLE_MANIFEST_FILE_NAME,
-  createVideoObjectCoreMLCache,
-  findPackedCoreMLArchiveOffset,
-  type CoreMLBundleManifest,
+	COREML_BUNDLE_MANIFEST_FILE_NAME,
+	createVideoObjectCoreMLCache,
+	findPackedCoreMLArchiveOffset,
+	type CoreMLBundleManifest,
 } from "../jianying-person-cutout/video-object-coreml-runtime.js";
 
 const execFileAsync = promisify(execFile);
 const bundleName = "20440.3_sod_fp16.mlmodelc";
 const validMetadata = [
-  {
-    inputSchema: [
-      { name: "data", shape: "[1, 3, 256, 256]" },
-      { name: "prev_img", shape: "[1, 3, 256, 256]" },
-      { name: "prev_mask", shape: "[1, 1, 256, 256]" },
-    ],
-    outputSchema: [{ name: "nn_3", shape: "[]" }],
-  },
+	{
+		inputSchema: [
+			{ name: "data", shape: "[1, 3, 256, 256]" },
+			{ name: "prev_img", shape: "[1, 3, 256, 256]" },
+			{ name: "prev_mask", shape: "[1, 1, 256, 256]" },
+		],
+		outputSchema: [{ name: "nn_3", shape: "[]" }],
+	},
 ];
 const fixtureFiles = new Map<string, Buffer>([
-  ["metadata.json", Buffer.from(JSON.stringify(validMetadata))],
-  ["model.espresso.net", Buffer.from("verified-network")],
-  ["model.espresso.weights", Buffer.from("verified-weights-content")],
-  ["model/coremldata.bin", Buffer.from("verified-model-data")],
+	["metadata.json", Buffer.from(JSON.stringify(validMetadata))],
+	["model.espresso.net", Buffer.from("verified-network")],
+	["model.espresso.weights", Buffer.from("verified-weights-content")],
+	["model/coremldata.bin", Buffer.from("verified-model-data")],
 ]);
 const fixtureManifest: CoreMLBundleManifest = {
-  bundleName,
-  packedModelSha256: "model-sha",
-  version: 1,
-  files: [...fixtureFiles.entries()].map(([filePath, contents]) => ({
-    path: filePath,
-    sha256: createHash("sha256").update(contents).digest("hex"),
-    size: contents.length,
-  })),
+	bundleName,
+	packedModelSha256: "model-sha",
+	version: 1,
+	files: [...fixtureFiles.entries()].map(([filePath, contents]) => ({
+		path: filePath,
+		sha256: createHash("sha256").update(contents).digest("hex"),
+		size: contents.length,
+	})),
 };
 const fixtureCache = createVideoObjectCoreMLCache({
-  expectedManifest: fixtureManifest,
+	expectedManifest: fixtureManifest,
 });
 const temporaryDirectories: string[] = [];
 
 function fixtureManifestContents() {
-  return `${JSON.stringify(
-    {
-      ...fixtureManifest,
-      files: [...fixtureManifest.files].sort((left, right) =>
-        left.path.localeCompare(right.path),
-      ),
-    },
-    null,
-    2,
-  )}\n`;
+	return `${JSON.stringify(
+		{
+			...fixtureManifest,
+			files: [...fixtureManifest.files].sort((left, right) =>
+				left.path.localeCompare(right.path)
+			),
+		},
+		null,
+		2
+	)}\n`;
 }
 
 async function createTemporaryDirectory() {
-  const directory = await mkdtemp(
-    path.join(os.tmpdir(), "qcut-video-object-coreml-test-"),
-  );
-  temporaryDirectories.push(directory);
-  return directory;
+	const directory = await mkdtemp(
+		path.join(os.tmpdir(), "qcut-video-object-coreml-test-")
+	);
+	temporaryDirectories.push(directory);
+	return directory;
 }
 
 async function writeBundle({
-  bundlePath,
-  overrides = new Map(),
+	bundlePath,
+	overrides = new Map(),
 }: {
-  bundlePath: string;
-  overrides?: ReadonlyMap<string, Buffer>;
+	bundlePath: string;
+	overrides?: ReadonlyMap<string, Buffer>;
 }) {
-  await Promise.all(
-    [...fixtureFiles.entries()].map(async ([relativePath, defaultContents]) => {
-      const filePath = path.join(bundlePath, ...relativePath.split("/"));
-      await mkdir(path.dirname(filePath), { recursive: true });
-      await writeFile(filePath, overrides.get(relativePath) ?? defaultContents);
-    }),
-  );
+	await Promise.all(
+		[...fixtureFiles.entries()].map(async ([relativePath, defaultContents]) => {
+			const filePath = path.join(bundlePath, ...relativePath.split("/"));
+			await mkdir(path.dirname(filePath), { recursive: true });
+			await writeFile(filePath, overrides.get(relativePath) ?? defaultContents);
+		})
+	);
 }
 
 async function writePublishedCache({
-  cacheDirectory,
-  overrides,
+	cacheDirectory,
+	overrides,
 }: {
-  cacheDirectory: string;
-  overrides?: ReadonlyMap<string, Buffer>;
+	cacheDirectory: string;
+	overrides?: ReadonlyMap<string, Buffer>;
 }) {
-  await writeBundle({
-    bundlePath: path.join(cacheDirectory, bundleName),
-    overrides,
-  });
-  await writeFile(
-    path.join(cacheDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
-    fixtureManifestContents(),
-    "utf8",
-  );
+	await writeBundle({
+		bundlePath: path.join(cacheDirectory, bundleName),
+		overrides,
+	});
+	await writeFile(
+		path.join(cacheDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
+		fixtureManifestContents(),
+		"utf8"
+	);
 }
 
 async function createPackedModel({ directory }: { directory: string }) {
-  const sourceDirectory = path.join(directory, "packed-source");
-  const bundlePath = path.join(sourceDirectory, bundleName);
-  const archivePath = path.join(sourceDirectory, "network.zip");
-  await writeBundle({ bundlePath });
-  await execFileAsync("/usr/bin/ditto", [
-    "-c",
-    "-k",
-    "--keepParent",
-    bundlePath,
-    archivePath,
-  ]);
-  const modelPath = path.join(directory, "video-object.model");
-  await writeFile(
-    modelPath,
-    Buffer.concat([
-      Buffer.from("packed-graph-header"),
-      await readFile(archivePath),
-    ]),
-  );
-  return modelPath;
+	const sourceDirectory = path.join(directory, "packed-source");
+	const bundlePath = path.join(sourceDirectory, bundleName);
+	const archivePath = path.join(sourceDirectory, "network.zip");
+	await writeBundle({ bundlePath });
+	await execFileAsync("/usr/bin/ditto", [
+		"-c",
+		"-k",
+		"--keepParent",
+		bundlePath,
+		archivePath,
+	]);
+	const modelPath = path.join(directory, "video-object.model");
+	await writeFile(
+		modelPath,
+		Buffer.concat([
+			Buffer.from("packed-graph-header"),
+			await readFile(archivePath),
+		])
+	);
+	return modelPath;
 }
 
 function configureCache({ directory }: { directory: string }) {
-  const cacheRoot = path.join(directory, "cache");
-  process.env.QCUT_VIDEO_OBJECT_COREML_CACHE_ROOT = cacheRoot;
-  return {
-    cacheDirectory: path.join(cacheRoot, fixtureManifest.packedModelSha256),
-    cacheRoot,
-  };
+	const cacheRoot = path.join(directory, "cache");
+	process.env.QCUT_VIDEO_OBJECT_COREML_CACHE_ROOT = cacheRoot;
+	return {
+		cacheDirectory: path.join(cacheRoot, fixtureManifest.packedModelSha256),
+		cacheRoot,
+	};
 }
 
 afterEach(async () => {
-  Reflect.deleteProperty(process.env, "QCUT_VIDEO_OBJECT_COREML_CACHE_ROOT");
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { force: true, recursive: true })),
-  );
+	Reflect.deleteProperty(process.env, "QCUT_VIDEO_OBJECT_COREML_CACHE_ROOT");
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { force: true, recursive: true }))
+	);
 });
 
 describe("packed video-object CoreML model", () => {
-  it("finds the embedded ZIP after the private graph header", () => {
-    const prefix = Buffer.from("packed-graph");
-    const modelContents = Buffer.concat([
-      prefix,
-      Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x01]),
-    ]);
-    expect(findPackedCoreMLArchiveOffset({ modelContents })).toBe(
-      prefix.length,
-    );
-  });
+	it("finds the embedded ZIP after the private graph header", () => {
+		const prefix = Buffer.from("packed-graph");
+		const modelContents = Buffer.concat([
+			prefix,
+			Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x01]),
+		]);
+		expect(findPackedCoreMLArchiveOffset({ modelContents })).toBe(
+			prefix.length
+		);
+	});
 
-  it("rejects a missing or unprefixed CoreML archive", () => {
-    expect(() =>
-      findPackedCoreMLArchiveOffset({
-        modelContents: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
-      }),
-    ).toThrow("不包含可读取的 CoreML 网络");
-    expect(() =>
-      findPackedCoreMLArchiveOffset({ modelContents: Buffer.from("graph") }),
-    ).toThrow("不包含可读取的 CoreML 网络");
-  });
+	it("rejects a missing or unprefixed CoreML archive", () => {
+		expect(() =>
+			findPackedCoreMLArchiveOffset({
+				modelContents: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+			})
+		).toThrow("不包含可读取的 CoreML 网络");
+		expect(() =>
+			findPackedCoreMLArchiveOffset({ modelContents: Buffer.from("graph") })
+		).toThrow("不包含可读取的 CoreML 网络");
+	});
 
-  it("rejects a published bundle whose tensor contract changed", async () => {
-    const directory = await createTemporaryDirectory();
-    const { cacheDirectory } = configureCache({ directory });
-    await writePublishedCache({
-      cacheDirectory,
-      overrides: new Map([
-        [
-          "metadata.json",
-          Buffer.from(
-            JSON.stringify([
-              {
-                ...validMetadata[0],
-                outputSchema: [{ name: "unexpected", shape: "[]" }],
-              },
-            ]),
-          ),
-        ],
-      ]),
-    });
-    await expect(
-      fixtureCache.isReadable({
-        modelPath: path.join(cacheDirectory, bundleName),
-      }),
-    ).resolves.toBe(false);
-  });
+	it("rejects a published bundle whose tensor contract changed", async () => {
+		const directory = await createTemporaryDirectory();
+		const { cacheDirectory } = configureCache({ directory });
+		await writePublishedCache({
+			cacheDirectory,
+			overrides: new Map([
+				[
+					"metadata.json",
+					Buffer.from(
+						JSON.stringify([
+							{
+								...validMetadata[0],
+								outputSchema: [{ name: "unexpected", shape: "[]" }],
+							},
+						])
+					),
+				],
+			]),
+		});
+		await expect(
+			fixtureCache.isReadable({
+				modelPath: path.join(cacheDirectory, bundleName),
+			})
+		).resolves.toBe(false);
+	});
 });
 
 describe.runIf(process.platform === "darwin")(
-  "video-object CoreML cache",
-  () => {
-    it("uses a fully validated cache without reopening the packed model", async () => {
-      const directory = await createTemporaryDirectory();
-      const { cacheDirectory } = configureCache({ directory });
-      await writePublishedCache({ cacheDirectory });
-      const cachedBundle = path.join(cacheDirectory, bundleName);
+	"video-object CoreML cache",
+	() => {
+		it("uses a fully validated cache without reopening the packed model", async () => {
+			const directory = await createTemporaryDirectory();
+			const { cacheDirectory } = configureCache({ directory });
+			await writePublishedCache({ cacheDirectory });
+			const cachedBundle = path.join(cacheDirectory, bundleName);
 
-      await expect(
-        fixtureCache.prepare({
-          modelPath: path.join(directory, "does-not-exist.model"),
-          modelSha256: fixtureManifest.packedModelSha256,
-        }),
-      ).resolves.toBe(cachedBundle);
-    });
+			await expect(
+				fixtureCache.prepare({
+					modelPath: path.join(directory, "does-not-exist.model"),
+					modelSha256: fixtureManifest.packedModelSha256,
+				})
+			).resolves.toBe(cachedBundle);
+		});
 
-    it.each([
-      {
-        name: "missing weights",
-        corrupt: async (cacheDirectory: string) =>
-          rm(path.join(cacheDirectory, bundleName, "model.espresso.weights")),
-      },
-      {
-        name: "truncated weights",
-        corrupt: async (cacheDirectory: string) =>
-          writeFile(
-            path.join(cacheDirectory, bundleName, "model.espresso.weights"),
-            Buffer.from("truncated"),
-          ),
-      },
-      {
-        name: "damaged manifest",
-        corrupt: async (cacheDirectory: string) =>
-          writeFile(
-            path.join(cacheDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
-            "{damaged",
-            "utf8",
-          ),
-      },
-    ])("atomically repairs $name", async ({ corrupt }) => {
-      const directory = await createTemporaryDirectory();
-      const { cacheDirectory } = configureCache({ directory });
-      await writePublishedCache({ cacheDirectory });
-      await corrupt(cacheDirectory);
-      const modelPath = await createPackedModel({ directory });
+		it.each([
+			{
+				name: "missing weights",
+				corrupt: async (cacheDirectory: string) =>
+					rm(path.join(cacheDirectory, bundleName, "model.espresso.weights")),
+			},
+			{
+				name: "truncated weights",
+				corrupt: async (cacheDirectory: string) =>
+					writeFile(
+						path.join(cacheDirectory, bundleName, "model.espresso.weights"),
+						Buffer.from("truncated")
+					),
+			},
+			{
+				name: "damaged manifest",
+				corrupt: async (cacheDirectory: string) =>
+					writeFile(
+						path.join(cacheDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
+						"{damaged",
+						"utf8"
+					),
+			},
+		])("atomically repairs $name", async ({ corrupt }) => {
+			const directory = await createTemporaryDirectory();
+			const { cacheDirectory } = configureCache({ directory });
+			await writePublishedCache({ cacheDirectory });
+			await corrupt(cacheDirectory);
+			const modelPath = await createPackedModel({ directory });
 
-      const result = await fixtureCache.prepare({
-        modelPath,
-        modelSha256: fixtureManifest.packedModelSha256,
-      });
+			const result = await fixtureCache.prepare({
+				modelPath,
+				modelSha256: fixtureManifest.packedModelSha256,
+			});
 
-      await expect(
-        fixtureCache.isReadable({ modelPath: result }),
-      ).resolves.toBe(true);
-      expect(
-        await readFile(path.join(result, "model.espresso.weights")),
-      ).toEqual(fixtureFiles.get("model.espresso.weights"));
-    });
+			await expect(
+				fixtureCache.isReadable({ modelPath: result })
+			).resolves.toBe(true);
+			expect(
+				await readFile(path.join(result, "model.espresso.weights"))
+			).toEqual(fixtureFiles.get("model.espresso.weights"));
+		});
 
-    it("publishes one immutable winner during concurrent repair", async () => {
-      const directory = await createTemporaryDirectory();
-      const { cacheDirectory, cacheRoot } = configureCache({ directory });
-      await writePublishedCache({ cacheDirectory });
-      await writeFile(
-        path.join(cacheDirectory, bundleName, "model.espresso.weights"),
-        Buffer.from("truncated"),
-      );
-      const modelPath = await createPackedModel({ directory });
-      const calls = Array.from({ length: 6 }, () =>
-        fixtureCache.prepare({
-          modelPath,
-          modelSha256: fixtureManifest.packedModelSha256,
-        }),
-      );
+		it("publishes one immutable winner during concurrent repair", async () => {
+			const directory = await createTemporaryDirectory();
+			const { cacheDirectory, cacheRoot } = configureCache({ directory });
+			await writePublishedCache({ cacheDirectory });
+			await writeFile(
+				path.join(cacheDirectory, bundleName, "model.espresso.weights"),
+				Buffer.from("truncated")
+			);
+			const modelPath = await createPackedModel({ directory });
+			const calls = Array.from({ length: 6 }, () =>
+				fixtureCache.prepare({
+					modelPath,
+					modelSha256: fixtureManifest.packedModelSha256,
+				})
+			);
 
-      const winner = await Promise.race(calls);
-      const winnerDirectory = path.dirname(winner);
-      const winnerStat = await stat(winnerDirectory);
-      const weightsHandle = await open(
-        path.join(winner, "model.espresso.weights"),
-        "r",
-      );
-      try {
-        const results = await Promise.all(calls);
-        expect(new Set(results)).toEqual(new Set([winner]));
-        expect((await stat(winnerDirectory)).ino).toBe(winnerStat.ino);
-        const probe = Buffer.alloc(8);
-        await weightsHandle.read(probe, 0, probe.length, 0);
-        expect(probe).toEqual(
-          fixtureFiles.get("model.espresso.weights")?.subarray(0, probe.length),
-        );
-      } finally {
-        await weightsHandle.close();
-      }
-      expect((await readdir(cacheRoot)).sort()).toEqual([
-        fixtureManifest.packedModelSha256,
-      ]);
-    });
+			const winner = await Promise.race(calls);
+			const winnerDirectory = path.dirname(winner);
+			const winnerStat = await stat(winnerDirectory);
+			const weightsHandle = await open(
+				path.join(winner, "model.espresso.weights"),
+				"r"
+			);
+			try {
+				const results = await Promise.all(calls);
+				expect(new Set(results)).toEqual(new Set([winner]));
+				expect((await stat(winnerDirectory)).ino).toBe(winnerStat.ino);
+				const probe = Buffer.alloc(8);
+				await weightsHandle.read(probe, 0, probe.length, 0);
+				expect(probe).toEqual(
+					fixtureFiles.get("model.espresso.weights")?.subarray(0, probe.length)
+				);
+			} finally {
+				await weightsHandle.close();
+			}
+			expect((await readdir(cacheRoot)).sort()).toEqual([
+				fixtureManifest.packedModelSha256,
+			]);
+		});
 
-    it("never steals an old lock owned by a live process", async () => {
-      const directory = await createTemporaryDirectory();
-      const { cacheRoot } = configureCache({ directory });
-      const lockPath = path.join(
-        cacheRoot,
-        `${fixtureManifest.packedModelSha256}.publish-lock`,
-      );
-      await mkdir(lockPath, { recursive: true });
-      await writeFile(
-        path.join(lockPath, ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME),
-        JSON.stringify({ createdAt: 0, pid: process.pid }),
-        "utf8",
-      );
-      const shortWaitCache = createVideoObjectCoreMLCache({
-        expectedManifest: fixtureManifest,
-        lockTiming: { retryMs: 1, waitMs: 5 },
-      });
+		it("never steals an old lock owned by a live process", async () => {
+			const directory = await createTemporaryDirectory();
+			const { cacheRoot } = configureCache({ directory });
+			const lockPath = path.join(
+				cacheRoot,
+				`${fixtureManifest.packedModelSha256}.publish-lock`
+			);
+			await mkdir(lockPath, { recursive: true });
+			await writeFile(
+				path.join(lockPath, ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME),
+				JSON.stringify({ createdAt: 0, pid: process.pid }),
+				"utf8"
+			);
+			const shortWaitCache = createVideoObjectCoreMLCache({
+				expectedManifest: fixtureManifest,
+				lockTiming: { retryMs: 1, waitMs: 5 },
+			});
 
-      await expect(
-        shortWaitCache.prepare({
-          modelPath: path.join(directory, "not-read.model"),
-          modelSha256: fixtureManifest.packedModelSha256,
-        }),
-      ).rejects.toThrow("Timed out waiting for cache publication lock");
-      expect((await stat(lockPath)).isDirectory()).toBe(true);
-    });
-  },
+			await expect(
+				shortWaitCache.prepare({
+					modelPath: path.join(directory, "not-read.model"),
+					modelSha256: fixtureManifest.packedModelSha256,
+				})
+			).rejects.toThrow("Timed out waiting for cache publication lock");
+			expect((await stat(lockPath)).isDirectory()).toBe(true);
+		});
+	}
 );

--- a/qcut/electron/__tests__/person-cutout-video-object-provider-fallback.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-provider-fallback.test.ts
@@ -2,213 +2,216 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
-  firstMatchingDirectory: vi.fn(),
-  firstMatchingFile: vi.fn(),
-  prepareVideoObjectCoreMLModel: vi.fn(),
-  resolveJianyingSaliencyBridge: vi.fn(),
-  resolveVideoObjectBachBridge: vi.fn(),
-  resolveVideoObjectCoreMLBridge: vi.fn(),
-  sha256File: vi.fn(),
-  verifyVideoObjectBachDependencyClosure: vi.fn(),
+	firstMatchingDirectory: vi.fn(),
+	firstMatchingFile: vi.fn(),
+	prepareVideoObjectCoreMLModel: vi.fn(),
+	resolveJianyingSaliencyBridge: vi.fn(),
+	resolveVideoObjectBachBridge: vi.fn(),
+	resolveVideoObjectCoreMLBridge: vi.fn(),
+	sha256File: vi.fn(),
+	verifyVideoObjectBachDependencyClosure: vi.fn(),
 }));
 
 vi.mock("../jianying-person-cutout/runtime-assets.js", () => ({
-  firstMatchingDirectory: runtimeMocks.firstMatchingDirectory,
-  firstMatchingFile: runtimeMocks.firstMatchingFile,
-  sha256File: runtimeMocks.sha256File,
-  VIDEO_FUSION_LIBRARY_SHA256: "video-fusion-library-sha256",
+	firstMatchingDirectory: runtimeMocks.firstMatchingDirectory,
+	firstMatchingFile: runtimeMocks.firstMatchingFile,
+	sha256File: runtimeMocks.sha256File,
+	VIDEO_FUSION_LIBRARY_SHA256: "video-fusion-library-sha256",
 }));
 vi.mock("../jianying-person-cutout/saliency-bridge-resolver.js", () => ({
-  resolveJianyingSaliencyBridge: runtimeMocks.resolveJianyingSaliencyBridge,
+	resolveJianyingSaliencyBridge: runtimeMocks.resolveJianyingSaliencyBridge,
 }));
 vi.mock(
-  "../jianying-person-cutout/video-object-bach-bridge-resolver.js",
-  () => ({
-    resolveVideoObjectBachBridge: runtimeMocks.resolveVideoObjectBachBridge,
-  }),
+	"../jianying-person-cutout/video-object-bach-bridge-resolver.js",
+	() => ({
+		resolveVideoObjectBachBridge: runtimeMocks.resolveVideoObjectBachBridge,
+	})
 );
 vi.mock(
-  "../jianying-person-cutout/video-object-coreml-bridge-resolver.js",
-  () => ({
-    resolveVideoObjectCoreMLBridge: runtimeMocks.resolveVideoObjectCoreMLBridge,
-  }),
+	"../jianying-person-cutout/video-object-coreml-bridge-resolver.js",
+	() => ({
+		resolveVideoObjectCoreMLBridge: runtimeMocks.resolveVideoObjectCoreMLBridge,
+	})
 );
 vi.mock("../jianying-person-cutout/video-object-coreml-runtime.js", () => ({
-  prepareVideoObjectCoreMLModel: runtimeMocks.prepareVideoObjectCoreMLModel,
+	prepareVideoObjectCoreMLModel: runtimeMocks.prepareVideoObjectCoreMLModel,
 }));
 vi.mock(
-  "../jianying-person-cutout/video-object-runtime-closure.js",
-  async (importOriginal) => ({
-    ...(await importOriginal<
-      typeof import("../jianying-person-cutout/video-object-runtime-closure.js")
-    >()),
-    verifyVideoObjectBachDependencyClosure:
-      runtimeMocks.verifyVideoObjectBachDependencyClosure,
-  }),
+	"../jianying-person-cutout/video-object-runtime-closure.js",
+	async (importOriginal) => ({
+		...(await importOriginal<
+			typeof import("../jianying-person-cutout/video-object-runtime-closure.js")
+		>()),
+		verifyVideoObjectBachDependencyClosure:
+			runtimeMocks.verifyVideoObjectBachDependencyClosure,
+	})
 );
 
 import {
-  resolveJianyingVideoObjectRuntimeCandidate,
-  resolveJianyingVideoObjectRuntimeCandidates,
-  VIDEO_OBJECT_BACH_RUNTIME_SHA256,
-  VIDEO_OBJECT_GRAPH_SHA256,
+	resolveJianyingVideoObjectRuntimeCandidate,
+	resolveJianyingVideoObjectRuntimeCandidates,
+	VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+	VIDEO_OBJECT_GRAPH_SHA256,
 } from "../jianying-person-cutout/video-object-runtime.js";
 
 beforeEach(() => {
-  runtimeMocks.firstMatchingDirectory.mockResolvedValue("/private/models");
-  runtimeMocks.firstMatchingFile.mockResolvedValue("/private/runtime-asset");
-  runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(null);
-  runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(null);
-  runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(null);
-  runtimeMocks.sha256File.mockResolvedValue("bridge-sha256");
-  runtimeMocks.verifyVideoObjectBachDependencyClosure.mockResolvedValue({
-    dependencyClosureMarker:
-      "jianying-runtime-framework-closure-d634-v1-e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e",
-    dependencyClosureSha256:
-      "e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e",
-  });
+	runtimeMocks.firstMatchingDirectory.mockResolvedValue("/private/models");
+	runtimeMocks.firstMatchingFile.mockResolvedValue("/private/runtime-asset");
+	runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(null);
+	runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(null);
+	runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(null);
+	runtimeMocks.sha256File.mockResolvedValue("bridge-sha256");
+	runtimeMocks.verifyVideoObjectBachDependencyClosure.mockResolvedValue({
+		dependencyClosureMarker:
+			"jianying-runtime-framework-closure-d634-v1-e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e",
+		dependencyClosureSha256:
+			"e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e",
+	});
 });
 
 afterEach(() => {
-  vi.restoreAllMocks();
+	vi.restoreAllMocks();
 });
 
 describe("optional video-object provider resolution", () => {
-  it("orders audited Bach, direct CoreML, and legacy host candidates", async () => {
-    runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
-      "/private/bach-bridge",
-    );
-    runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
-      "/private/coreml-bridge",
-    );
-    runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
-      "/private/model.mlmodelc",
-    );
-    runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(
-      "/private/host-bridge",
-    );
+	it("orders audited Bach, direct CoreML, and legacy host candidates", async () => {
+		runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
+			"/private/bach-bridge"
+		);
+		runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
+			"/private/coreml-bridge"
+		);
+		runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
+			"/private/model.mlmodelc"
+		);
+		runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(
+			"/private/host-bridge"
+		);
 
-    const candidates = await resolveJianyingVideoObjectRuntimeCandidates({
-      height: 1080,
-      width: 1920,
-    });
+		const candidates = await resolveJianyingVideoObjectRuntimeCandidates({
+			height: 1080,
+			width: 1920,
+		});
 
-    expect(candidates.map(({ executionBackend }) => executionBackend)).toEqual([
-      "jianying-bach-v2-exact-d634-v1",
-      "same-model-coreml-v1",
-      "effect-host-interop-v1",
-    ]);
-    expect(candidates[0]).toMatchObject({
-      graphDirectory: "/private",
-      libraryPath: "/private/runtime-asset",
-      readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
-    });
-    expect(runtimeMocks.firstMatchingDirectory).toHaveBeenCalledWith(
-      expect.objectContaining({
-        candidates: expect.arrayContaining([
-          expect.stringContaining(
-            "JianyingTransition/current/Models/user-cache",
-          ),
-        ]),
-      }),
-    );
-    expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
-      expect.objectContaining({ sha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256 }),
-    );
-    expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        candidates: expect.arrayContaining([
-          expect.stringContaining(
-            "JianyingTransition/current/Models/app-bundle/matting_config/ai_matting_video_object/algorithmConfig.json",
-          ),
-        ]),
-        sha256: VIDEO_OBJECT_GRAPH_SHA256,
-      }),
-    );
-  });
+		expect(candidates.map(({ executionBackend }) => executionBackend)).toEqual([
+			"jianying-bach-v2-exact-d634-v1",
+			"same-model-coreml-v1",
+			"effect-host-interop-v1",
+		]);
+		expect(candidates[0]).toMatchObject({
+			graphDirectory: "/private",
+			libraryPath: "/private/runtime-asset",
+			readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
+		});
+		expect(runtimeMocks.firstMatchingDirectory).toHaveBeenCalledWith(
+			expect.objectContaining({
+				candidates: expect.arrayContaining([
+					expect.stringContaining(
+						"JianyingTransition/current/Models/user-cache"
+					),
+				]),
+			})
+		);
+		expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
+			expect.objectContaining({ sha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256 })
+		);
+		expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
+			expect.objectContaining({
+				candidates: expect.arrayContaining([
+					expect.stringContaining(
+						"JianyingTransition/current/Models/app-bundle/matting_config/ai_matting_video_object/algorithmConfig.json"
+					),
+				]),
+				sha256: VIDEO_OBJECT_GRAPH_SHA256,
+			})
+		);
+	});
 
-  it("continues to direct CoreML when the Bach resolver rejects", async () => {
-    runtimeMocks.resolveVideoObjectBachBridge.mockRejectedValue(
-      new Error("Bach compiler failed"),
-    );
-    runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
-      "/private/coreml-bridge",
-    );
-    runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
-      "/private/model.mlmodelc",
-    );
-    const warning = vi
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
+	it("continues to direct CoreML when the Bach resolver rejects", async () => {
+		runtimeMocks.resolveVideoObjectBachBridge.mockRejectedValue(
+			new Error("Bach compiler failed")
+		);
+		runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
+			"/private/coreml-bridge"
+		);
+		runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
+			"/private/model.mlmodelc"
+		);
+		const warning = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => undefined);
 
-    await expect(
-      resolveJianyingVideoObjectRuntimeCandidate({
-        height: 1080,
-        width: 1920,
-      }),
-    ).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
-    expect(warning).toHaveBeenCalledWith(
-      "QCut could not prepare the audited Jianying Bach runtime.",
-      expect.any(Error),
-    );
-  });
+		await expect(
+			resolveJianyingVideoObjectRuntimeCandidate({
+				height: 1080,
+				width: 1920,
+			})
+		).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
+		expect(warning).toHaveBeenCalledWith(
+			"QCut could not prepare the audited Jianying Bach runtime.",
+			expect.any(Error)
+		);
+	});
 
-  it("continues to direct CoreML when the dependency manifest is stale", async () => {
-    runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
-      "/private/bach-bridge",
-    );
-    runtimeMocks.verifyVideoObjectBachDependencyClosure.mockRejectedValue(
-      new Error("stale dependency manifest"),
-    );
-    runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
-      "/private/coreml-bridge",
-    );
-    runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
-      "/private/model.mlmodelc",
-    );
+	it("continues to direct CoreML when the dependency manifest is stale", async () => {
+		runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
+			"/private/bach-bridge"
+		);
+		runtimeMocks.verifyVideoObjectBachDependencyClosure.mockRejectedValue(
+			new Error("stale dependency manifest")
+		);
+		runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
+			"/private/coreml-bridge"
+		);
+		runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
+			"/private/model.mlmodelc"
+		);
 
-    await expect(
-      resolveJianyingVideoObjectRuntimeCandidate({
-        height: 1080,
-        width: 1920,
-      }),
-    ).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
-  });
+		await expect(
+			resolveJianyingVideoObjectRuntimeCandidate({
+				height: 1080,
+				width: 1920,
+			})
+		).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
+	});
 
-  it("continues to host interop when the direct resolver rejects", async () => {
-    runtimeMocks.resolveVideoObjectCoreMLBridge.mockRejectedValue(
-      new Error("clang failed"),
-    );
-    const warning = vi
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
+	it("continues to host interop when the direct resolver rejects", async () => {
+		runtimeMocks.resolveVideoObjectCoreMLBridge.mockRejectedValue(
+			new Error("clang failed")
+		);
+		runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(
+			"/private/host-bridge"
+		);
+		const warning = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => undefined);
 
-    await expect(
-      resolveJianyingVideoObjectRuntimeCandidate({ height: 1080, width: 1920 }),
-    ).resolves.toBeNull();
+		await expect(
+			resolveJianyingVideoObjectRuntimeCandidate({ height: 1080, width: 1920 })
+		).resolves.toMatchObject({ executionBackend: "effect-host-interop-v1" });
 
-    expect(runtimeMocks.resolveJianyingSaliencyBridge).toHaveBeenCalledOnce();
-    expect(warning).toHaveBeenCalledWith(
-      "QCut could not prepare the same-model CoreML video-object runtime.",
-      expect.any(Error),
-    );
-  });
+		expect(runtimeMocks.resolveJianyingSaliencyBridge).toHaveBeenCalledOnce();
+		expect(warning).toHaveBeenCalledWith(
+			"QCut could not prepare the same-model CoreML video-object runtime.",
+			expect.any(Error)
+		);
+	});
 
-  it("returns null when the host resolver rejects", async () => {
-    runtimeMocks.resolveJianyingSaliencyBridge.mockRejectedValue(
-      new Error("host bridge unavailable"),
-    );
-    const warning = vi
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
+	it("returns null when the host resolver rejects", async () => {
+		runtimeMocks.resolveJianyingSaliencyBridge.mockRejectedValue(
+			new Error("host bridge unavailable")
+		);
+		const warning = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => undefined);
 
-    await expect(
-      resolveJianyingVideoObjectRuntimeCandidate({ height: 1080, width: 1920 }),
-    ).resolves.toBeNull();
+		await expect(
+			resolveJianyingVideoObjectRuntimeCandidate({ height: 1080, width: 1920 })
+		).resolves.toBeNull();
 
-    expect(warning).toHaveBeenCalledWith(
-      "QCut could not prepare the host video-object runtime.",
-      expect.any(Error),
-    );
-  });
+		expect(warning).toHaveBeenCalledWith(
+			"QCut could not prepare the host video-object runtime.",
+			expect.any(Error)
+		);
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-video-object-provider-fallback.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-provider-fallback.test.ts
@@ -73,145 +73,156 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-describe("optional video-object provider resolution", () => {
-	it("orders audited Bach, direct CoreML, and legacy host candidates", async () => {
-		runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
-			"/private/bach-bridge"
-		);
-		runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
-			"/private/coreml-bridge"
-		);
-		runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
-			"/private/model.mlmodelc"
-		);
-		runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(
-			"/private/host-bridge"
-		);
+describe.runIf(process.platform === "darwin")(
+	"optional video-object provider resolution",
+	() => {
+		it("orders audited Bach, direct CoreML, and legacy host candidates", async () => {
+			runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
+				"/private/bach-bridge"
+			);
+			runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
+				"/private/coreml-bridge"
+			);
+			runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
+				"/private/model.mlmodelc"
+			);
+			runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(
+				"/private/host-bridge"
+			);
 
-		const candidates = await resolveJianyingVideoObjectRuntimeCandidates({
-			height: 1080,
-			width: 1920,
-		});
-
-		expect(candidates.map(({ executionBackend }) => executionBackend)).toEqual([
-			"jianying-bach-v2-exact-d634-v1",
-			"same-model-coreml-v1",
-			"effect-host-interop-v1",
-		]);
-		expect(candidates[0]).toMatchObject({
-			graphDirectory: "/private",
-			libraryPath: "/private/runtime-asset",
-			readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
-		});
-		expect(runtimeMocks.firstMatchingDirectory).toHaveBeenCalledWith(
-			expect.objectContaining({
-				candidates: expect.arrayContaining([
-					expect.stringContaining(
-						"JianyingTransition/current/Models/user-cache"
-					),
-				]),
-			})
-		);
-		expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
-			expect.objectContaining({ sha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256 })
-		);
-		expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
-			expect.objectContaining({
-				candidates: expect.arrayContaining([
-					expect.stringContaining(
-						"JianyingTransition/current/Models/app-bundle/matting_config/ai_matting_video_object/algorithmConfig.json"
-					),
-				]),
-				sha256: VIDEO_OBJECT_GRAPH_SHA256,
-			})
-		);
-	});
-
-	it("continues to direct CoreML when the Bach resolver rejects", async () => {
-		runtimeMocks.resolveVideoObjectBachBridge.mockRejectedValue(
-			new Error("Bach compiler failed")
-		);
-		runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
-			"/private/coreml-bridge"
-		);
-		runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
-			"/private/model.mlmodelc"
-		);
-		const warning = vi
-			.spyOn(console, "warn")
-			.mockImplementation(() => undefined);
-
-		await expect(
-			resolveJianyingVideoObjectRuntimeCandidate({
+			const candidates = await resolveJianyingVideoObjectRuntimeCandidates({
 				height: 1080,
 				width: 1920,
-			})
-		).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
-		expect(warning).toHaveBeenCalledWith(
-			"QCut could not prepare the audited Jianying Bach runtime.",
-			expect.any(Error)
-		);
-	});
+			});
 
-	it("continues to direct CoreML when the dependency manifest is stale", async () => {
-		runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
-			"/private/bach-bridge"
-		);
-		runtimeMocks.verifyVideoObjectBachDependencyClosure.mockRejectedValue(
-			new Error("stale dependency manifest")
-		);
-		runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
-			"/private/coreml-bridge"
-		);
-		runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
-			"/private/model.mlmodelc"
-		);
+			expect(
+				candidates.map(({ executionBackend }) => executionBackend)
+			).toEqual([
+				"jianying-bach-v2-exact-d634-v1",
+				"same-model-coreml-v1",
+				"effect-host-interop-v1",
+			]);
+			expect(candidates[0]).toMatchObject({
+				graphDirectory: "/private",
+				libraryPath: "/private/runtime-asset",
+				readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
+			});
+			expect(runtimeMocks.firstMatchingDirectory).toHaveBeenCalledWith(
+				expect.objectContaining({
+					candidates: expect.arrayContaining([
+						expect.stringContaining(
+							"JianyingTransition/current/Models/user-cache"
+						),
+					]),
+				})
+			);
+			expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
+				expect.objectContaining({ sha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256 })
+			);
+			expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
+				expect.objectContaining({
+					candidates: expect.arrayContaining([
+						expect.stringContaining(
+							"JianyingTransition/current/Models/app-bundle/matting_config/ai_matting_video_object/algorithmConfig.json"
+						),
+					]),
+					sha256: VIDEO_OBJECT_GRAPH_SHA256,
+				})
+			);
+		});
 
-		await expect(
-			resolveJianyingVideoObjectRuntimeCandidate({
-				height: 1080,
-				width: 1920,
-			})
-		).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
-	});
+		it("continues to direct CoreML when the Bach resolver rejects", async () => {
+			runtimeMocks.resolveVideoObjectBachBridge.mockRejectedValue(
+				new Error("Bach compiler failed")
+			);
+			runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
+				"/private/coreml-bridge"
+			);
+			runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
+				"/private/model.mlmodelc"
+			);
+			const warning = vi
+				.spyOn(console, "warn")
+				.mockImplementation(() => undefined);
 
-	it("continues to host interop when the direct resolver rejects", async () => {
-		runtimeMocks.resolveVideoObjectCoreMLBridge.mockRejectedValue(
-			new Error("clang failed")
-		);
-		runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(
-			"/private/host-bridge"
-		);
-		const warning = vi
-			.spyOn(console, "warn")
-			.mockImplementation(() => undefined);
+			await expect(
+				resolveJianyingVideoObjectRuntimeCandidate({
+					height: 1080,
+					width: 1920,
+				})
+			).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
+			expect(warning).toHaveBeenCalledWith(
+				"QCut could not prepare the audited Jianying Bach runtime.",
+				expect.any(Error)
+			);
+		});
 
-		await expect(
-			resolveJianyingVideoObjectRuntimeCandidate({ height: 1080, width: 1920 })
-		).resolves.toMatchObject({ executionBackend: "effect-host-interop-v1" });
+		it("continues to direct CoreML when the dependency manifest is stale", async () => {
+			runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
+				"/private/bach-bridge"
+			);
+			runtimeMocks.verifyVideoObjectBachDependencyClosure.mockRejectedValue(
+				new Error("stale dependency manifest")
+			);
+			runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
+				"/private/coreml-bridge"
+			);
+			runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
+				"/private/model.mlmodelc"
+			);
 
-		expect(runtimeMocks.resolveJianyingSaliencyBridge).toHaveBeenCalledOnce();
-		expect(warning).toHaveBeenCalledWith(
-			"QCut could not prepare the same-model CoreML video-object runtime.",
-			expect.any(Error)
-		);
-	});
+			await expect(
+				resolveJianyingVideoObjectRuntimeCandidate({
+					height: 1080,
+					width: 1920,
+				})
+			).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
+		});
 
-	it("returns null when the host resolver rejects", async () => {
-		runtimeMocks.resolveJianyingSaliencyBridge.mockRejectedValue(
-			new Error("host bridge unavailable")
-		);
-		const warning = vi
-			.spyOn(console, "warn")
-			.mockImplementation(() => undefined);
+		it("continues to host interop when the direct resolver rejects", async () => {
+			runtimeMocks.resolveVideoObjectCoreMLBridge.mockRejectedValue(
+				new Error("clang failed")
+			);
+			runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(
+				"/private/host-bridge"
+			);
+			const warning = vi
+				.spyOn(console, "warn")
+				.mockImplementation(() => undefined);
 
-		await expect(
-			resolveJianyingVideoObjectRuntimeCandidate({ height: 1080, width: 1920 })
-		).resolves.toBeNull();
+			await expect(
+				resolveJianyingVideoObjectRuntimeCandidate({
+					height: 1080,
+					width: 1920,
+				})
+			).resolves.toMatchObject({ executionBackend: "effect-host-interop-v1" });
 
-		expect(warning).toHaveBeenCalledWith(
-			"QCut could not prepare the host video-object runtime.",
-			expect.any(Error)
-		);
-	});
-});
+			expect(runtimeMocks.resolveJianyingSaliencyBridge).toHaveBeenCalledOnce();
+			expect(warning).toHaveBeenCalledWith(
+				"QCut could not prepare the same-model CoreML video-object runtime.",
+				expect.any(Error)
+			);
+		});
+
+		it("returns null when the host resolver rejects", async () => {
+			runtimeMocks.resolveJianyingSaliencyBridge.mockRejectedValue(
+				new Error("host bridge unavailable")
+			);
+			const warning = vi
+				.spyOn(console, "warn")
+				.mockImplementation(() => undefined);
+
+			await expect(
+				resolveJianyingVideoObjectRuntimeCandidate({
+					height: 1080,
+					width: 1920,
+				})
+			).resolves.toBeNull();
+
+			expect(warning).toHaveBeenCalledWith(
+				"QCut could not prepare the host video-object runtime.",
+				expect.any(Error)
+			);
+		});
+	}
+);

--- a/qcut/electron/__tests__/person-cutout-video-object-provider-fallback.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-provider-fallback.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeMocks = vi.hoisted(() => ({
+  firstMatchingDirectory: vi.fn(),
+  firstMatchingFile: vi.fn(),
+  prepareVideoObjectCoreMLModel: vi.fn(),
+  resolveJianyingSaliencyBridge: vi.fn(),
+  resolveVideoObjectBachBridge: vi.fn(),
+  resolveVideoObjectCoreMLBridge: vi.fn(),
+  sha256File: vi.fn(),
+  verifyVideoObjectBachDependencyClosure: vi.fn(),
+}));
+
+vi.mock("../jianying-person-cutout/runtime-assets.js", () => ({
+  firstMatchingDirectory: runtimeMocks.firstMatchingDirectory,
+  firstMatchingFile: runtimeMocks.firstMatchingFile,
+  sha256File: runtimeMocks.sha256File,
+  VIDEO_FUSION_LIBRARY_SHA256: "video-fusion-library-sha256",
+}));
+vi.mock("../jianying-person-cutout/saliency-bridge-resolver.js", () => ({
+  resolveJianyingSaliencyBridge: runtimeMocks.resolveJianyingSaliencyBridge,
+}));
+vi.mock(
+  "../jianying-person-cutout/video-object-bach-bridge-resolver.js",
+  () => ({
+    resolveVideoObjectBachBridge: runtimeMocks.resolveVideoObjectBachBridge,
+  }),
+);
+vi.mock(
+  "../jianying-person-cutout/video-object-coreml-bridge-resolver.js",
+  () => ({
+    resolveVideoObjectCoreMLBridge: runtimeMocks.resolveVideoObjectCoreMLBridge,
+  }),
+);
+vi.mock("../jianying-person-cutout/video-object-coreml-runtime.js", () => ({
+  prepareVideoObjectCoreMLModel: runtimeMocks.prepareVideoObjectCoreMLModel,
+}));
+vi.mock(
+  "../jianying-person-cutout/video-object-runtime-closure.js",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("../jianying-person-cutout/video-object-runtime-closure.js")
+    >()),
+    verifyVideoObjectBachDependencyClosure:
+      runtimeMocks.verifyVideoObjectBachDependencyClosure,
+  }),
+);
+
+import {
+  resolveJianyingVideoObjectRuntimeCandidate,
+  resolveJianyingVideoObjectRuntimeCandidates,
+  VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+  VIDEO_OBJECT_GRAPH_SHA256,
+} from "../jianying-person-cutout/video-object-runtime.js";
+
+beforeEach(() => {
+  runtimeMocks.firstMatchingDirectory.mockResolvedValue("/private/models");
+  runtimeMocks.firstMatchingFile.mockResolvedValue("/private/runtime-asset");
+  runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(null);
+  runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(null);
+  runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(null);
+  runtimeMocks.sha256File.mockResolvedValue("bridge-sha256");
+  runtimeMocks.verifyVideoObjectBachDependencyClosure.mockResolvedValue({
+    dependencyClosureMarker:
+      "jianying-runtime-framework-closure-d634-v1-e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e",
+    dependencyClosureSha256:
+      "e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e",
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("optional video-object provider resolution", () => {
+  it("orders audited Bach, direct CoreML, and legacy host candidates", async () => {
+    runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
+      "/private/bach-bridge",
+    );
+    runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
+      "/private/coreml-bridge",
+    );
+    runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
+      "/private/model.mlmodelc",
+    );
+    runtimeMocks.resolveJianyingSaliencyBridge.mockResolvedValue(
+      "/private/host-bridge",
+    );
+
+    const candidates = await resolveJianyingVideoObjectRuntimeCandidates({
+      height: 1080,
+      width: 1920,
+    });
+
+    expect(candidates.map(({ executionBackend }) => executionBackend)).toEqual([
+      "jianying-bach-v2-exact-d634-v1",
+      "same-model-coreml-v1",
+      "effect-host-interop-v1",
+    ]);
+    expect(candidates[0]).toMatchObject({
+      graphDirectory: "/private",
+      libraryPath: "/private/runtime-asset",
+      readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
+    });
+    expect(runtimeMocks.firstMatchingDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidates: expect.arrayContaining([
+          expect.stringContaining(
+            "JianyingTransition/current/Models/user-cache",
+          ),
+        ]),
+      }),
+    );
+    expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
+      expect.objectContaining({ sha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256 }),
+    );
+    expect(runtimeMocks.firstMatchingFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidates: expect.arrayContaining([
+          expect.stringContaining(
+            "JianyingTransition/current/Models/app-bundle/matting_config/ai_matting_video_object/algorithmConfig.json",
+          ),
+        ]),
+        sha256: VIDEO_OBJECT_GRAPH_SHA256,
+      }),
+    );
+  });
+
+  it("continues to direct CoreML when the Bach resolver rejects", async () => {
+    runtimeMocks.resolveVideoObjectBachBridge.mockRejectedValue(
+      new Error("Bach compiler failed"),
+    );
+    runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
+      "/private/coreml-bridge",
+    );
+    runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
+      "/private/model.mlmodelc",
+    );
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      resolveJianyingVideoObjectRuntimeCandidate({
+        height: 1080,
+        width: 1920,
+      }),
+    ).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
+    expect(warning).toHaveBeenCalledWith(
+      "QCut could not prepare the audited Jianying Bach runtime.",
+      expect.any(Error),
+    );
+  });
+
+  it("continues to direct CoreML when the dependency manifest is stale", async () => {
+    runtimeMocks.resolveVideoObjectBachBridge.mockResolvedValue(
+      "/private/bach-bridge",
+    );
+    runtimeMocks.verifyVideoObjectBachDependencyClosure.mockRejectedValue(
+      new Error("stale dependency manifest"),
+    );
+    runtimeMocks.resolveVideoObjectCoreMLBridge.mockResolvedValue(
+      "/private/coreml-bridge",
+    );
+    runtimeMocks.prepareVideoObjectCoreMLModel.mockResolvedValue(
+      "/private/model.mlmodelc",
+    );
+
+    await expect(
+      resolveJianyingVideoObjectRuntimeCandidate({
+        height: 1080,
+        width: 1920,
+      }),
+    ).resolves.toMatchObject({ executionBackend: "same-model-coreml-v1" });
+  });
+
+  it("continues to host interop when the direct resolver rejects", async () => {
+    runtimeMocks.resolveVideoObjectCoreMLBridge.mockRejectedValue(
+      new Error("clang failed"),
+    );
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      resolveJianyingVideoObjectRuntimeCandidate({ height: 1080, width: 1920 }),
+    ).resolves.toBeNull();
+
+    expect(runtimeMocks.resolveJianyingSaliencyBridge).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith(
+      "QCut could not prepare the same-model CoreML video-object runtime.",
+      expect.any(Error),
+    );
+  });
+
+  it("returns null when the host resolver rejects", async () => {
+    runtimeMocks.resolveJianyingSaliencyBridge.mockRejectedValue(
+      new Error("host bridge unavailable"),
+    );
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      resolveJianyingVideoObjectRuntimeCandidate({ height: 1080, width: 1920 }),
+    ).resolves.toBeNull();
+
+    expect(warning).toHaveBeenCalledWith(
+      "QCut could not prepare the host video-object runtime.",
+      expect.any(Error),
+    );
+  });
+});

--- a/qcut/electron/__tests__/person-cutout-video-object-runtime-closure.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-runtime-closure.test.ts
@@ -4,146 +4,146 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  verifyVideoObjectBachDependencyClosure,
-  VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
-  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+	verifyVideoObjectBachDependencyClosure,
+	VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
+	VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+	VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
 } from "../jianying-person-cutout/video-object-runtime-closure.js";
 
 const CORE_UUID = "D6342ECD-5432-33F0-A2AD-0C28F5699994";
 const RUNTIME_SHA256 =
-  "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9";
+	"0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9";
 const temporaryDirectories: string[] = [];
 
 async function createRuntimeManifest({
-  coreUuid = CORE_UUID,
-  dependencyShaOverride,
-  omittedDependency,
+	coreUuid = CORE_UUID,
+	dependencyShaOverride,
+	omittedDependency,
 }: {
-  coreUuid?: string;
-  dependencyShaOverride?: { fileName: string; sha256: string };
-  omittedDependency?: string;
+	coreUuid?: string;
+	dependencyShaOverride?: { fileName: string; sha256: string };
+	omittedDependency?: string;
 } = {}) {
-  const runtimeRoot = await mkdtemp(
-    path.join(tmpdir(), "qcut-bach-runtime-closure-"),
-  );
-  temporaryDirectories.push(runtimeRoot);
-  const files = VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.filter(
-    ([dependencyPath]) => path.basename(dependencyPath) !== omittedDependency,
-  ).map(([dependencyPath, sha256]) => {
-    const fileName = path.basename(dependencyPath);
-    return {
-      bytes: fileName.length,
-      path: dependencyPath,
-      sha256:
-        dependencyShaOverride?.fileName === fileName
-          ? dependencyShaOverride.sha256
-          : sha256,
-    };
-  });
-  await writeFile(
-    path.join(runtimeRoot, "qcut-effect-runtime.json"),
-    JSON.stringify({
-      cloudUpload: false,
-      coreUuid,
-      files,
-      localOnly: true,
-      schemaVersion: 1,
-    }),
-  );
-  return { files, runtimeRoot };
+	const runtimeRoot = await mkdtemp(
+		path.join(tmpdir(), "qcut-bach-runtime-closure-")
+	);
+	temporaryDirectories.push(runtimeRoot);
+	const files = VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.filter(
+		([dependencyPath]) => path.basename(dependencyPath) !== omittedDependency
+	).map(([dependencyPath, sha256]) => {
+		const fileName = path.basename(dependencyPath);
+		return {
+			bytes: fileName.length,
+			path: dependencyPath,
+			sha256:
+				dependencyShaOverride?.fileName === fileName
+					? dependencyShaOverride.sha256
+					: sha256,
+		};
+	});
+	await writeFile(
+		path.join(runtimeRoot, "qcut-effect-runtime.json"),
+		JSON.stringify({
+			cloudUpload: false,
+			coreUuid,
+			files,
+			localOnly: true,
+			schemaVersion: 1,
+		})
+	);
+	return { files, runtimeRoot };
 }
 
 afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { force: true, recursive: true })),
-  );
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { force: true, recursive: true }))
+	);
 });
 
 describe("audited Bach dependency closure", () => {
-  it("returns the stable native closure identity after verifying every file", async () => {
-    const fixture = await createRuntimeManifest();
-    const manifestByName = new Map(
-      fixture.files.map((file) => [path.basename(file.path), file]),
-    );
-    await expect(
-      verifyVideoObjectBachDependencyClosure({
-        expectedCoreUuid: CORE_UUID,
-        expectedRuntimeSha256: RUNTIME_SHA256,
-        inspect: async ({ filePath }) => {
-          const file = manifestByName.get(path.basename(filePath));
-          return { bytes: file?.bytes ?? -1, sha256: file?.sha256 ?? null };
-        },
-        runtimeRoot: fixture.runtimeRoot,
-      }),
-    ).resolves.toEqual({
-      dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-      dependencyClosureSha256: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
-    });
-  });
+	it("returns the stable native closure identity after verifying every file", async () => {
+		const fixture = await createRuntimeManifest();
+		const manifestByName = new Map(
+			fixture.files.map((file) => [path.basename(file.path), file])
+		);
+		await expect(
+			verifyVideoObjectBachDependencyClosure({
+				expectedCoreUuid: CORE_UUID,
+				expectedRuntimeSha256: RUNTIME_SHA256,
+				inspect: async ({ filePath }) => {
+					const file = manifestByName.get(path.basename(filePath));
+					return { bytes: file?.bytes ?? -1, sha256: file?.sha256 ?? null };
+				},
+				runtimeRoot: fixture.runtimeRoot,
+			})
+		).resolves.toEqual({
+			dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+			dependencyClosureSha256: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+		});
+	});
 
-  it("rejects a stale runtime UUID", async () => {
-    const fixture = await createRuntimeManifest({
-      coreUuid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
-    });
-    await expect(
-      verifyVideoObjectBachDependencyClosure({
-        expectedCoreUuid: CORE_UUID,
-        expectedRuntimeSha256: RUNTIME_SHA256,
-        runtimeRoot: fixture.runtimeRoot,
-      }),
-    ).rejects.toThrow("audited UUID");
-  });
+	it("rejects a stale runtime UUID", async () => {
+		const fixture = await createRuntimeManifest({
+			coreUuid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+		});
+		await expect(
+			verifyVideoObjectBachDependencyClosure({
+				expectedCoreUuid: CORE_UUID,
+				expectedRuntimeSha256: RUNTIME_SHA256,
+				runtimeRoot: fixture.runtimeRoot,
+			})
+		).rejects.toThrow("audited UUID");
+	});
 
-  it("rejects a mixed dependency recorded by the manifest", async () => {
-    const fixture = await createRuntimeManifest({
-      dependencyShaOverride: {
-        fileName: "libAGFX.dylib",
-        sha256: "a".repeat(64),
-      },
-    });
-    await expect(
-      verifyVideoObjectBachDependencyClosure({
-        expectedCoreUuid: CORE_UUID,
-        expectedRuntimeSha256: RUNTIME_SHA256,
-        runtimeRoot: fixture.runtimeRoot,
-      }),
-    ).rejects.toThrow("mixed dependency");
-  });
+	it("rejects a mixed dependency recorded by the manifest", async () => {
+		const fixture = await createRuntimeManifest({
+			dependencyShaOverride: {
+				fileName: "libAGFX.dylib",
+				sha256: "a".repeat(64),
+			},
+		});
+		await expect(
+			verifyVideoObjectBachDependencyClosure({
+				expectedCoreUuid: CORE_UUID,
+				expectedRuntimeSha256: RUNTIME_SHA256,
+				runtimeRoot: fixture.runtimeRoot,
+			})
+		).rejects.toThrow("mixed dependency");
+	});
 
-  it("rejects a manifest missing any framework in the audited closure", async () => {
-    const fixture = await createRuntimeManifest({
-      omittedDependency: "libIESAppLogger.dylib",
-    });
-    await expect(
-      verifyVideoObjectBachDependencyClosure({
-        expectedCoreUuid: CORE_UUID,
-        expectedRuntimeSha256: RUNTIME_SHA256,
-        runtimeRoot: fixture.runtimeRoot,
-      }),
-    ).rejects.toThrow("inventory is incomplete");
-  });
+	it("rejects a manifest missing any framework in the audited closure", async () => {
+		const fixture = await createRuntimeManifest({
+			omittedDependency: "libIESAppLogger.dylib",
+		});
+		await expect(
+			verifyVideoObjectBachDependencyClosure({
+				expectedCoreUuid: CORE_UUID,
+				expectedRuntimeSha256: RUNTIME_SHA256,
+				runtimeRoot: fixture.runtimeRoot,
+			})
+		).rejects.toThrow("inventory is incomplete");
+	});
 
-  it("rejects an actual dependency tampered after the manifest was written", async () => {
-    const fixture = await createRuntimeManifest();
-    await expect(
-      verifyVideoObjectBachDependencyClosure({
-        expectedCoreUuid: CORE_UUID,
-        expectedRuntimeSha256: RUNTIME_SHA256,
-        inspect: async ({ filePath }) => ({
-          bytes: path.basename(filePath).length,
-          sha256:
-            path.basename(filePath) === "libfastcv.dylib"
-              ? "b".repeat(64)
-              : (VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.find(
-                  ([dependencyPath]) =>
-                    path.basename(dependencyPath) === path.basename(filePath),
-                )?.[1] ?? null),
-        }),
-        runtimeRoot: fixture.runtimeRoot,
-      }),
-    ).rejects.toThrow("checksum mismatch");
-  });
+	it("rejects an actual dependency tampered after the manifest was written", async () => {
+		const fixture = await createRuntimeManifest();
+		await expect(
+			verifyVideoObjectBachDependencyClosure({
+				expectedCoreUuid: CORE_UUID,
+				expectedRuntimeSha256: RUNTIME_SHA256,
+				inspect: async ({ filePath }) => ({
+					bytes: path.basename(filePath).length,
+					sha256:
+						path.basename(filePath) === "libfastcv.dylib"
+							? "b".repeat(64)
+							: (VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.find(
+									([dependencyPath]) =>
+										path.basename(dependencyPath) === path.basename(filePath)
+								)?.[1] ?? null),
+				}),
+				runtimeRoot: fixture.runtimeRoot,
+			})
+		).rejects.toThrow("checksum mismatch");
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-video-object-runtime-closure.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-runtime-closure.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment node
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  verifyVideoObjectBachDependencyClosure,
+  VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
+  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+} from "../jianying-person-cutout/video-object-runtime-closure.js";
+
+const CORE_UUID = "D6342ECD-5432-33F0-A2AD-0C28F5699994";
+const RUNTIME_SHA256 =
+  "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9";
+const temporaryDirectories: string[] = [];
+
+async function createRuntimeManifest({
+  coreUuid = CORE_UUID,
+  dependencyShaOverride,
+  omittedDependency,
+}: {
+  coreUuid?: string;
+  dependencyShaOverride?: { fileName: string; sha256: string };
+  omittedDependency?: string;
+} = {}) {
+  const runtimeRoot = await mkdtemp(
+    path.join(tmpdir(), "qcut-bach-runtime-closure-"),
+  );
+  temporaryDirectories.push(runtimeRoot);
+  const files = VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.filter(
+    ([dependencyPath]) => path.basename(dependencyPath) !== omittedDependency,
+  ).map(([dependencyPath, sha256]) => {
+    const fileName = path.basename(dependencyPath);
+    return {
+      bytes: fileName.length,
+      path: dependencyPath,
+      sha256:
+        dependencyShaOverride?.fileName === fileName
+          ? dependencyShaOverride.sha256
+          : sha256,
+    };
+  });
+  await writeFile(
+    path.join(runtimeRoot, "qcut-effect-runtime.json"),
+    JSON.stringify({
+      cloudUpload: false,
+      coreUuid,
+      files,
+      localOnly: true,
+      schemaVersion: 1,
+    }),
+  );
+  return { files, runtimeRoot };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("audited Bach dependency closure", () => {
+  it("returns the stable native closure identity after verifying every file", async () => {
+    const fixture = await createRuntimeManifest();
+    const manifestByName = new Map(
+      fixture.files.map((file) => [path.basename(file.path), file]),
+    );
+    await expect(
+      verifyVideoObjectBachDependencyClosure({
+        expectedCoreUuid: CORE_UUID,
+        expectedRuntimeSha256: RUNTIME_SHA256,
+        inspect: async ({ filePath }) => {
+          const file = manifestByName.get(path.basename(filePath));
+          return { bytes: file?.bytes ?? -1, sha256: file?.sha256 ?? null };
+        },
+        runtimeRoot: fixture.runtimeRoot,
+      }),
+    ).resolves.toEqual({
+      dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+      dependencyClosureSha256: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+    });
+  });
+
+  it("rejects a stale runtime UUID", async () => {
+    const fixture = await createRuntimeManifest({
+      coreUuid: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+    });
+    await expect(
+      verifyVideoObjectBachDependencyClosure({
+        expectedCoreUuid: CORE_UUID,
+        expectedRuntimeSha256: RUNTIME_SHA256,
+        runtimeRoot: fixture.runtimeRoot,
+      }),
+    ).rejects.toThrow("audited UUID");
+  });
+
+  it("rejects a mixed dependency recorded by the manifest", async () => {
+    const fixture = await createRuntimeManifest({
+      dependencyShaOverride: {
+        fileName: "libAGFX.dylib",
+        sha256: "a".repeat(64),
+      },
+    });
+    await expect(
+      verifyVideoObjectBachDependencyClosure({
+        expectedCoreUuid: CORE_UUID,
+        expectedRuntimeSha256: RUNTIME_SHA256,
+        runtimeRoot: fixture.runtimeRoot,
+      }),
+    ).rejects.toThrow("mixed dependency");
+  });
+
+  it("rejects a manifest missing any framework in the audited closure", async () => {
+    const fixture = await createRuntimeManifest({
+      omittedDependency: "libIESAppLogger.dylib",
+    });
+    await expect(
+      verifyVideoObjectBachDependencyClosure({
+        expectedCoreUuid: CORE_UUID,
+        expectedRuntimeSha256: RUNTIME_SHA256,
+        runtimeRoot: fixture.runtimeRoot,
+      }),
+    ).rejects.toThrow("inventory is incomplete");
+  });
+
+  it("rejects an actual dependency tampered after the manifest was written", async () => {
+    const fixture = await createRuntimeManifest();
+    await expect(
+      verifyVideoObjectBachDependencyClosure({
+        expectedCoreUuid: CORE_UUID,
+        expectedRuntimeSha256: RUNTIME_SHA256,
+        inspect: async ({ filePath }) => ({
+          bytes: path.basename(filePath).length,
+          sha256:
+            path.basename(filePath) === "libfastcv.dylib"
+              ? "b".repeat(64)
+              : (VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.find(
+                  ([dependencyPath]) =>
+                    path.basename(dependencyPath) === path.basename(filePath),
+                )?.[1] ?? null),
+        }),
+        runtimeRoot: fixture.runtimeRoot,
+      }),
+    ).rejects.toThrow("checksum mismatch");
+  });
+});

--- a/qcut/electron/__tests__/person-cutout-video-object-runtime.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-runtime.test.ts
@@ -1,32 +1,128 @@
 import { describe, expect, it } from "vitest";
-import { calculateVideoObjectGraphSize } from "../jianying-person-cutout/video-object-runtime.js";
+import {
+  calculateVideoObjectGraphSize,
+  createVideoObjectRuntimeFingerprints,
+  VIDEO_OBJECT_BACH_PROCESSOR_VERSION,
+  VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY,
+  VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+  VIDEO_OBJECT_BACH_RUNTIME_UUID,
+  VIDEO_OBJECT_COREML_PROCESSOR_VERSION,
+  VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
+  VIDEO_OBJECT_PROVIDER_CAPABILITY,
+} from "../jianying-person-cutout/video-object-runtime.js";
+import {
+  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+} from "../jianying-person-cutout/video-object-runtime-closure.js";
 
-describe("video-object graph sizing", () => {
-	it("matches Jianying's 512-pixel portrait and landscape graph inputs", () => {
-		expect(calculateVideoObjectGraphSize({ height: 640, width: 360 })).toEqual({
-			height: 512,
-			width: 288,
-		});
-		expect(
-			calculateVideoObjectGraphSize({ height: 1080, width: 1920 })
-		).toEqual({
-			height: 288,
-			width: 512,
-		});
-	});
+describe("legacy host video-object graph sizing", () => {
+  it("matches Jianying's 512-pixel portrait and landscape graph inputs", () => {
+    expect(calculateVideoObjectGraphSize({ height: 640, width: 360 })).toEqual({
+      height: 512,
+      width: 288,
+    });
+    expect(
+      calculateVideoObjectGraphSize({ height: 1080, width: 1920 }),
+    ).toEqual({
+      height: 288,
+      width: 512,
+    });
+  });
 
-	it("keeps odd aspect ratios on even texture dimensions", () => {
-		expect(calculateVideoObjectGraphSize({ height: 333, width: 1000 })).toEqual(
-			{
-				height: 170,
-				width: 512,
-			}
-		);
-	});
+  it("keeps odd aspect ratios on even texture dimensions", () => {
+    expect(calculateVideoObjectGraphSize({ height: 333, width: 1000 })).toEqual(
+      {
+        height: 170,
+        width: 512,
+      },
+    );
+  });
 
-	it("rejects invalid source dimensions", () => {
-		expect(() =>
-			calculateVideoObjectGraphSize({ height: 0, width: 1920 })
-		).toThrow("视频尺寸无效");
-	});
+  it("rejects invalid source dimensions", () => {
+    expect(() =>
+      calculateVideoObjectGraphSize({ height: 0, width: 1920 }),
+    ).toThrow("视频尺寸无效");
+  });
+
+  it("keeps capability failures stable across output resolutions", () => {
+    const portrait = createVideoObjectRuntimeFingerprints({
+      bridgeSha256: "bridge-a",
+      height: 1920,
+      width: 1080,
+    });
+    const landscape = createVideoObjectRuntimeFingerprints({
+      bridgeSha256: "bridge-a",
+      height: 1080,
+      width: 1920,
+    });
+
+    expect(portrait.capabilitySha256).toBe(landscape.capabilitySha256);
+    expect(portrait.capabilitySha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(portrait.processorSha256).not.toBe(landscape.processorSha256);
+    expect(
+      createVideoObjectRuntimeFingerprints({
+        backend: "effect-host-interop-v1",
+        bridgeSha256: "bridge-a",
+        height: 1920,
+        width: 1080,
+      }).capabilitySha256,
+    ).not.toBe(portrait.capabilitySha256);
+    expect(
+      createVideoObjectRuntimeFingerprints({
+        backend: "jianying-bach-v2-exact-d634-v1",
+        bridgeSha256: "bridge-a",
+        height: 1920,
+        width: 1080,
+      }).capabilitySha256,
+    ).not.toBe(portrait.capabilitySha256);
+  });
+
+  it("pins the audited Bach runtime, graph, model, and processor identity", () => {
+    expect(VIDEO_OBJECT_BACH_RUNTIME_UUID).toBe(
+      "D6342ECD-5432-33F0-A2AD-0C28F5699994",
+    );
+    expect(VIDEO_OBJECT_BACH_RUNTIME_SHA256).toBe(
+      "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9",
+    );
+    expect(VIDEO_OBJECT_BACH_PROCESSOR_VERSION).toBe(
+      "jianying-bach-d634-tematting-blend-v2-source-alpha-v1",
+    );
+    expect(VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY).toMatchObject({
+      dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+      dependencyClosureSha256: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+      graphSha256:
+        "797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b",
+      modelSha256:
+        "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+      outputContract: "tematting-blend-effect-v2-source-alpha-u8-v1",
+      postprocess: "TEMattingBlendEffectV2-vendor-exact",
+      readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
+      refinement: "vendor-v2-exact-no-qcut-refinement-v1",
+      runtimeSha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+      runtimeUuid: VIDEO_OBJECT_BACH_RUNTIME_UUID,
+      temporalState: "te-bach-matting-session-v1",
+    });
+  });
+
+  it("describes direct CoreML separately from host interop", () => {
+    expect(VIDEO_OBJECT_PROVIDER_CAPABILITY).toEqual({
+      effectRegistration: "not-required-direct-coreml",
+      hostEffectRegistry: "bypassed",
+      implementationRole: "private-host-independent-fallback",
+      inputTransport: "same-model-coreml-source-rgba-direct-256-v2",
+      inputTransportStatus: "bach-capture-close-not-bit-exact-frame0",
+      modelResolution: "resolved",
+      modelResolver: "packed-model-coreml-extractor-v1",
+      outputValidation: "coreml-tensor-contract-v1",
+      readiness: "same-model-coreml-validated",
+      temporalState: "previous-image-and-mask-v1",
+    });
+    expect(VIDEO_OBJECT_COREML_PROCESSOR_VERSION).toBe(
+      "source-rgba-direct-256-v2",
+    );
+    expect(VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY).toMatchObject({
+      hostEffectRegistry: "not-reproduced",
+      readiness: "output-gated-candidate",
+    });
+  });
 });

--- a/qcut/electron/__tests__/person-cutout-video-object-runtime.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-runtime.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { calculateVideoObjectGraphSize } from "../jianying-person-cutout/video-object-runtime.js";
+
+describe("video-object graph sizing", () => {
+	it("matches Jianying's 512-pixel portrait and landscape graph inputs", () => {
+		expect(calculateVideoObjectGraphSize({ height: 640, width: 360 })).toEqual({
+			height: 512,
+			width: 288,
+		});
+		expect(
+			calculateVideoObjectGraphSize({ height: 1080, width: 1920 })
+		).toEqual({
+			height: 288,
+			width: 512,
+		});
+	});
+
+	it("keeps odd aspect ratios on even texture dimensions", () => {
+		expect(calculateVideoObjectGraphSize({ height: 333, width: 1000 })).toEqual(
+			{
+				height: 170,
+				width: 512,
+			}
+		);
+	});
+
+	it("rejects invalid source dimensions", () => {
+		expect(() =>
+			calculateVideoObjectGraphSize({ height: 0, width: 1920 })
+		).toThrow("视频尺寸无效");
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-video-object-runtime.test.ts
+++ b/qcut/electron/__tests__/person-cutout-video-object-runtime.test.ts
@@ -1,128 +1,128 @@
 import { describe, expect, it } from "vitest";
 import {
-  calculateVideoObjectGraphSize,
-  createVideoObjectRuntimeFingerprints,
-  VIDEO_OBJECT_BACH_PROCESSOR_VERSION,
-  VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY,
-  VIDEO_OBJECT_BACH_RUNTIME_SHA256,
-  VIDEO_OBJECT_BACH_RUNTIME_UUID,
-  VIDEO_OBJECT_COREML_PROCESSOR_VERSION,
-  VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
-  VIDEO_OBJECT_PROVIDER_CAPABILITY,
+	calculateVideoObjectGraphSize,
+	createVideoObjectRuntimeFingerprints,
+	VIDEO_OBJECT_BACH_PROCESSOR_VERSION,
+	VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY,
+	VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+	VIDEO_OBJECT_BACH_RUNTIME_UUID,
+	VIDEO_OBJECT_COREML_PROCESSOR_VERSION,
+	VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
+	VIDEO_OBJECT_PROVIDER_CAPABILITY,
 } from "../jianying-person-cutout/video-object-runtime.js";
 import {
-  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+	VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+	VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
 } from "../jianying-person-cutout/video-object-runtime-closure.js";
 
 describe("legacy host video-object graph sizing", () => {
-  it("matches Jianying's 512-pixel portrait and landscape graph inputs", () => {
-    expect(calculateVideoObjectGraphSize({ height: 640, width: 360 })).toEqual({
-      height: 512,
-      width: 288,
-    });
-    expect(
-      calculateVideoObjectGraphSize({ height: 1080, width: 1920 }),
-    ).toEqual({
-      height: 288,
-      width: 512,
-    });
-  });
+	it("matches Jianying's 512-pixel portrait and landscape graph inputs", () => {
+		expect(calculateVideoObjectGraphSize({ height: 640, width: 360 })).toEqual({
+			height: 512,
+			width: 288,
+		});
+		expect(
+			calculateVideoObjectGraphSize({ height: 1080, width: 1920 })
+		).toEqual({
+			height: 288,
+			width: 512,
+		});
+	});
 
-  it("keeps odd aspect ratios on even texture dimensions", () => {
-    expect(calculateVideoObjectGraphSize({ height: 333, width: 1000 })).toEqual(
-      {
-        height: 170,
-        width: 512,
-      },
-    );
-  });
+	it("keeps odd aspect ratios on even texture dimensions", () => {
+		expect(calculateVideoObjectGraphSize({ height: 333, width: 1000 })).toEqual(
+			{
+				height: 170,
+				width: 512,
+			}
+		);
+	});
 
-  it("rejects invalid source dimensions", () => {
-    expect(() =>
-      calculateVideoObjectGraphSize({ height: 0, width: 1920 }),
-    ).toThrow("视频尺寸无效");
-  });
+	it("rejects invalid source dimensions", () => {
+		expect(() =>
+			calculateVideoObjectGraphSize({ height: 0, width: 1920 })
+		).toThrow("视频尺寸无效");
+	});
 
-  it("keeps capability failures stable across output resolutions", () => {
-    const portrait = createVideoObjectRuntimeFingerprints({
-      bridgeSha256: "bridge-a",
-      height: 1920,
-      width: 1080,
-    });
-    const landscape = createVideoObjectRuntimeFingerprints({
-      bridgeSha256: "bridge-a",
-      height: 1080,
-      width: 1920,
-    });
+	it("keeps capability failures stable across output resolutions", () => {
+		const portrait = createVideoObjectRuntimeFingerprints({
+			bridgeSha256: "bridge-a",
+			height: 1920,
+			width: 1080,
+		});
+		const landscape = createVideoObjectRuntimeFingerprints({
+			bridgeSha256: "bridge-a",
+			height: 1080,
+			width: 1920,
+		});
 
-    expect(portrait.capabilitySha256).toBe(landscape.capabilitySha256);
-    expect(portrait.capabilitySha256).toMatch(/^[a-f0-9]{64}$/);
-    expect(portrait.processorSha256).not.toBe(landscape.processorSha256);
-    expect(
-      createVideoObjectRuntimeFingerprints({
-        backend: "effect-host-interop-v1",
-        bridgeSha256: "bridge-a",
-        height: 1920,
-        width: 1080,
-      }).capabilitySha256,
-    ).not.toBe(portrait.capabilitySha256);
-    expect(
-      createVideoObjectRuntimeFingerprints({
-        backend: "jianying-bach-v2-exact-d634-v1",
-        bridgeSha256: "bridge-a",
-        height: 1920,
-        width: 1080,
-      }).capabilitySha256,
-    ).not.toBe(portrait.capabilitySha256);
-  });
+		expect(portrait.capabilitySha256).toBe(landscape.capabilitySha256);
+		expect(portrait.capabilitySha256).toMatch(/^[a-f0-9]{64}$/);
+		expect(portrait.processorSha256).not.toBe(landscape.processorSha256);
+		expect(
+			createVideoObjectRuntimeFingerprints({
+				backend: "effect-host-interop-v1",
+				bridgeSha256: "bridge-a",
+				height: 1920,
+				width: 1080,
+			}).capabilitySha256
+		).not.toBe(portrait.capabilitySha256);
+		expect(
+			createVideoObjectRuntimeFingerprints({
+				backend: "jianying-bach-v2-exact-d634-v1",
+				bridgeSha256: "bridge-a",
+				height: 1920,
+				width: 1080,
+			}).capabilitySha256
+		).not.toBe(portrait.capabilitySha256);
+	});
 
-  it("pins the audited Bach runtime, graph, model, and processor identity", () => {
-    expect(VIDEO_OBJECT_BACH_RUNTIME_UUID).toBe(
-      "D6342ECD-5432-33F0-A2AD-0C28F5699994",
-    );
-    expect(VIDEO_OBJECT_BACH_RUNTIME_SHA256).toBe(
-      "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9",
-    );
-    expect(VIDEO_OBJECT_BACH_PROCESSOR_VERSION).toBe(
-      "jianying-bach-d634-tematting-blend-v2-source-alpha-v1",
-    );
-    expect(VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY).toMatchObject({
-      dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-      dependencyClosureSha256: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
-      graphSha256:
-        "797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b",
-      modelSha256:
-        "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
-      outputContract: "tematting-blend-effect-v2-source-alpha-u8-v1",
-      postprocess: "TEMattingBlendEffectV2-vendor-exact",
-      readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
-      refinement: "vendor-v2-exact-no-qcut-refinement-v1",
-      runtimeSha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
-      runtimeUuid: VIDEO_OBJECT_BACH_RUNTIME_UUID,
-      temporalState: "te-bach-matting-session-v1",
-    });
-  });
+	it("pins the audited Bach runtime, graph, model, and processor identity", () => {
+		expect(VIDEO_OBJECT_BACH_RUNTIME_UUID).toBe(
+			"D6342ECD-5432-33F0-A2AD-0C28F5699994"
+		);
+		expect(VIDEO_OBJECT_BACH_RUNTIME_SHA256).toBe(
+			"0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9"
+		);
+		expect(VIDEO_OBJECT_BACH_PROCESSOR_VERSION).toBe(
+			"jianying-bach-d634-tematting-blend-v2-source-alpha-v1"
+		);
+		expect(VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY).toMatchObject({
+			dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+			dependencyClosureSha256: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+			graphSha256:
+				"797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b",
+			modelSha256:
+				"346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+			outputContract: "tematting-blend-effect-v2-source-alpha-u8-v1",
+			postprocess: "TEMattingBlendEffectV2-vendor-exact",
+			readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
+			refinement: "vendor-v2-exact-no-qcut-refinement-v1",
+			runtimeSha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+			runtimeUuid: VIDEO_OBJECT_BACH_RUNTIME_UUID,
+			temporalState: "te-bach-matting-session-v1",
+		});
+	});
 
-  it("describes direct CoreML separately from host interop", () => {
-    expect(VIDEO_OBJECT_PROVIDER_CAPABILITY).toEqual({
-      effectRegistration: "not-required-direct-coreml",
-      hostEffectRegistry: "bypassed",
-      implementationRole: "private-host-independent-fallback",
-      inputTransport: "same-model-coreml-source-rgba-direct-256-v2",
-      inputTransportStatus: "bach-capture-close-not-bit-exact-frame0",
-      modelResolution: "resolved",
-      modelResolver: "packed-model-coreml-extractor-v1",
-      outputValidation: "coreml-tensor-contract-v1",
-      readiness: "same-model-coreml-validated",
-      temporalState: "previous-image-and-mask-v1",
-    });
-    expect(VIDEO_OBJECT_COREML_PROCESSOR_VERSION).toBe(
-      "source-rgba-direct-256-v2",
-    );
-    expect(VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY).toMatchObject({
-      hostEffectRegistry: "not-reproduced",
-      readiness: "output-gated-candidate",
-    });
-  });
+	it("describes direct CoreML separately from host interop", () => {
+		expect(VIDEO_OBJECT_PROVIDER_CAPABILITY).toEqual({
+			effectRegistration: "not-required-direct-coreml",
+			hostEffectRegistry: "bypassed",
+			implementationRole: "private-host-independent-fallback",
+			inputTransport: "same-model-coreml-source-rgba-direct-256-v2",
+			inputTransportStatus: "bach-capture-close-not-bit-exact-frame0",
+			modelResolution: "resolved",
+			modelResolver: "packed-model-coreml-extractor-v1",
+			outputValidation: "coreml-tensor-contract-v1",
+			readiness: "same-model-coreml-validated",
+			temporalState: "previous-image-and-mask-v1",
+		});
+		expect(VIDEO_OBJECT_COREML_PROCESSOR_VERSION).toBe(
+			"source-rgba-direct-256-v2"
+		);
+		expect(VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY).toMatchObject({
+			hostEffectRegistry: "not-reproduced",
+			readiness: "output-gated-candidate",
+		});
+	});
 });

--- a/qcut/electron/__tests__/person-cutout-vision-fusion.test.ts
+++ b/qcut/electron/__tests__/person-cutout-vision-fusion.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const describeOnMac = process.platform === "darwin" ? describe : describe.skip;
+let temporaryDirectory = "";
+
+describeOnMac("person cutout Vision fusion", () => {
+	beforeAll(async () => {
+		temporaryDirectory = await mkdtemp(
+			path.join(os.tmpdir(), "qcut-vision-fusion-test-")
+		);
+	});
+
+	afterAll(async () => {
+		if (!temporaryDirectory) return;
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	});
+
+	it("boosts missing person confidence without weakening the GRU alpha", async () => {
+		const nativeDirectory = path.resolve(
+			"electron",
+			"jianying-person-cutout",
+			"native"
+		);
+		const executablePath = path.join(temporaryDirectory, "alpha-fusion-test");
+		await execFileAsync("xcrun", [
+			"clang++",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			path.join(nativeDirectory, "alpha-mask-fusion.cpp"),
+			path.join(nativeDirectory, "alpha-mask-fusion.test.cpp"),
+			"-o",
+			executablePath,
+		]);
+		await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+	});
+
+	it("resizes model alpha with centered bilinear sampling", async () => {
+		const nativeDirectory = path.resolve(
+			"electron",
+			"jianying-person-cutout",
+			"native"
+		);
+		const executablePath = path.join(temporaryDirectory, "alpha-resize-test");
+		await execFileAsync("xcrun", [
+			"clang++",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			path.join(nativeDirectory, "alpha-resize.cpp"),
+			path.join(nativeDirectory, "alpha-resize.test.cpp"),
+			"-o",
+			executablePath,
+		]);
+		await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+	});
+
+	it("returns a full-size mask through the macOS Vision runtime", async () => {
+		const nativeDirectory = path.resolve(
+			"electron",
+			"jianying-person-cutout",
+			"native"
+		);
+		const executablePath = path.join(temporaryDirectory, "vision-runtime-test");
+		await execFileAsync("xcrun", [
+			"clang++",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			path.join(nativeDirectory, "alpha-resize.cpp"),
+			path.join(nativeDirectory, "vision-person-segmentation.mm"),
+			path.join(nativeDirectory, "vision-person-segmentation.test.mm"),
+			"-framework",
+			"Vision",
+			"-framework",
+			"CoreVideo",
+			"-framework",
+			"Foundation",
+			"-framework",
+			"ImageIO",
+			"-o",
+			executablePath,
+		]);
+		await expect(execFileAsync(executablePath)).resolves.toBeDefined();
+	});
+});

--- a/qcut/electron/__tests__/person-cutout-vision-fusion.test.ts
+++ b/qcut/electron/__tests__/person-cutout-vision-fusion.test.ts
@@ -92,5 +92,5 @@ describeOnMac("person cutout Vision fusion", () => {
 			executablePath,
 		]);
 		await expect(execFileAsync(executablePath)).resolves.toBeDefined();
-	});
+	}, 120_000);
 });

--- a/qcut/electron/__tests__/tematting-blend.test.ts
+++ b/qcut/electron/__tests__/tematting-blend.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildTemattingOutputMetadata,
+	buildTemattingTransparentBlendFilter,
+	TEMATTING_COMPATIBLE_BLEND,
+	TEMATTING_NATIVE_METAL_BLEND,
+} from "../jianying-person-cutout/tematting-blend.js";
+
+describe("TEMattingBlendEffectV2-compatible output", () => {
+	it("keeps the GRU alpha as the transparent blend mask", () => {
+		expect(buildTemattingTransparentBlendFilter()).toBe(
+			"[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]"
+		);
+		expect(buildTemattingTransparentBlendFilter()).not.toContain("premultiply");
+	});
+
+	it("marks outputs with the exact model and blend implementation", () => {
+		expect(TEMATTING_COMPATIBLE_BLEND).toBe(
+			"TEMattingBlendEffectV2-compatible"
+		);
+		expect(
+			buildTemattingOutputMetadata({
+				implementation: TEMATTING_COMPATIBLE_BLEND,
+			})
+		).toEqual([
+			"-metadata:s:v:0",
+			"qcut_matting_blend=TEMattingBlendEffectV2-compatible",
+			"-metadata:s:v:0",
+			"qcut_matting_model=tt_matting_video_gru_v1.0",
+			"-metadata:s:v:0",
+			"qcut_matting_route=portrait-gru",
+		]);
+	});
+
+	it("records native Metal output without changing the model identity", () => {
+		expect(
+			buildTemattingOutputMetadata({
+				implementation: TEMATTING_NATIVE_METAL_BLEND,
+			})
+		).toEqual([
+			"-metadata:s:v:0",
+			"qcut_matting_blend=TEMattingBlendEffectV2-native-metal",
+			"-metadata:s:v:0",
+			"qcut_matting_model=tt_matting_video_gru_v1.0",
+			"-metadata:s:v:0",
+			"qcut_matting_route=portrait-gru",
+		]);
+	});
+
+	it("records the saliency graph identity without exposing it in the UI", () => {
+		expect(
+			buildTemattingOutputMetadata({
+				implementation: TEMATTING_COMPATIBLE_BLEND,
+				modelName: "saliency_script_for_cc_v1.2",
+				modelRoute: "saliency-script",
+			})
+		).toEqual([
+			"-metadata:s:v:0",
+			"qcut_matting_blend=TEMattingBlendEffectV2-compatible",
+			"-metadata:s:v:0",
+			"qcut_matting_model=saliency_script_for_cc_v1.2",
+			"-metadata:s:v:0",
+			"qcut_matting_route=saliency-script",
+		]);
+	});
+});

--- a/qcut/electron/__tests__/tematting-blend.test.ts
+++ b/qcut/electron/__tests__/tematting-blend.test.ts
@@ -1,66 +1,152 @@
 import { describe, expect, it } from "vitest";
 import {
-	buildTemattingOutputMetadata,
-	buildTemattingTransparentBlendFilter,
-	TEMATTING_COMPATIBLE_BLEND,
-	TEMATTING_NATIVE_METAL_BLEND,
+  buildTemattingOutputMetadata,
+  buildTemattingTransparentBlendFilter,
+  resolveTemattingOutputBlendImplementation,
+  resolveTemattingOutputProvenance,
+  TEMATTING_COMPATIBLE_BLEND,
+  TEMATTING_NATIVE_METAL_CANARY,
+  TEMATTING_VENDOR_V2_EXACT_BLEND,
 } from "../jianying-person-cutout/tematting-blend.js";
+import {
+  GRU_VISION_PERSON_CUTOUT_PIPELINE,
+  JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+  JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+  VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+} from "../jianying-person-cutout/pipeline-descriptor.js";
 
 describe("TEMattingBlendEffectV2-compatible output", () => {
-	it("keeps the GRU alpha as the transparent blend mask", () => {
-		expect(buildTemattingTransparentBlendFilter()).toBe(
-			"[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]"
-		);
-		expect(buildTemattingTransparentBlendFilter()).not.toContain("premultiply");
-	});
+  it("keeps the GRU alpha as the transparent blend mask", () => {
+    expect(buildTemattingTransparentBlendFilter()).toBe(
+      "[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]",
+    );
+    expect(buildTemattingTransparentBlendFilter()).not.toContain("premultiply");
+  });
 
-	it("marks outputs with the exact model and blend implementation", () => {
-		expect(TEMATTING_COMPATIBLE_BLEND).toBe(
-			"TEMattingBlendEffectV2-compatible"
-		);
-		expect(
-			buildTemattingOutputMetadata({
-				implementation: TEMATTING_COMPATIBLE_BLEND,
-			})
-		).toEqual([
-			"-metadata:s:v:0",
-			"qcut_matting_blend=TEMattingBlendEffectV2-compatible",
-			"-metadata:s:v:0",
-			"qcut_matting_model=tt_matting_video_gru_v1.0",
-			"-metadata:s:v:0",
-			"qcut_matting_route=portrait-gru",
-		]);
-	});
+  it("marks outputs with the exact model and blend implementation", () => {
+    expect(TEMATTING_COMPATIBLE_BLEND).toBe(
+      "TEMattingBlendEffectV2-compatible",
+    );
+    expect(
+      buildTemattingOutputMetadata({
+        implementation: TEMATTING_COMPATIBLE_BLEND,
+      }),
+    ).toEqual([
+      "-metadata:s:v:0",
+      "qcut_matting_blend=TEMattingBlendEffectV2-compatible",
+      "-metadata:s:v:0",
+      "qcut_matting_model=tt_matting_video_gru_v1.0",
+      "-metadata:s:v:0",
+      "qcut_matting_route=portrait-gru",
+    ]);
+  });
 
-	it("records native Metal output without changing the model identity", () => {
-		expect(
-			buildTemattingOutputMetadata({
-				implementation: TEMATTING_NATIVE_METAL_BLEND,
-			})
-		).toEqual([
-			"-metadata:s:v:0",
-			"qcut_matting_blend=TEMattingBlendEffectV2-native-metal",
-			"-metadata:s:v:0",
-			"qcut_matting_model=tt_matting_video_gru_v1.0",
-			"-metadata:s:v:0",
-			"qcut_matting_route=portrait-gru",
-		]);
-	});
+  it("records Metal as a canary while keeping output provenance compatible", () => {
+    expect(
+      buildTemattingOutputMetadata({
+        implementation: TEMATTING_NATIVE_METAL_CANARY,
+      }),
+    ).toEqual([
+      "-metadata:s:v:0",
+      "qcut_matting_blend=TEMattingBlendEffectV2-compatible",
+      "-metadata:s:v:0",
+      "qcut_matting_model=tt_matting_video_gru_v1.0",
+      "-metadata:s:v:0",
+      "qcut_matting_route=portrait-gru",
+      "-metadata:s:v:0",
+      "qcut_matting_native_canary=passed",
+    ]);
+  });
 
-	it("records the saliency graph identity without exposing it in the UI", () => {
-		expect(
-			buildTemattingOutputMetadata({
-				implementation: TEMATTING_COMPATIBLE_BLEND,
-				modelName: "saliency_script_for_cc_v1.2",
-				modelRoute: "saliency-script",
-			})
-		).toEqual([
-			"-metadata:s:v:0",
-			"qcut_matting_blend=TEMattingBlendEffectV2-compatible",
-			"-metadata:s:v:0",
-			"qcut_matting_model=saliency_script_for_cc_v1.2",
-			"-metadata:s:v:0",
-			"qcut_matting_route=saliency-script",
-		]);
-	});
+  it("separates completed output provenance from the canary attempt", () => {
+    expect(
+      resolveTemattingOutputProvenance({
+        completedImplementation: TEMATTING_NATIVE_METAL_CANARY,
+        preferredImplementation: TEMATTING_NATIVE_METAL_CANARY,
+      }),
+    ).toEqual({
+      blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+      nativeMetalCanary: "passed",
+    });
+    expect(
+      resolveTemattingOutputProvenance({
+        completedImplementation: TEMATTING_COMPATIBLE_BLEND,
+        preferredImplementation: TEMATTING_NATIVE_METAL_CANARY,
+      }),
+    ).toEqual({
+      blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+      nativeMetalCanary: "failed-fallback",
+    });
+    expect(
+      buildTemattingOutputMetadata({
+        implementation: TEMATTING_COMPATIBLE_BLEND,
+        nativeMetalCanary: "failed-fallback",
+      }),
+    ).toContain("qcut_matting_native_canary=failed-fallback");
+  });
+
+  it("records the saliency graph identity without exposing it in the UI", () => {
+    expect(
+      buildTemattingOutputMetadata({
+        implementation: TEMATTING_COMPATIBLE_BLEND,
+        modelName: "saliency_script_for_cc_v1.2",
+        modelRoute: "saliency-script",
+      }),
+    ).toEqual([
+      "-metadata:s:v:0",
+      "qcut_matting_blend=TEMattingBlendEffectV2-compatible",
+      "-metadata:s:v:0",
+      "qcut_matting_model=saliency_script_for_cc_v1.2",
+      "-metadata:s:v:0",
+      "qcut_matting_route=saliency-script",
+    ]);
+  });
+
+  it("records the actual QCut pipeline without claiming full Jianying hosting", () => {
+    expect(
+      buildTemattingOutputMetadata({
+        implementation: TEMATTING_COMPATIBLE_BLEND,
+        pipelineDescriptor: GRU_VISION_PERSON_CUTOUT_PIPELINE,
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        "qcut_matting_provider=qcut-local-person-matting-v1",
+        "qcut_matting_pipeline=qcut-gru-vision-fusion-v1",
+        "qcut_matting_refinement=qcut-portrait-temporal-border-refinement-v1",
+      ]),
+    );
+  });
+
+  it("reports vendor V2 only for the exact Bach output", () => {
+    expect(
+      resolveTemattingOutputBlendImplementation({
+        pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+      }),
+    ).toBe(TEMATTING_VENDOR_V2_EXACT_BLEND);
+    for (const pipelineDescriptor of [
+      JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+      VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+      GRU_VISION_PERSON_CUTOUT_PIPELINE,
+    ]) {
+      expect(
+        resolveTemattingOutputBlendImplementation({ pipelineDescriptor }),
+      ).toBe(TEMATTING_COMPATIBLE_BLEND);
+    }
+    expect(
+      buildTemattingOutputMetadata({
+        implementation: TEMATTING_COMPATIBLE_BLEND,
+        pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+      }),
+    ).toContain("qcut_matting_blend=TEMattingBlendEffectV2-vendor-exact");
+    expect(
+      resolveTemattingOutputProvenance({
+        completedImplementation: TEMATTING_COMPATIBLE_BLEND,
+        pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+        preferredImplementation: TEMATTING_COMPATIBLE_BLEND,
+      }),
+    ).toEqual({
+      blendImplementation: TEMATTING_VENDOR_V2_EXACT_BLEND,
+      nativeMetalCanary: "not-run",
+    });
+  });
 });

--- a/qcut/electron/__tests__/tematting-blend.test.ts
+++ b/qcut/electron/__tests__/tematting-blend.test.ts
@@ -1,152 +1,152 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildTemattingOutputMetadata,
-  buildTemattingTransparentBlendFilter,
-  resolveTemattingOutputBlendImplementation,
-  resolveTemattingOutputProvenance,
-  TEMATTING_COMPATIBLE_BLEND,
-  TEMATTING_NATIVE_METAL_CANARY,
-  TEMATTING_VENDOR_V2_EXACT_BLEND,
+	buildTemattingOutputMetadata,
+	buildTemattingTransparentBlendFilter,
+	resolveTemattingOutputBlendImplementation,
+	resolveTemattingOutputProvenance,
+	TEMATTING_COMPATIBLE_BLEND,
+	TEMATTING_NATIVE_METAL_CANARY,
+	TEMATTING_VENDOR_V2_EXACT_BLEND,
 } from "../jianying-person-cutout/tematting-blend.js";
 import {
-  GRU_VISION_PERSON_CUTOUT_PIPELINE,
-  JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-  JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
-  VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+	GRU_VISION_PERSON_CUTOUT_PIPELINE,
+	JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+	JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+	VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
 } from "../jianying-person-cutout/pipeline-descriptor.js";
 
 describe("TEMattingBlendEffectV2-compatible output", () => {
-  it("keeps the GRU alpha as the transparent blend mask", () => {
-    expect(buildTemattingTransparentBlendFilter()).toBe(
-      "[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]",
-    );
-    expect(buildTemattingTransparentBlendFilter()).not.toContain("premultiply");
-  });
+	it("keeps the GRU alpha as the transparent blend mask", () => {
+		expect(buildTemattingTransparentBlendFilter()).toBe(
+			"[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]"
+		);
+		expect(buildTemattingTransparentBlendFilter()).not.toContain("premultiply");
+	});
 
-  it("marks outputs with the exact model and blend implementation", () => {
-    expect(TEMATTING_COMPATIBLE_BLEND).toBe(
-      "TEMattingBlendEffectV2-compatible",
-    );
-    expect(
-      buildTemattingOutputMetadata({
-        implementation: TEMATTING_COMPATIBLE_BLEND,
-      }),
-    ).toEqual([
-      "-metadata:s:v:0",
-      "qcut_matting_blend=TEMattingBlendEffectV2-compatible",
-      "-metadata:s:v:0",
-      "qcut_matting_model=tt_matting_video_gru_v1.0",
-      "-metadata:s:v:0",
-      "qcut_matting_route=portrait-gru",
-    ]);
-  });
+	it("marks outputs with the exact model and blend implementation", () => {
+		expect(TEMATTING_COMPATIBLE_BLEND).toBe(
+			"TEMattingBlendEffectV2-compatible"
+		);
+		expect(
+			buildTemattingOutputMetadata({
+				implementation: TEMATTING_COMPATIBLE_BLEND,
+			})
+		).toEqual([
+			"-metadata:s:v:0",
+			"qcut_matting_blend=TEMattingBlendEffectV2-compatible",
+			"-metadata:s:v:0",
+			"qcut_matting_model=tt_matting_video_gru_v1.0",
+			"-metadata:s:v:0",
+			"qcut_matting_route=portrait-gru",
+		]);
+	});
 
-  it("records Metal as a canary while keeping output provenance compatible", () => {
-    expect(
-      buildTemattingOutputMetadata({
-        implementation: TEMATTING_NATIVE_METAL_CANARY,
-      }),
-    ).toEqual([
-      "-metadata:s:v:0",
-      "qcut_matting_blend=TEMattingBlendEffectV2-compatible",
-      "-metadata:s:v:0",
-      "qcut_matting_model=tt_matting_video_gru_v1.0",
-      "-metadata:s:v:0",
-      "qcut_matting_route=portrait-gru",
-      "-metadata:s:v:0",
-      "qcut_matting_native_canary=passed",
-    ]);
-  });
+	it("records Metal as a canary while keeping output provenance compatible", () => {
+		expect(
+			buildTemattingOutputMetadata({
+				implementation: TEMATTING_NATIVE_METAL_CANARY,
+			})
+		).toEqual([
+			"-metadata:s:v:0",
+			"qcut_matting_blend=TEMattingBlendEffectV2-compatible",
+			"-metadata:s:v:0",
+			"qcut_matting_model=tt_matting_video_gru_v1.0",
+			"-metadata:s:v:0",
+			"qcut_matting_route=portrait-gru",
+			"-metadata:s:v:0",
+			"qcut_matting_native_canary=passed",
+		]);
+	});
 
-  it("separates completed output provenance from the canary attempt", () => {
-    expect(
-      resolveTemattingOutputProvenance({
-        completedImplementation: TEMATTING_NATIVE_METAL_CANARY,
-        preferredImplementation: TEMATTING_NATIVE_METAL_CANARY,
-      }),
-    ).toEqual({
-      blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-      nativeMetalCanary: "passed",
-    });
-    expect(
-      resolveTemattingOutputProvenance({
-        completedImplementation: TEMATTING_COMPATIBLE_BLEND,
-        preferredImplementation: TEMATTING_NATIVE_METAL_CANARY,
-      }),
-    ).toEqual({
-      blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-      nativeMetalCanary: "failed-fallback",
-    });
-    expect(
-      buildTemattingOutputMetadata({
-        implementation: TEMATTING_COMPATIBLE_BLEND,
-        nativeMetalCanary: "failed-fallback",
-      }),
-    ).toContain("qcut_matting_native_canary=failed-fallback");
-  });
+	it("separates completed output provenance from the canary attempt", () => {
+		expect(
+			resolveTemattingOutputProvenance({
+				completedImplementation: TEMATTING_NATIVE_METAL_CANARY,
+				preferredImplementation: TEMATTING_NATIVE_METAL_CANARY,
+			})
+		).toEqual({
+			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+			nativeMetalCanary: "passed",
+		});
+		expect(
+			resolveTemattingOutputProvenance({
+				completedImplementation: TEMATTING_COMPATIBLE_BLEND,
+				preferredImplementation: TEMATTING_NATIVE_METAL_CANARY,
+			})
+		).toEqual({
+			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+			nativeMetalCanary: "failed-fallback",
+		});
+		expect(
+			buildTemattingOutputMetadata({
+				implementation: TEMATTING_COMPATIBLE_BLEND,
+				nativeMetalCanary: "failed-fallback",
+			})
+		).toContain("qcut_matting_native_canary=failed-fallback");
+	});
 
-  it("records the saliency graph identity without exposing it in the UI", () => {
-    expect(
-      buildTemattingOutputMetadata({
-        implementation: TEMATTING_COMPATIBLE_BLEND,
-        modelName: "saliency_script_for_cc_v1.2",
-        modelRoute: "saliency-script",
-      }),
-    ).toEqual([
-      "-metadata:s:v:0",
-      "qcut_matting_blend=TEMattingBlendEffectV2-compatible",
-      "-metadata:s:v:0",
-      "qcut_matting_model=saliency_script_for_cc_v1.2",
-      "-metadata:s:v:0",
-      "qcut_matting_route=saliency-script",
-    ]);
-  });
+	it("records the saliency graph identity without exposing it in the UI", () => {
+		expect(
+			buildTemattingOutputMetadata({
+				implementation: TEMATTING_COMPATIBLE_BLEND,
+				modelName: "saliency_script_for_cc_v1.2",
+				modelRoute: "saliency-script",
+			})
+		).toEqual([
+			"-metadata:s:v:0",
+			"qcut_matting_blend=TEMattingBlendEffectV2-compatible",
+			"-metadata:s:v:0",
+			"qcut_matting_model=saliency_script_for_cc_v1.2",
+			"-metadata:s:v:0",
+			"qcut_matting_route=saliency-script",
+		]);
+	});
 
-  it("records the actual QCut pipeline without claiming full Jianying hosting", () => {
-    expect(
-      buildTemattingOutputMetadata({
-        implementation: TEMATTING_COMPATIBLE_BLEND,
-        pipelineDescriptor: GRU_VISION_PERSON_CUTOUT_PIPELINE,
-      }),
-    ).toEqual(
-      expect.arrayContaining([
-        "qcut_matting_provider=qcut-local-person-matting-v1",
-        "qcut_matting_pipeline=qcut-gru-vision-fusion-v1",
-        "qcut_matting_refinement=qcut-portrait-temporal-border-refinement-v1",
-      ]),
-    );
-  });
+	it("records the actual QCut pipeline without claiming full Jianying hosting", () => {
+		expect(
+			buildTemattingOutputMetadata({
+				implementation: TEMATTING_COMPATIBLE_BLEND,
+				pipelineDescriptor: GRU_VISION_PERSON_CUTOUT_PIPELINE,
+			})
+		).toEqual(
+			expect.arrayContaining([
+				"qcut_matting_provider=qcut-local-person-matting-v1",
+				"qcut_matting_pipeline=qcut-gru-vision-fusion-v1",
+				"qcut_matting_refinement=qcut-portrait-temporal-border-refinement-v1",
+			])
+		);
+	});
 
-  it("reports vendor V2 only for the exact Bach output", () => {
-    expect(
-      resolveTemattingOutputBlendImplementation({
-        pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-      }),
-    ).toBe(TEMATTING_VENDOR_V2_EXACT_BLEND);
-    for (const pipelineDescriptor of [
-      JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
-      VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-      GRU_VISION_PERSON_CUTOUT_PIPELINE,
-    ]) {
-      expect(
-        resolveTemattingOutputBlendImplementation({ pipelineDescriptor }),
-      ).toBe(TEMATTING_COMPATIBLE_BLEND);
-    }
-    expect(
-      buildTemattingOutputMetadata({
-        implementation: TEMATTING_COMPATIBLE_BLEND,
-        pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-      }),
-    ).toContain("qcut_matting_blend=TEMattingBlendEffectV2-vendor-exact");
-    expect(
-      resolveTemattingOutputProvenance({
-        completedImplementation: TEMATTING_COMPATIBLE_BLEND,
-        pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-        preferredImplementation: TEMATTING_COMPATIBLE_BLEND,
-      }),
-    ).toEqual({
-      blendImplementation: TEMATTING_VENDOR_V2_EXACT_BLEND,
-      nativeMetalCanary: "not-run",
-    });
-  });
+	it("reports vendor V2 only for the exact Bach output", () => {
+		expect(
+			resolveTemattingOutputBlendImplementation({
+				pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+			})
+		).toBe(TEMATTING_VENDOR_V2_EXACT_BLEND);
+		for (const pipelineDescriptor of [
+			JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE,
+			VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+			GRU_VISION_PERSON_CUTOUT_PIPELINE,
+		]) {
+			expect(
+				resolveTemattingOutputBlendImplementation({ pipelineDescriptor })
+			).toBe(TEMATTING_COMPATIBLE_BLEND);
+		}
+		expect(
+			buildTemattingOutputMetadata({
+				implementation: TEMATTING_COMPATIBLE_BLEND,
+				pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+			})
+		).toContain("qcut_matting_blend=TEMattingBlendEffectV2-vendor-exact");
+		expect(
+			resolveTemattingOutputProvenance({
+				completedImplementation: TEMATTING_COMPATIBLE_BLEND,
+				pipelineDescriptor: JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+				preferredImplementation: TEMATTING_COMPATIBLE_BLEND,
+			})
+		).toEqual({
+			blendImplementation: TEMATTING_VENDOR_V2_EXACT_BLEND,
+			nativeMetalCanary: "not-run",
+		});
+	});
 });

--- a/qcut/electron/jianying-person-cutout-contract.ts
+++ b/qcut/electron/jianying-person-cutout-contract.ts
@@ -1,0 +1,72 @@
+import type { TemattingBlendImplementation } from "./jianying-person-cutout/tematting-blend.js";
+
+export const JIANYING_PERSON_CUTOUT_INSPECT_CHANNEL =
+	"jianying-person-cutout:inspect";
+export const JIANYING_PERSON_CUTOUT_RENDER_CHANNEL =
+	"jianying-person-cutout:render";
+export const JIANYING_PERSON_CUTOUT_CANCEL_CHANNEL =
+	"jianying-person-cutout:cancel";
+export const JIANYING_PERSON_CUTOUT_PROGRESS_CHANNEL =
+	"jianying-person-cutout:progress";
+export const JIANYING_PERSON_CUTOUT_RELEASE_CHANNEL =
+	"jianying-person-cutout:release";
+
+export interface JianyingPersonCutoutStatus {
+	available: boolean;
+	blendImplementation: TemattingBlendImplementation;
+	message: string;
+	provider: "jianying-gru-local-v1";
+	offlineReady: boolean;
+}
+
+export interface JianyingPersonCutoutRenderRequest {
+	taskId: string;
+	sourcePath: string;
+	settings: {
+		threshold: number;
+		temporalSmoothing: number;
+		edgeShift: number;
+		feather: number;
+	};
+}
+
+export interface JianyingPersonCutoutCancelRequest {
+	taskId: string;
+}
+
+export interface JianyingPersonCutoutProgress {
+	taskId: string;
+	progress: number;
+	status: string;
+}
+
+export interface JianyingPersonCutoutRenderResult {
+	blendImplementation: TemattingBlendImplementation;
+	provider: "jianying-gru-local-v1";
+	outputPath: string;
+	width: number;
+	height: number;
+	duration: number;
+	frameRate: number;
+	frameCount: number;
+	hasAudio: boolean;
+	codec: "vp9";
+}
+
+export interface JianyingPersonCutoutReleaseRequest {
+	outputPath: string;
+}
+
+export interface JianyingPersonCutoutAPI {
+	inspect: () => Promise<JianyingPersonCutoutStatus>;
+	render: (
+		request: JianyingPersonCutoutRenderRequest
+	) => Promise<JianyingPersonCutoutRenderResult>;
+	cancel: (request: JianyingPersonCutoutCancelRequest) => Promise<void>;
+	onProgress: (
+		callback: (progress: JianyingPersonCutoutProgress) => void
+	) => () => void;
+	release: (request: JianyingPersonCutoutReleaseRequest) => Promise<void>;
+}
+
+export type { TemattingBlendImplementation } from "./jianying-person-cutout/tematting-blend.js";

--- a/qcut/electron/jianying-person-cutout-contract.ts
+++ b/qcut/electron/jianying-person-cutout-contract.ts
@@ -1,4 +1,13 @@
-import type { TemattingBlendImplementation } from "./jianying-person-cutout/tematting-blend.js";
+import type {
+	TemattingNativeMetalCanaryStatus,
+	TemattingOutputBlendImplementation,
+} from "./jianying-person-cutout/tematting-blend.js";
+import type {
+	PersonCutoutModelRoute,
+	PersonCutoutPipelineId,
+	PersonCutoutProviderId,
+	PersonCutoutRefinementProvider,
+} from "./jianying-person-cutout/pipeline-descriptor.js";
 
 export const JIANYING_PERSON_CUTOUT_INSPECT_CHANNEL =
 	"jianying-person-cutout:inspect";
@@ -13,10 +22,22 @@ export const JIANYING_PERSON_CUTOUT_RELEASE_CHANNEL =
 
 export interface JianyingPersonCutoutStatus {
 	available: boolean;
-	blendImplementation: TemattingBlendImplementation;
+	blendImplementation: TemattingOutputBlendImplementation;
 	message: string;
-	provider: "jianying-gru-local-v1";
+	nativeMetalCanaryEnabled?: boolean;
+	pipelineId: PersonCutoutPipelineId;
+	provider: PersonCutoutProviderId;
+	refinementProvider: PersonCutoutRefinementProvider;
 	offlineReady: boolean;
+}
+
+export interface PersonCutoutExecutionMetadata {
+	didModelRouteFallback: boolean;
+	modelRoute: PersonCutoutModelRoute;
+	pipelineId: PersonCutoutPipelineId;
+	provider: PersonCutoutProviderId;
+	refinementProvider: PersonCutoutRefinementProvider;
+	requestedModelRoute: PersonCutoutModelRoute | "auto";
 }
 
 export interface JianyingPersonCutoutRenderRequest {
@@ -40,9 +61,10 @@ export interface JianyingPersonCutoutProgress {
 	status: string;
 }
 
-export interface JianyingPersonCutoutRenderResult {
-	blendImplementation: TemattingBlendImplementation;
-	provider: "jianying-gru-local-v1";
+export interface JianyingPersonCutoutRenderResult
+	extends PersonCutoutExecutionMetadata {
+	blendImplementation: TemattingOutputBlendImplementation;
+	nativeMetalCanary?: TemattingNativeMetalCanaryStatus;
 	outputPath: string;
 	width: number;
 	height: number;
@@ -69,4 +91,7 @@ export interface JianyingPersonCutoutAPI {
 	release: (request: JianyingPersonCutoutReleaseRequest) => Promise<void>;
 }
 
-export type { TemattingBlendImplementation } from "./jianying-person-cutout/tematting-blend.js";
+export type {
+	TemattingBlendImplementation,
+	TemattingOutputBlendImplementation,
+} from "./jianying-person-cutout/tematting-blend.js";

--- a/qcut/electron/jianying-person-cutout-handler.ts
+++ b/qcut/electron/jianying-person-cutout-handler.ts
@@ -1,0 +1,60 @@
+import { ipcMain } from "electron";
+import {
+	JIANYING_PERSON_CUTOUT_CANCEL_CHANNEL,
+	JIANYING_PERSON_CUTOUT_INSPECT_CHANNEL,
+	JIANYING_PERSON_CUTOUT_PROGRESS_CHANNEL,
+	JIANYING_PERSON_CUTOUT_RELEASE_CHANNEL,
+	JIANYING_PERSON_CUTOUT_RENDER_CHANNEL,
+	type JianyingPersonCutoutCancelRequest,
+	type JianyingPersonCutoutReleaseRequest,
+	type JianyingPersonCutoutRenderRequest,
+} from "./jianying-person-cutout-contract.js";
+import {
+	inspectJianyingPersonCutout,
+	releaseJianyingPersonCutout,
+	renderJianyingPersonCutout,
+} from "./jianying-person-cutout/runtime.js";
+
+export function setupJianyingPersonCutoutIPC() {
+	const activeTasks = new Map<string, AbortController>();
+	ipcMain.handle(JIANYING_PERSON_CUTOUT_INSPECT_CHANNEL, () =>
+		inspectJianyingPersonCutout()
+	);
+	ipcMain.handle(
+		JIANYING_PERSON_CUTOUT_RENDER_CHANNEL,
+		async (event, request: JianyingPersonCutoutRenderRequest) => {
+			if (!request.taskId || activeTasks.has(request.taskId)) {
+				throw new Error("人物抠像任务无效或已在运行");
+			}
+			const controller = new AbortController();
+			activeTasks.set(request.taskId, controller);
+			try {
+				return await renderJianyingPersonCutout({
+					...request,
+					signal: controller.signal,
+					onProgress: ({ progress, status }) => {
+						if (event.sender.isDestroyed()) return;
+						event.sender.send(JIANYING_PERSON_CUTOUT_PROGRESS_CHANNEL, {
+							progress,
+							status,
+							taskId: request.taskId,
+						});
+					},
+				});
+			} finally {
+				activeTasks.delete(request.taskId);
+			}
+		}
+	);
+	ipcMain.handle(
+		JIANYING_PERSON_CUTOUT_CANCEL_CHANNEL,
+		(_event, request: JianyingPersonCutoutCancelRequest) => {
+			activeTasks.get(request.taskId)?.abort();
+		}
+	);
+	ipcMain.handle(
+		JIANYING_PERSON_CUTOUT_RELEASE_CHANNEL,
+		(_event, request: JianyingPersonCutoutReleaseRequest) =>
+			releaseJianyingPersonCutout(request)
+	);
+}

--- a/qcut/electron/jianying-person-cutout/abort.ts
+++ b/qcut/electron/jianying-person-cutout/abort.ts
@@ -1,0 +1,51 @@
+export function createPersonCutoutAbortError() {
+	const error = new Error("人物抠像已取消");
+	error.name = "AbortError";
+	return error;
+}
+
+export function throwIfPersonCutoutAborted({
+	signal,
+}: {
+	signal?: AbortSignal;
+}) {
+	if (signal?.aborted) throw createPersonCutoutAbortError();
+}
+
+export function waitForPersonCutoutPromise<Result>({
+	promise,
+	signal,
+}: {
+	promise: Promise<Result>;
+	signal?: AbortSignal;
+}): Promise<Result> {
+	if (!signal) return promise;
+	if (signal.aborted) return Promise.reject(createPersonCutoutAbortError());
+	return new Promise<Result>((resolve, reject) => {
+		let settled = false;
+		const cleanup = () => signal.removeEventListener("abort", abort);
+		const finish = ({
+			error,
+			kind,
+			value,
+		}:
+			| { kind: "rejected"; error: unknown; value?: never }
+			| { kind: "resolved"; error?: never; value: Result }) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			if (kind === "rejected") {
+				reject(error);
+				return;
+			}
+			resolve(value);
+		};
+		const abort = () =>
+			finish({ kind: "rejected", error: createPersonCutoutAbortError() });
+		signal.addEventListener("abort", abort, { once: true });
+		promise.then(
+			(value) => finish({ kind: "resolved", value }),
+			(error: unknown) => finish({ kind: "rejected", error })
+		);
+	});
+}

--- a/qcut/electron/jianying-person-cutout/atomic-publish-lock.ts
+++ b/qcut/electron/jianying-person-cutout/atomic-publish-lock.ts
@@ -1,0 +1,111 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
+
+const LOCK_RETRY_MS = 25;
+const LOCK_WAIT_MS = 90_000;
+export const ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME = "owner.json";
+
+export interface AtomicPublishLockTiming {
+  retryMs?: number;
+  waitMs?: number;
+}
+
+interface LockOwner {
+  pid?: unknown;
+}
+
+function processExists({ pid }: { pid: number }) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function removeAbandonedLock({ lockPath }: { lockPath: string }) {
+  try {
+    const ownerValue: unknown = JSON.parse(
+      await readFile(
+        `${lockPath}/${ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME}`,
+        "utf8",
+      ),
+    );
+    const owner = ownerValue as LockOwner;
+    if (
+      typeof owner.pid !== "number" ||
+      !Number.isSafeInteger(owner.pid) ||
+      owner.pid <= 0 ||
+      processExists({ pid: owner.pid })
+    ) {
+      return false;
+    }
+    await rm(lockPath, { force: true, recursive: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function acquireDirectoryLock({
+  lockPath,
+  startedAt,
+  timing,
+}: {
+  lockPath: string;
+  startedAt: number;
+  timing: AtomicPublishLockTiming;
+}): Promise<() => Promise<void>> {
+  try {
+    await mkdir(lockPath);
+    try {
+      await writeFile(
+        `${lockPath}/${ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME}`,
+        JSON.stringify({ createdAt: Date.now(), pid: process.pid }),
+        "utf8",
+      );
+    } catch (error) {
+      await rm(lockPath, { force: true, recursive: true });
+      throw error;
+    }
+    return () => rm(lockPath, { force: true, recursive: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+
+  if (Date.now() - startedAt > (timing.waitMs ?? LOCK_WAIT_MS)) {
+    if (await removeAbandonedLock({ lockPath })) {
+      return acquireDirectoryLock({
+        lockPath,
+        startedAt: Date.now(),
+        timing,
+      });
+    }
+    throw new Error(
+      `Timed out waiting for cache publication lock: ${lockPath}`,
+    );
+  }
+  await delay(timing.retryMs ?? LOCK_RETRY_MS);
+  return acquireDirectoryLock({ lockPath, startedAt, timing });
+}
+
+export async function withAtomicPublishLock<Result>({
+  action,
+  lockPath,
+  timing = {},
+}: {
+  action: () => Promise<Result>;
+  lockPath: string;
+  timing?: AtomicPublishLockTiming;
+}) {
+  const release = await acquireDirectoryLock({
+    lockPath,
+    startedAt: Date.now(),
+    timing,
+  });
+  try {
+    return await action();
+  } finally {
+    await release();
+  }
+}

--- a/qcut/electron/jianying-person-cutout/atomic-publish-lock.ts
+++ b/qcut/electron/jianying-person-cutout/atomic-publish-lock.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { setTimeout as delay } from "node:timers/promises";
 
 const LOCK_RETRY_MS = 25;
@@ -6,106 +7,104 @@ const LOCK_WAIT_MS = 90_000;
 export const ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME = "owner.json";
 
 export interface AtomicPublishLockTiming {
-  retryMs?: number;
-  waitMs?: number;
+	retryMs?: number;
+	waitMs?: number;
 }
 
 interface LockOwner {
-  pid?: unknown;
+	pid?: unknown;
 }
 
 function processExists({ pid }: { pid: number }) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "EPERM";
-  }
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
 }
 
 async function removeAbandonedLock({ lockPath }: { lockPath: string }) {
-  try {
-    const ownerValue: unknown = JSON.parse(
-      await readFile(
-        `${lockPath}/${ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME}`,
-        "utf8",
-      ),
-    );
-    const owner = ownerValue as LockOwner;
-    if (
-      typeof owner.pid !== "number" ||
-      !Number.isSafeInteger(owner.pid) ||
-      owner.pid <= 0 ||
-      processExists({ pid: owner.pid })
-    ) {
-      return false;
-    }
-    await rm(lockPath, { force: true, recursive: true });
-    return true;
-  } catch {
-    return false;
-  }
+	try {
+		const ownerValue: unknown = JSON.parse(
+			await readFile(
+				`${lockPath}/${ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME}`,
+				"utf8"
+			)
+		);
+		const owner = ownerValue as LockOwner;
+		if (
+			typeof owner.pid !== "number" ||
+			!Number.isSafeInteger(owner.pid) ||
+			owner.pid <= 0 ||
+			processExists({ pid: owner.pid })
+		) {
+			return false;
+		}
+		const reclaimPath = `${lockPath}.reclaim.${process.pid}.${randomUUID()}`;
+		await rename(lockPath, reclaimPath);
+		await rm(reclaimPath, { force: true, recursive: true });
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 async function acquireDirectoryLock({
-  lockPath,
-  startedAt,
-  timing,
+	lockPath,
+	startedAt,
+	timing,
 }: {
-  lockPath: string;
-  startedAt: number;
-  timing: AtomicPublishLockTiming;
+	lockPath: string;
+	startedAt: number;
+	timing: AtomicPublishLockTiming;
 }): Promise<() => Promise<void>> {
-  try {
-    await mkdir(lockPath);
-    try {
-      await writeFile(
-        `${lockPath}/${ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME}`,
-        JSON.stringify({ createdAt: Date.now(), pid: process.pid }),
-        "utf8",
-      );
-    } catch (error) {
-      await rm(lockPath, { force: true, recursive: true });
-      throw error;
-    }
-    return () => rm(lockPath, { force: true, recursive: true });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-  }
+	try {
+		await mkdir(lockPath);
+		try {
+			await writeFile(
+				`${lockPath}/${ATOMIC_PUBLISH_LOCK_OWNER_FILE_NAME}`,
+				JSON.stringify({ createdAt: Date.now(), pid: process.pid }),
+				"utf8"
+			);
+		} catch (error) {
+			await rm(lockPath, { force: true, recursive: true });
+			throw error;
+		}
+		return () => rm(lockPath, { force: true, recursive: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+	}
 
-  if (Date.now() - startedAt > (timing.waitMs ?? LOCK_WAIT_MS)) {
-    if (await removeAbandonedLock({ lockPath })) {
-      return acquireDirectoryLock({
-        lockPath,
-        startedAt: Date.now(),
-        timing,
-      });
-    }
-    throw new Error(
-      `Timed out waiting for cache publication lock: ${lockPath}`,
-    );
-  }
-  await delay(timing.retryMs ?? LOCK_RETRY_MS);
-  return acquireDirectoryLock({ lockPath, startedAt, timing });
+	if (await removeAbandonedLock({ lockPath })) {
+		return acquireDirectoryLock({ lockPath, startedAt, timing });
+	}
+	if (Date.now() - startedAt > (timing.waitMs ?? LOCK_WAIT_MS)) {
+		throw new Error(
+			`Timed out waiting for cache publication lock: ${lockPath}`
+		);
+	}
+	await delay(timing.retryMs ?? LOCK_RETRY_MS);
+	return acquireDirectoryLock({ lockPath, startedAt, timing });
 }
 
 export async function withAtomicPublishLock<Result>({
-  action,
-  lockPath,
-  timing = {},
+	action,
+	lockPath,
+	timing = {},
 }: {
-  action: () => Promise<Result>;
-  lockPath: string;
-  timing?: AtomicPublishLockTiming;
+	action: () => Promise<Result>;
+	lockPath: string;
+	timing?: AtomicPublishLockTiming;
 }) {
-  const release = await acquireDirectoryLock({
-    lockPath,
-    startedAt: Date.now(),
-    timing,
-  });
-  try {
-    return await action();
-  } finally {
-    await release();
-  }
+	const release = await acquireDirectoryLock({
+		lockPath,
+		startedAt: Date.now(),
+		timing,
+	});
+	try {
+		return await action();
+	} finally {
+		await release();
+	}
 }

--- a/qcut/electron/jianying-person-cutout/bridge-resolver.ts
+++ b/qcut/electron/jianying-person-cutout/bridge-resolver.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants, existsSync } from "node:fs";
-import { access, mkdir, readFile } from "node:fs/promises";
+import { access, mkdir, readFile, rename, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -10,12 +10,7 @@ const execFileAsync = promisify(execFile);
 export const JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME =
 	"jianying-person-cutout-bridge";
 const SOURCE_RELATIVE_PATHS = [
-	path.join(
-		"electron",
-		"jianying-person-cutout",
-		"native",
-		"alpha-resize.cpp"
-	),
+	path.join("electron", "jianying-person-cutout", "native", "alpha-resize.cpp"),
 	path.join(
 		"electron",
 		"jianying-person-cutout",
@@ -55,12 +50,7 @@ const SOURCE_RELATIVE_PATHS = [
 ] as const;
 const FINGERPRINT_RELATIVE_PATHS = [
 	...SOURCE_RELATIVE_PATHS,
-	path.join(
-		"electron",
-		"jianying-person-cutout",
-		"native",
-		"alpha-resize.hpp"
-	),
+	path.join("electron", "jianying-person-cutout", "native", "alpha-resize.hpp"),
 	path.join(
 		"electron",
 		"jianying-person-cutout",
@@ -173,6 +163,7 @@ export async function compileJianyingPersonCutoutBridge({
 	);
 	if (await isExecutable({ filePath: outputPath })) return outputPath;
 	await mkdir(path.dirname(outputPath), { recursive: true });
+	const stagingPath = `${outputPath}.${randomUUID()}.tmp`;
 	await execFileAsync(
 		"xcrun",
 		[
@@ -194,12 +185,14 @@ export async function compileJianyingPersonCutoutBridge({
 			"ImageIO",
 			"-ldl",
 			"-o",
-			outputPath,
+			stagingPath,
 		],
 		{ maxBuffer: 16 * 1024 * 1024 }
 	);
-	if (!(await isExecutable({ filePath: outputPath }))) {
+	if (!(await isExecutable({ filePath: stagingPath }))) {
+		await rm(stagingPath, { force: true });
 		throw new Error("精细抠像本机桥构建后不可执行");
 	}
+	await rename(stagingPath, outputPath);
 	return outputPath;
 }

--- a/qcut/electron/jianying-person-cutout/bridge-resolver.ts
+++ b/qcut/electron/jianying-person-cutout/bridge-resolver.ts
@@ -1,0 +1,205 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants, existsSync } from "node:fs";
+import { access, mkdir, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+export const JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME =
+	"jianying-person-cutout-bridge";
+const SOURCE_RELATIVE_PATHS = [
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-resize.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-mask-fusion.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-refinement.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-temporal-stabilizer.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"matting-gru-bridge.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"metal-matting-blend.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"vision-person-segmentation.mm"
+	),
+] as const;
+const FINGERPRINT_RELATIVE_PATHS = [
+	...SOURCE_RELATIVE_PATHS,
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-resize.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-mask-fusion.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-refinement.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-temporal-stabilizer.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"metal-matting-blend.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"vision-person-segmentation.hpp"
+	),
+] as const;
+
+async function isExecutable({ filePath }: { filePath: string }) {
+	try {
+		await access(filePath, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function findProjectRoot() {
+	const candidates = [
+		process.cwd(),
+		path.resolve(__dirname, "..", ".."),
+		path.resolve(__dirname, "..", "..", ".."),
+	];
+	return (
+		candidates.find((candidate) =>
+			FINGERPRINT_RELATIVE_PATHS.every((relativePath) =>
+				existsSync(path.join(candidate, relativePath))
+			)
+		) ?? null
+	);
+}
+
+function packagedBridgePath() {
+	const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string })
+		.resourcesPath;
+	return resourcesPath
+		? path.join(resourcesPath, "bin", JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME)
+		: null;
+}
+
+export async function resolveJianyingPersonCutoutBridge() {
+	if (process.platform !== "darwin") return null;
+	const configured = process.env.QCUT_JIANYING_PERSON_CUTOUT_BRIDGE;
+	const packaged = packagedBridgePath();
+	for (const candidate of [configured, packaged]) {
+		if (candidate && (await isExecutable({ filePath: candidate }))) {
+			return candidate;
+		}
+	}
+	const projectRoot = findProjectRoot();
+	if (!projectRoot) return null;
+	const sourcePaths = FINGERPRINT_RELATIVE_PATHS.map((relativePath) =>
+		path.join(projectRoot, relativePath)
+	);
+	const sourceContents = await Promise.all(
+		sourcePaths.map((sourcePath) => readFile(sourcePath))
+	);
+	const sourceHash = createHash("sha256");
+	for (const contents of sourceContents) sourceHash.update(contents);
+	const fingerprint = sourceHash
+		.update(process.arch)
+		.digest("hex")
+		.slice(0, 16);
+	const outputPath = path.join(
+		os.homedir(),
+		"Library",
+		"Caches",
+		"QCut",
+		"jianying-person-cutout-bridge",
+		fingerprint,
+		JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME
+	);
+	if (await isExecutable({ filePath: outputPath })) return outputPath;
+	return compileJianyingPersonCutoutBridge({ projectRoot, outputPath });
+}
+
+export async function compileJianyingPersonCutoutBridge({
+	projectRoot,
+	outputPath,
+}: {
+	projectRoot: string;
+	outputPath: string;
+}) {
+	const sourcePaths = SOURCE_RELATIVE_PATHS.map((relativePath) =>
+		path.join(projectRoot, relativePath)
+	);
+	if (await isExecutable({ filePath: outputPath })) return outputPath;
+	await mkdir(path.dirname(outputPath), { recursive: true });
+	await execFileAsync(
+		"xcrun",
+		[
+			"clang++",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			...sourcePaths,
+			"-framework",
+			"OpenGL",
+			"-framework",
+			"Vision",
+			"-framework",
+			"CoreVideo",
+			"-framework",
+			"Foundation",
+			"-framework",
+			"ImageIO",
+			"-ldl",
+			"-o",
+			outputPath,
+		],
+		{ maxBuffer: 16 * 1024 * 1024 }
+	);
+	if (!(await isExecutable({ filePath: outputPath }))) {
+		throw new Error("精细抠像本机桥构建后不可执行");
+	}
+	return outputPath;
+}

--- a/qcut/electron/jianying-person-cutout/bridge-timing.ts
+++ b/qcut/electron/jianying-person-cutout/bridge-timing.ts
@@ -1,0 +1,122 @@
+const TIMING_PREFIX = "qcut-person-cutout-timing ";
+
+export interface PersonCutoutBridgeTiming {
+	alphaResizeMicros: number;
+	cacheWriteMicros: number;
+	frameCount: number;
+	gruInferenceMicros: number;
+	inputReadMicros: number;
+	nativeCanaryFrames: number;
+	nativeCanaryMicros: number;
+	outputFlushMicros: number;
+	postprocessMicros: number;
+	processingMicros: number;
+	rgbaToBgrMicros: number;
+	setupMicros: number;
+	teardownMicros: number;
+	totalMicros: number;
+	visionInferenceMicros: number;
+	wallMicros: number;
+}
+
+const TIMING_FIELDS = {
+	alphaResizeMicros: "alpha_resize_us",
+	cacheWriteMicros: "cache_write_us",
+	frameCount: "frames",
+	gruInferenceMicros: "gru_infer_us",
+	inputReadMicros: "input_read_us",
+	postprocessMicros: "postprocess_us",
+	processingMicros: "processing_us",
+	rgbaToBgrMicros: "rgba_to_bgr_us",
+	setupMicros: "setup_us",
+	totalMicros: "total_us",
+	visionInferenceMicros: "vision_infer_us",
+} as const;
+
+function readCompatibleTimingField({
+	fallbackField,
+	field,
+	value,
+}: {
+	fallbackField?: string;
+	field: string;
+	value: Record<string, unknown>;
+}) {
+	return (
+		readNonNegativeInteger({ field, value }) ??
+		(fallbackField
+			? readNonNegativeInteger({ field: fallbackField, value })
+			: null)
+	);
+}
+
+function readNonNegativeInteger({
+	field,
+	value,
+}: {
+	field: string;
+	value: Record<string, unknown>;
+}) {
+	const candidate = value[field];
+	return typeof candidate === "number" &&
+		Number.isSafeInteger(candidate) &&
+		candidate >= 0
+		? candidate
+		: null;
+}
+
+export function parsePersonCutoutBridgeTiming({
+	line,
+}: {
+	line: string;
+}): PersonCutoutBridgeTiming | null {
+	if (!line.startsWith(TIMING_PREFIX)) return null;
+	try {
+		const parsed: unknown = JSON.parse(line.slice(TIMING_PREFIX.length));
+		if (!parsed || typeof parsed !== "object") return null;
+		const value = parsed as Record<string, unknown>;
+		if (value.schema !== 1) return null;
+		const entries = Object.entries(TIMING_FIELDS).map(
+			([key, field]) => [key, readNonNegativeInteger({ field, value })] as const
+		);
+		if (entries.some(([, fieldValue]) => fieldValue === null)) return null;
+		const requiredTiming = Object.fromEntries(entries) as Omit<
+			PersonCutoutBridgeTiming,
+			| "nativeCanaryFrames"
+			| "nativeCanaryMicros"
+			| "outputFlushMicros"
+			| "teardownMicros"
+			| "wallMicros"
+		>;
+		const nativeCanaryFrames = readCompatibleTimingField({
+			fallbackField: "native_validation_frames",
+			field: "native_canary_frames",
+			value,
+		});
+		const nativeCanaryMicros = readCompatibleTimingField({
+			fallbackField: "native_validation_us",
+			field: "native_canary_us",
+			value,
+		});
+		if (nativeCanaryFrames === null || nativeCanaryMicros === null) return null;
+		const timing: PersonCutoutBridgeTiming = {
+			...requiredTiming,
+			nativeCanaryFrames,
+			nativeCanaryMicros,
+			outputFlushMicros:
+				readNonNegativeInteger({ field: "output_flush_us", value }) ?? 0,
+			teardownMicros:
+				readNonNegativeInteger({ field: "teardown_us", value }) ?? 0,
+			wallMicros:
+				readNonNegativeInteger({ field: "wall_us", value }) ??
+				requiredTiming.totalMicros,
+		};
+		return timing.frameCount > 0 &&
+			timing.processingMicros <= timing.totalMicros &&
+			timing.totalMicros <= timing.wallMicros
+			? timing
+			: null;
+	} catch {
+		return null;
+	}
+}

--- a/qcut/electron/jianying-person-cutout/frame-count.ts
+++ b/qcut/electron/jianying-person-cutout/frame-count.ts
@@ -1,0 +1,54 @@
+export interface PersonCutoutFrameCountExpectation {
+	count: number;
+	source: "counted" | "declared" | "estimated";
+	tolerance: number;
+}
+
+function positiveFrameCount({ value }: { value?: string }) {
+	if (!value) return null;
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function resolvePersonCutoutFrameCountExpectation({
+	declaredFrames,
+	duration,
+	frameRate,
+	readFrames,
+}: {
+	declaredFrames?: string;
+	duration: number;
+	frameRate: number;
+	readFrames?: string;
+}): PersonCutoutFrameCountExpectation {
+	const counted = positiveFrameCount({ value: readFrames });
+	if (counted !== null) {
+		return { count: counted, source: "counted", tolerance: 0 };
+	}
+	const declared = positiveFrameCount({ value: declaredFrames });
+	if (declared !== null) {
+		return { count: declared, source: "declared", tolerance: 0 };
+	}
+	const estimated = Math.round(duration * frameRate);
+	if (!Number.isSafeInteger(estimated) || estimated <= 0) {
+		throw new Error("无法读取视频帧数");
+	}
+	return { count: estimated, source: "estimated", tolerance: 1 };
+}
+
+export function validatePersonCutoutAlphaFrameCount({
+	actualFrameCount,
+	expectation,
+}: {
+	actualFrameCount: number;
+	expectation: PersonCutoutFrameCountExpectation;
+}) {
+	const isValidActual =
+		Number.isSafeInteger(actualFrameCount) && actualFrameCount > 0;
+	const difference = Math.abs(actualFrameCount - expectation.count);
+	if (!isValidActual || difference > expectation.tolerance) {
+		throw new Error(
+			`人物蒙版帧数不完整（源视频 ${expectation.count} 帧，蒙版 ${actualFrameCount} 帧）`
+		);
+	}
+}

--- a/qcut/electron/jianying-person-cutout/inference-pipeline.ts
+++ b/qcut/electron/jianying-person-cutout/inference-pipeline.ts
@@ -2,45 +2,45 @@ import type { PersonCutoutModelRoute } from "./mask-cache.js";
 import { executePersonCutoutRouteWithFallback } from "./model-route-fallback.js";
 
 interface PersonCutoutInferenceRuntime {
-  modelRoute: PersonCutoutModelRoute;
+	modelRoute: PersonCutoutModelRoute;
 }
 
 export async function executePersonCutoutInferencePipeline<
-  Runtime extends PersonCutoutInferenceRuntime,
-  InferenceResult,
-  FinalResult,
+	Runtime extends PersonCutoutInferenceRuntime,
+	InferenceResult,
+	FinalResult,
 >({
-  executeInference,
-  fallbackRuntimes = [],
-  finalize,
-  onFallback,
-  portraitRuntime,
-  selectedRuntime,
+	executeInference,
+	fallbackRuntimes = [],
+	finalize,
+	onFallback,
+	portraitRuntime,
+	selectedRuntime,
 }: {
-  executeInference: (runtime: Runtime) => Promise<InferenceResult>;
-  fallbackRuntimes?: Runtime[];
-  finalize: (input: {
-    inferenceResult: InferenceResult;
-    runtime: Runtime;
-  }) => Promise<FinalResult>;
-  onFallback?: (event: {
-    error: unknown;
-    failedRuntime: Runtime;
-    nextRuntime: Runtime;
-  }) => void;
-  portraitRuntime: Runtime;
-  selectedRuntime: Runtime;
+	executeInference: (runtime: Runtime) => Promise<InferenceResult>;
+	fallbackRuntimes?: Runtime[];
+	finalize: (input: {
+		inferenceResult: InferenceResult;
+		runtime: Runtime;
+	}) => Promise<FinalResult>;
+	onFallback?: (event: {
+		error: unknown;
+		failedRuntime: Runtime;
+		nextRuntime: Runtime;
+	}) => void;
+	portraitRuntime: Runtime;
+	selectedRuntime: Runtime;
 }) {
-  const inferenceAttempt = await executePersonCutoutRouteWithFallback({
-    execute: executeInference,
-    fallbackRuntimes,
-    onFallback,
-    portraitRuntime,
-    selectedRuntime,
-  });
-  const finalResult = await finalize({
-    inferenceResult: inferenceAttempt.result,
-    runtime: inferenceAttempt.runtime,
-  });
-  return { finalResult, inferenceAttempt };
+	const inferenceAttempt = await executePersonCutoutRouteWithFallback({
+		execute: executeInference,
+		fallbackRuntimes,
+		onFallback,
+		portraitRuntime,
+		selectedRuntime,
+	});
+	const finalResult = await finalize({
+		inferenceResult: inferenceAttempt.result,
+		runtime: inferenceAttempt.runtime,
+	});
+	return { finalResult, inferenceAttempt };
 }

--- a/qcut/electron/jianying-person-cutout/inference-pipeline.ts
+++ b/qcut/electron/jianying-person-cutout/inference-pipeline.ts
@@ -1,0 +1,46 @@
+import type { PersonCutoutModelRoute } from "./mask-cache.js";
+import { executePersonCutoutRouteWithFallback } from "./model-route-fallback.js";
+
+interface PersonCutoutInferenceRuntime {
+  modelRoute: PersonCutoutModelRoute;
+}
+
+export async function executePersonCutoutInferencePipeline<
+  Runtime extends PersonCutoutInferenceRuntime,
+  InferenceResult,
+  FinalResult,
+>({
+  executeInference,
+  fallbackRuntimes = [],
+  finalize,
+  onFallback,
+  portraitRuntime,
+  selectedRuntime,
+}: {
+  executeInference: (runtime: Runtime) => Promise<InferenceResult>;
+  fallbackRuntimes?: Runtime[];
+  finalize: (input: {
+    inferenceResult: InferenceResult;
+    runtime: Runtime;
+  }) => Promise<FinalResult>;
+  onFallback?: (event: {
+    error: unknown;
+    failedRuntime: Runtime;
+    nextRuntime: Runtime;
+  }) => void;
+  portraitRuntime: Runtime;
+  selectedRuntime: Runtime;
+}) {
+  const inferenceAttempt = await executePersonCutoutRouteWithFallback({
+    execute: executeInference,
+    fallbackRuntimes,
+    onFallback,
+    portraitRuntime,
+    selectedRuntime,
+  });
+  const finalResult = await finalize({
+    inferenceResult: inferenceAttempt.result,
+    runtime: inferenceAttempt.runtime,
+  });
+  return { finalResult, inferenceAttempt };
+}

--- a/qcut/electron/jianying-person-cutout/mask-cache.ts
+++ b/qcut/electron/jianying-person-cutout/mask-cache.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
 import {
 	mkdir,
+	readdir,
 	readFile,
 	realpath,
 	rename,
@@ -31,6 +32,7 @@ const CACHE_ROOT = path.join(
 	"person-cutout",
 	`v${CACHE_VERSION}`
 );
+const MAX_CACHE_BYTES = 20 * 1024 * 1024 * 1024;
 
 export interface PersonCutoutCacheSettings {
 	edgeShift: number;
@@ -273,6 +275,52 @@ export async function createPersonCutoutMaskCacheBuild({
 	};
 }
 
+async function prunePersonCutoutMaskCache({
+	keepBytes,
+	keepCacheKey,
+}: {
+	keepBytes: number;
+	keepCacheKey: string;
+}) {
+	const cacheRoot = getCacheRoot();
+	let names: string[];
+	try {
+		names = await readdir(cacheRoot);
+	} catch {
+		return;
+	}
+	const entries: Array<{
+		bytes: number;
+		createdAt: number;
+		directory: string;
+	}> = [];
+	for (const name of names) {
+		if (name === keepCacheKey || name.startsWith(".")) continue;
+		const directory = path.join(cacheRoot, name);
+		try {
+			const manifestValue: unknown = JSON.parse(
+				await readFile(path.join(directory, "manifest.json"), "utf8")
+			);
+			if (!isManifest({ value: manifestValue })) continue;
+			const manifest = manifestValue as PersonCutoutMaskCacheManifest;
+			entries.push({
+				bytes: manifest.alphaBytes,
+				createdAt: Date.parse(manifest.createdAt) || 0,
+				directory,
+			});
+		} catch {
+			// 读不出 manifest 的目录交给 inspect 当缓存未命中处理。
+		}
+	}
+	entries.sort((a, b) => a.createdAt - b.createdAt);
+	let totalBytes = entries.reduce((sum, entry) => sum + entry.bytes, keepBytes);
+	for (const entry of entries) {
+		if (totalBytes <= MAX_CACHE_BYTES) return;
+		await rm(entry.directory, { force: true, recursive: true });
+		totalBytes -= entry.bytes;
+	}
+}
+
 export async function commitPersonCutoutMaskCache({
 	buildDirectory,
 	frameCount,
@@ -306,6 +354,14 @@ export async function commitPersonCutoutMaskCache({
 	const target = cachePaths({ cacheKey });
 	await rm(target.directory, { force: true, recursive: true });
 	await rename(buildDirectory, target.directory);
+	try {
+		await prunePersonCutoutMaskCache({
+			keepBytes: alphaBytes,
+			keepCacheKey: cacheKey,
+		});
+	} catch {
+		// 清理是尽力而为，失败不影响本次缓存提交。
+	}
 	return {
 		alphaPath: target.alphaPath,
 		cacheKey,

--- a/qcut/electron/jianying-person-cutout/mask-cache.ts
+++ b/qcut/electron/jianying-person-cutout/mask-cache.ts
@@ -11,9 +11,18 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createPersonCutoutAbortError } from "./abort.js";
+import {
+	defaultPersonCutoutPipelineDescriptor,
+	type PersonCutoutModelRoute,
+	type PersonCutoutPipelineDescriptor,
+	type PersonCutoutPipelineId,
+	type PersonCutoutProviderId,
+	type PersonCutoutRefinementProvider,
+} from "./pipeline-descriptor.js";
 import type { TemattingBlendImplementation } from "./tematting-blend.js";
 
-const CACHE_VERSION = 3;
+const CACHE_VERSION = 4;
 const CACHE_ROOT = path.join(
 	os.homedir(),
 	"Library",
@@ -37,7 +46,10 @@ export interface PersonCutoutCacheIdentity {
 	modelName: string;
 	modelRoute: PersonCutoutModelRoute;
 	modelSha256: string;
+	pipelineId: PersonCutoutPipelineId;
 	processorSha256: string;
+	providerId: PersonCutoutProviderId;
+	refinementProvider: PersonCutoutRefinementProvider;
 	settings: PersonCutoutCacheSettings;
 	sourceMtimeMs: number;
 	sourcePath: string;
@@ -45,11 +57,6 @@ export interface PersonCutoutCacheIdentity {
 	sourceSize: number;
 	width: number;
 }
-
-export type PersonCutoutModelRoute =
-	| "portrait-gru"
-	| "video-object"
-	| "saliency-script";
 
 export interface PersonCutoutMaskCacheEntry {
 	alphaPath: string;
@@ -60,6 +67,7 @@ export interface PersonCutoutMaskCacheEntry {
 
 interface PersonCutoutMaskCacheManifest {
 	alphaBytes: number;
+	alphaSha256: string;
 	cacheKey: string;
 	createdAt: string;
 	frameCount: number;
@@ -74,13 +82,15 @@ function getCacheRoot() {
 function stableIdentity({ identity }: { identity: PersonCutoutCacheIdentity }) {
 	return JSON.stringify({
 		version: CACHE_VERSION,
-		blendImplementation: identity.blendImplementation,
 		frameRate: identity.frameRate,
 		height: identity.height,
 		modelName: identity.modelName,
 		modelRoute: identity.modelRoute,
 		modelSha256: identity.modelSha256,
+		pipelineId: identity.pipelineId,
 		processorSha256: identity.processorSha256,
+		providerId: identity.providerId,
+		refinementProvider: identity.refinementProvider,
 		settings: identity.settings,
 		sourceContentSha256: identity.sourceContentSha256,
 		sourceSize: identity.sourceSize,
@@ -98,10 +108,16 @@ export function createPersonCutoutCacheKey({
 		.digest("hex");
 }
 
-function hashSourceContent({ filePath }: { filePath: string }) {
+function hashFileContents({
+	filePath,
+	signal,
+}: {
+	filePath: string;
+	signal?: AbortSignal;
+}) {
 	return new Promise<string>((resolve, reject) => {
 		const hash = createHash("sha256");
-		const input = createReadStream(filePath);
+		const input = createReadStream(filePath, { signal });
 		input.on("data", (chunk) => hash.update(chunk));
 		input.once("error", reject);
 		input.once("end", () => resolve(hash.digest("hex")));
@@ -115,8 +131,10 @@ export async function createPersonCutoutCacheIdentity({
 	modelName,
 	modelRoute,
 	modelSha256,
+	pipelineDescriptor,
 	processorSha256,
 	settings,
+	signal,
 	sourcePath,
 	width,
 }: {
@@ -126,26 +144,40 @@ export async function createPersonCutoutCacheIdentity({
 	modelName: string;
 	modelRoute?: PersonCutoutModelRoute;
 	modelSha256: string;
+	pipelineDescriptor?: PersonCutoutPipelineDescriptor;
 	processorSha256: string;
 	settings: PersonCutoutCacheSettings;
+	signal?: AbortSignal;
 	sourcePath: string;
 	width: number;
 }): Promise<PersonCutoutCacheIdentity> {
 	const resolvedSourcePath = await realpath(sourcePath);
 	const sourceStat = await stat(resolvedSourcePath);
+	const resolvedModelRoute =
+		modelRoute ?? pipelineDescriptor?.modelRoute ?? "portrait-gru";
+	const resolvedPipelineDescriptor =
+		pipelineDescriptor ??
+		defaultPersonCutoutPipelineDescriptor({ modelRoute: resolvedModelRoute });
+	if (resolvedPipelineDescriptor.modelRoute !== resolvedModelRoute) {
+		throw new Error("人物抠像管线与模型路线不一致");
+	}
 	return {
 		blendImplementation,
 		frameRate,
 		height,
 		modelName,
-		modelRoute: modelRoute ?? "portrait-gru",
+		modelRoute: resolvedModelRoute,
 		modelSha256,
+		pipelineId: resolvedPipelineDescriptor.pipelineId,
 		processorSha256,
+		providerId: resolvedPipelineDescriptor.providerId,
+		refinementProvider: resolvedPipelineDescriptor.refinementProvider,
 		settings,
 		sourceMtimeMs: sourceStat.mtimeMs,
 		sourcePath: resolvedSourcePath,
-		sourceContentSha256: await hashSourceContent({
+		sourceContentSha256: await hashFileContents({
 			filePath: resolvedSourcePath,
+			signal,
 		}),
 		sourceSize: sourceStat.size,
 		width,
@@ -168,6 +200,7 @@ function isManifest({ value }: { value: unknown }) {
 		manifest.version === CACHE_VERSION &&
 		typeof manifest.cacheKey === "string" &&
 		typeof manifest.alphaBytes === "number" &&
+		typeof manifest.alphaSha256 === "string" &&
 		typeof manifest.frameCount === "number" &&
 		manifest.frameCount > 0 &&
 		Boolean(manifest.identity)
@@ -176,8 +209,10 @@ function isManifest({ value }: { value: unknown }) {
 
 export async function inspectPersonCutoutMaskCache({
 	identity,
+	signal,
 }: {
 	identity: PersonCutoutCacheIdentity;
+	signal?: AbortSignal;
 }): Promise<PersonCutoutMaskCacheEntry | null> {
 	const cacheKey = createPersonCutoutCacheKey({ identity });
 	const paths = cachePaths({ cacheKey });
@@ -200,6 +235,12 @@ export async function inspectPersonCutoutMaskCache({
 		) {
 			return null;
 		}
+		if (
+			manifest.alphaSha256 !==
+			(await hashFileContents({ filePath: paths.alphaPath, signal }))
+		) {
+			return null;
+		}
 		return {
 			alphaPath: paths.alphaPath,
 			cacheKey,
@@ -207,6 +248,7 @@ export async function inspectPersonCutoutMaskCache({
 			frameCount: manifest.frameCount,
 		};
 	} catch {
+		if (signal?.aborted) throw createPersonCutoutAbortError();
 		return null;
 	}
 }
@@ -249,6 +291,7 @@ export async function commitPersonCutoutMaskCache({
 	}
 	const manifest: PersonCutoutMaskCacheManifest = {
 		alphaBytes,
+		alphaSha256: await hashFileContents({ filePath: alphaPath }),
 		cacheKey,
 		createdAt: new Date().toISOString(),
 		frameCount,
@@ -270,6 +313,14 @@ export async function commitPersonCutoutMaskCache({
 		frameCount,
 	};
 }
+
+export type {
+	PersonCutoutModelRoute,
+	PersonCutoutPipelineDescriptor,
+	PersonCutoutPipelineId,
+	PersonCutoutProviderId,
+	PersonCutoutRefinementProvider,
+} from "./pipeline-descriptor.js";
 
 export async function discardPersonCutoutMaskCacheBuild({
 	buildDirectory,

--- a/qcut/electron/jianying-person-cutout/mask-cache.ts
+++ b/qcut/electron/jianying-person-cutout/mask-cache.ts
@@ -1,0 +1,280 @@
+import { createHash, randomUUID } from "node:crypto";
+import { createReadStream } from "node:fs";
+import {
+	mkdir,
+	readFile,
+	realpath,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { TemattingBlendImplementation } from "./tematting-blend.js";
+
+const CACHE_VERSION = 3;
+const CACHE_ROOT = path.join(
+	os.homedir(),
+	"Library",
+	"Caches",
+	"QCut",
+	"person-cutout",
+	`v${CACHE_VERSION}`
+);
+
+export interface PersonCutoutCacheSettings {
+	edgeShift: number;
+	feather: number;
+	temporalSmoothing: number;
+	threshold: number;
+}
+
+export interface PersonCutoutCacheIdentity {
+	blendImplementation: TemattingBlendImplementation;
+	frameRate: number;
+	height: number;
+	modelName: string;
+	modelRoute: PersonCutoutModelRoute;
+	modelSha256: string;
+	processorSha256: string;
+	settings: PersonCutoutCacheSettings;
+	sourceMtimeMs: number;
+	sourcePath: string;
+	sourceContentSha256: string;
+	sourceSize: number;
+	width: number;
+}
+
+export type PersonCutoutModelRoute =
+	| "portrait-gru"
+	| "video-object"
+	| "saliency-script";
+
+export interface PersonCutoutMaskCacheEntry {
+	alphaPath: string;
+	cacheKey: string;
+	directory: string;
+	frameCount: number;
+}
+
+interface PersonCutoutMaskCacheManifest {
+	alphaBytes: number;
+	cacheKey: string;
+	createdAt: string;
+	frameCount: number;
+	identity: PersonCutoutCacheIdentity;
+	version: number;
+}
+
+function getCacheRoot() {
+	return process.env.QCUT_PERSON_CUTOUT_CACHE_ROOT || CACHE_ROOT;
+}
+
+function stableIdentity({ identity }: { identity: PersonCutoutCacheIdentity }) {
+	return JSON.stringify({
+		version: CACHE_VERSION,
+		blendImplementation: identity.blendImplementation,
+		frameRate: identity.frameRate,
+		height: identity.height,
+		modelName: identity.modelName,
+		modelRoute: identity.modelRoute,
+		modelSha256: identity.modelSha256,
+		processorSha256: identity.processorSha256,
+		settings: identity.settings,
+		sourceContentSha256: identity.sourceContentSha256,
+		sourceSize: identity.sourceSize,
+		width: identity.width,
+	});
+}
+
+export function createPersonCutoutCacheKey({
+	identity,
+}: {
+	identity: PersonCutoutCacheIdentity;
+}) {
+	return createHash("sha256")
+		.update(stableIdentity({ identity }))
+		.digest("hex");
+}
+
+function hashSourceContent({ filePath }: { filePath: string }) {
+	return new Promise<string>((resolve, reject) => {
+		const hash = createHash("sha256");
+		const input = createReadStream(filePath);
+		input.on("data", (chunk) => hash.update(chunk));
+		input.once("error", reject);
+		input.once("end", () => resolve(hash.digest("hex")));
+	});
+}
+
+export async function createPersonCutoutCacheIdentity({
+	blendImplementation,
+	frameRate,
+	height,
+	modelName,
+	modelRoute,
+	modelSha256,
+	processorSha256,
+	settings,
+	sourcePath,
+	width,
+}: {
+	blendImplementation: TemattingBlendImplementation;
+	frameRate: number;
+	height: number;
+	modelName: string;
+	modelRoute?: PersonCutoutModelRoute;
+	modelSha256: string;
+	processorSha256: string;
+	settings: PersonCutoutCacheSettings;
+	sourcePath: string;
+	width: number;
+}): Promise<PersonCutoutCacheIdentity> {
+	const resolvedSourcePath = await realpath(sourcePath);
+	const sourceStat = await stat(resolvedSourcePath);
+	return {
+		blendImplementation,
+		frameRate,
+		height,
+		modelName,
+		modelRoute: modelRoute ?? "portrait-gru",
+		modelSha256,
+		processorSha256,
+		settings,
+		sourceMtimeMs: sourceStat.mtimeMs,
+		sourcePath: resolvedSourcePath,
+		sourceContentSha256: await hashSourceContent({
+			filePath: resolvedSourcePath,
+		}),
+		sourceSize: sourceStat.size,
+		width,
+	};
+}
+
+function cachePaths({ cacheKey }: { cacheKey: string }) {
+	const directory = path.join(getCacheRoot(), cacheKey);
+	return {
+		alphaPath: path.join(directory, "alpha.gray"),
+		directory,
+		manifestPath: path.join(directory, "manifest.json"),
+	};
+}
+
+function isManifest({ value }: { value: unknown }) {
+	if (!value || typeof value !== "object") return false;
+	const manifest = value as Partial<PersonCutoutMaskCacheManifest>;
+	return (
+		manifest.version === CACHE_VERSION &&
+		typeof manifest.cacheKey === "string" &&
+		typeof manifest.alphaBytes === "number" &&
+		typeof manifest.frameCount === "number" &&
+		manifest.frameCount > 0 &&
+		Boolean(manifest.identity)
+	);
+}
+
+export async function inspectPersonCutoutMaskCache({
+	identity,
+}: {
+	identity: PersonCutoutCacheIdentity;
+}): Promise<PersonCutoutMaskCacheEntry | null> {
+	const cacheKey = createPersonCutoutCacheKey({ identity });
+	const paths = cachePaths({ cacheKey });
+	try {
+		const [manifestText, alphaStat] = await Promise.all([
+			readFile(paths.manifestPath, "utf8"),
+			stat(paths.alphaPath),
+		]);
+		const manifestValue: unknown = JSON.parse(manifestText);
+		if (!isManifest({ value: manifestValue })) return null;
+		const manifest = manifestValue as PersonCutoutMaskCacheManifest;
+		const expectedBytes =
+			manifest.frameCount * identity.width * identity.height;
+		if (
+			manifest.cacheKey !== cacheKey ||
+			manifest.alphaBytes !== expectedBytes ||
+			alphaStat.size !== expectedBytes ||
+			stableIdentity({ identity: manifest.identity }) !==
+				stableIdentity({ identity })
+		) {
+			return null;
+		}
+		return {
+			alphaPath: paths.alphaPath,
+			cacheKey,
+			directory: paths.directory,
+			frameCount: manifest.frameCount,
+		};
+	} catch {
+		return null;
+	}
+}
+
+export async function createPersonCutoutMaskCacheBuild({
+	identity,
+}: {
+	identity: PersonCutoutCacheIdentity;
+}) {
+	const cacheKey = createPersonCutoutCacheKey({ identity });
+	const cacheRoot = getCacheRoot();
+	await mkdir(cacheRoot, { recursive: true });
+	const directory = path.join(
+		cacheRoot,
+		`.building-${cacheKey}-${process.pid}-${randomUUID()}`
+	);
+	await mkdir(directory);
+	return {
+		alphaPath: path.join(directory, "alpha.gray"),
+		cacheKey,
+		directory,
+	};
+}
+
+export async function commitPersonCutoutMaskCache({
+	buildDirectory,
+	frameCount,
+	identity,
+}: {
+	buildDirectory: string;
+	frameCount: number;
+	identity: PersonCutoutCacheIdentity;
+}): Promise<PersonCutoutMaskCacheEntry> {
+	const cacheKey = createPersonCutoutCacheKey({ identity });
+	const alphaBytes = frameCount * identity.width * identity.height;
+	const alphaPath = path.join(buildDirectory, "alpha.gray");
+	const alphaStat = await stat(alphaPath);
+	if (frameCount <= 0 || alphaStat.size !== alphaBytes) {
+		throw new Error("人物蒙版缓存不完整，已停止导出");
+	}
+	const manifest: PersonCutoutMaskCacheManifest = {
+		alphaBytes,
+		cacheKey,
+		createdAt: new Date().toISOString(),
+		frameCount,
+		identity,
+		version: CACHE_VERSION,
+	};
+	await writeFile(
+		path.join(buildDirectory, "manifest.json"),
+		`${JSON.stringify(manifest, null, 2)}\n`,
+		"utf8"
+	);
+	const target = cachePaths({ cacheKey });
+	await rm(target.directory, { force: true, recursive: true });
+	await rename(buildDirectory, target.directory);
+	return {
+		alphaPath: target.alphaPath,
+		cacheKey,
+		directory: target.directory,
+		frameCount,
+	};
+}
+
+export async function discardPersonCutoutMaskCacheBuild({
+	buildDirectory,
+}: {
+	buildDirectory: string;
+}) {
+	await rm(buildDirectory, { force: true, recursive: true });
+}

--- a/qcut/electron/jianying-person-cutout/model-route-fallback.ts
+++ b/qcut/electron/jianying-person-cutout/model-route-fallback.ts
@@ -1,58 +1,58 @@
 import type { PersonCutoutModelRoute } from "./mask-cache.js";
 
 interface RouteRuntime {
-  modelRoute: PersonCutoutModelRoute;
+	modelRoute: PersonCutoutModelRoute;
 }
 
 export async function executePersonCutoutRouteWithFallback<
-  Runtime extends RouteRuntime,
-  Result,
+	Runtime extends RouteRuntime,
+	Result,
 >({
-  execute,
-  fallbackRuntimes = [],
-  onFallback,
-  portraitRuntime,
-  selectedRuntime,
+	execute,
+	fallbackRuntimes = [],
+	onFallback,
+	portraitRuntime,
+	selectedRuntime,
 }: {
-  execute: (runtime: Runtime) => Promise<Result>;
-  fallbackRuntimes?: Runtime[];
-  onFallback?: (event: {
-    error: unknown;
-    failedRuntime: Runtime;
-    nextRuntime: Runtime;
-  }) => void;
-  portraitRuntime: Runtime;
-  selectedRuntime: Runtime;
+	execute: (runtime: Runtime) => Promise<Result>;
+	fallbackRuntimes?: Runtime[];
+	onFallback?: (event: {
+		error: unknown;
+		failedRuntime: Runtime;
+		nextRuntime: Runtime;
+	}) => void;
+	portraitRuntime: Runtime;
+	selectedRuntime: Runtime;
 }) {
-  const orderedRuntimes = [
-    selectedRuntime,
-    ...fallbackRuntimes,
-    portraitRuntime,
-  ].filter((runtime, index, runtimes) => runtimes.indexOf(runtime) === index);
-  const executeAt = async ({
-    index,
-  }: {
-    index: number;
-  }): Promise<{
-    didFallback: boolean;
-    result: Result;
-    runtime: Runtime;
-  }> => {
-    const runtime = orderedRuntimes[index];
-    if (!runtime) throw new Error("人物抠像运行时链为空");
-    try {
-      return {
-        didFallback: index > 0,
-        result: await execute(runtime),
-        runtime,
-      };
-    } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") throw error;
-      const nextRuntime = orderedRuntimes[index + 1];
-      if (!nextRuntime || runtime.modelRoute === "portrait-gru") throw error;
-      onFallback?.({ error, failedRuntime: runtime, nextRuntime });
-      return executeAt({ index: index + 1 });
-    }
-  };
-  return executeAt({ index: 0 });
+	const orderedRuntimes = [
+		selectedRuntime,
+		...fallbackRuntimes,
+		portraitRuntime,
+	].filter((runtime, index, runtimes) => runtimes.indexOf(runtime) === index);
+	const executeAt = async ({
+		index,
+	}: {
+		index: number;
+	}): Promise<{
+		didFallback: boolean;
+		result: Result;
+		runtime: Runtime;
+	}> => {
+		const runtime = orderedRuntimes[index];
+		if (!runtime) throw new Error("人物抠像运行时链为空");
+		try {
+			return {
+				didFallback: index > 0,
+				result: await execute(runtime),
+				runtime,
+			};
+		} catch (error) {
+			if (error instanceof Error && error.name === "AbortError") throw error;
+			const nextRuntime = orderedRuntimes[index + 1];
+			if (!nextRuntime || runtime.modelRoute === "portrait-gru") throw error;
+			onFallback?.({ error, failedRuntime: runtime, nextRuntime });
+			return executeAt({ index: index + 1 });
+		}
+	};
+	return executeAt({ index: 0 });
 }

--- a/qcut/electron/jianying-person-cutout/model-route-fallback.ts
+++ b/qcut/electron/jianying-person-cutout/model-route-fallback.ts
@@ -1,41 +1,58 @@
 import type { PersonCutoutModelRoute } from "./mask-cache.js";
 
 interface RouteRuntime {
-	modelRoute: PersonCutoutModelRoute;
+  modelRoute: PersonCutoutModelRoute;
 }
 
 export async function executePersonCutoutRouteWithFallback<
-	Runtime extends RouteRuntime,
-	Result,
+  Runtime extends RouteRuntime,
+  Result,
 >({
-	execute,
-	onFallback,
-	portraitRuntime,
-	selectedRuntime,
+  execute,
+  fallbackRuntimes = [],
+  onFallback,
+  portraitRuntime,
+  selectedRuntime,
 }: {
-	execute: (runtime: Runtime) => Promise<Result>;
-	onFallback?: (error: unknown) => void;
-	portraitRuntime: Runtime;
-	selectedRuntime: Runtime;
+  execute: (runtime: Runtime) => Promise<Result>;
+  fallbackRuntimes?: Runtime[];
+  onFallback?: (event: {
+    error: unknown;
+    failedRuntime: Runtime;
+    nextRuntime: Runtime;
+  }) => void;
+  portraitRuntime: Runtime;
+  selectedRuntime: Runtime;
 }) {
-	try {
-		return {
-			didFallback: false,
-			result: await execute(selectedRuntime),
-			runtime: selectedRuntime,
-		};
-	} catch (error) {
-		if (
-			selectedRuntime.modelRoute === "portrait-gru" ||
-			(error instanceof Error && error.name === "AbortError")
-		) {
-			throw error;
-		}
-		onFallback?.(error);
-		return {
-			didFallback: true,
-			result: await execute(portraitRuntime),
-			runtime: portraitRuntime,
-		};
-	}
+  const orderedRuntimes = [
+    selectedRuntime,
+    ...fallbackRuntimes,
+    portraitRuntime,
+  ].filter((runtime, index, runtimes) => runtimes.indexOf(runtime) === index);
+  const executeAt = async ({
+    index,
+  }: {
+    index: number;
+  }): Promise<{
+    didFallback: boolean;
+    result: Result;
+    runtime: Runtime;
+  }> => {
+    const runtime = orderedRuntimes[index];
+    if (!runtime) throw new Error("人物抠像运行时链为空");
+    try {
+      return {
+        didFallback: index > 0,
+        result: await execute(runtime),
+        runtime,
+      };
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") throw error;
+      const nextRuntime = orderedRuntimes[index + 1];
+      if (!nextRuntime || runtime.modelRoute === "portrait-gru") throw error;
+      onFallback?.({ error, failedRuntime: runtime, nextRuntime });
+      return executeAt({ index: index + 1 });
+    }
+  };
+  return executeAt({ index: 0 });
 }

--- a/qcut/electron/jianying-person-cutout/model-route-fallback.ts
+++ b/qcut/electron/jianying-person-cutout/model-route-fallback.ts
@@ -1,0 +1,41 @@
+import type { PersonCutoutModelRoute } from "./mask-cache.js";
+
+interface RouteRuntime {
+	modelRoute: PersonCutoutModelRoute;
+}
+
+export async function executePersonCutoutRouteWithFallback<
+	Runtime extends RouteRuntime,
+	Result,
+>({
+	execute,
+	onFallback,
+	portraitRuntime,
+	selectedRuntime,
+}: {
+	execute: (runtime: Runtime) => Promise<Result>;
+	onFallback?: (error: unknown) => void;
+	portraitRuntime: Runtime;
+	selectedRuntime: Runtime;
+}) {
+	try {
+		return {
+			didFallback: false,
+			result: await execute(selectedRuntime),
+			runtime: selectedRuntime,
+		};
+	} catch (error) {
+		if (
+			selectedRuntime.modelRoute === "portrait-gru" ||
+			(error instanceof Error && error.name === "AbortError")
+		) {
+			throw error;
+		}
+		onFallback?.(error);
+		return {
+			didFallback: true,
+			result: await execute(portraitRuntime),
+			runtime: portraitRuntime,
+		};
+	}
+}

--- a/qcut/electron/jianying-person-cutout/model-router.ts
+++ b/qcut/electron/jianying-person-cutout/model-router.ts
@@ -4,6 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { createJianyingPortraitAdjustmentProvider } from "../jianying-portrait-adjustment-runtime/provider.js";
+import {
+	createPersonCutoutAbortError,
+	throwIfPersonCutoutAborted,
+} from "./abort.js";
 import type { PersonCutoutModelRoute } from "./mask-cache.js";
 
 const execFileAsync = promisify(execFile);
@@ -11,6 +15,140 @@ const SAMPLE_POSITIONS = [0.15, 0.35, 0.6] as const;
 export const JIANYING_FACE_SAMPLE_RATIO_THRESHOLD = 0.5;
 
 export type PersonCutoutRoutingMode = PersonCutoutModelRoute | "auto";
+
+export type PersonCutoutRouteReason =
+	| "face-ratio-at-or-above-threshold"
+	| "face-ratio-below-threshold"
+	| "face-sampling-failed"
+	| "incomplete-face-samples"
+	| "invalid-face-sample-counts"
+	| "invalid-video-metadata"
+	| "video-object-unavailable";
+
+export interface PersonCutoutRouteDecision {
+	confidence: "fail-closed" | "sampled-face-ratio";
+	expectedSampleCount: number;
+	facePositiveSampleCount: number;
+	faceSampleRatio: number | null;
+	reason: PersonCutoutRouteReason;
+	route: PersonCutoutModelRoute;
+	threshold: number;
+	validSampleCount: number;
+}
+
+interface FaceSampleRequest {
+	frameNumber: number;
+	height: number;
+	rgba: Uint8Array;
+	width: number;
+}
+
+interface FaceSampleDetector {
+	clear: () => Promise<void>;
+	detectFace: (request: FaceSampleRequest) => Promise<boolean>;
+}
+
+interface ExtractFaceSampleRequest {
+	ffmpegPath: string;
+	outputPath: string;
+	sampleIndex: number;
+	signal?: AbortSignal;
+	sourcePath: string;
+	timestamp: number;
+}
+
+export interface PersonCutoutModelRouterDependencies {
+	createFaceDetector: () => FaceSampleDetector;
+	createTemporaryDirectory: () => Promise<string>;
+	extractSample: (request: ExtractFaceSampleRequest) => Promise<void>;
+	readSample: ({ filePath }: { filePath: string }) => Promise<Uint8Array>;
+	removeTemporaryDirectory: ({
+		directory,
+	}: {
+		directory: string;
+	}) => Promise<void>;
+	warn: (message: string, error: unknown) => void;
+}
+
+const defaultDependencies: PersonCutoutModelRouterDependencies = {
+	createFaceDetector: () => {
+		const provider = createJianyingPortraitAdjustmentProvider();
+		return {
+			clear: () => provider.clear(),
+			detectFace: async ({ frameNumber, height, rgba, width }) => {
+				const result = await provider.detect({
+					frameNumber,
+					height,
+					personBindings: [],
+					rgba,
+					width,
+				});
+				return result.faces.length > 0;
+			},
+		};
+	},
+	createTemporaryDirectory: () =>
+		mkdtemp(path.join(os.tmpdir(), "qcut-matting-route-")),
+	extractSample: async ({
+		ffmpegPath,
+		outputPath,
+		signal,
+		sourcePath,
+		timestamp,
+	}) => {
+		await execFileAsync(
+			ffmpegPath,
+			[
+				"-y",
+				"-v",
+				"error",
+				"-ss",
+				String(timestamp),
+				"-i",
+				sourcePath,
+				"-frames:v",
+				"1",
+				"-pix_fmt",
+				"rgba",
+				"-f",
+				"rawvideo",
+				outputPath,
+			],
+			{ maxBuffer: 4 * 1024 * 1024, signal }
+		);
+	},
+	readSample: async ({ filePath }) => new Uint8Array(await readFile(filePath)),
+	removeTemporaryDirectory: async ({ directory }) => {
+		await rm(directory, { force: true, recursive: true });
+	},
+	warn: (message, error) => console.warn(message, error),
+};
+
+function failClosedDecision({
+	expectedSampleCount,
+	facePositiveSampleCount = 0,
+	reason,
+	validSampleCount = 0,
+}: {
+	expectedSampleCount: number;
+	facePositiveSampleCount?: number;
+	reason: Exclude<
+		PersonCutoutRouteReason,
+		"face-ratio-at-or-above-threshold" | "face-ratio-below-threshold"
+	>;
+	validSampleCount?: number;
+}): PersonCutoutRouteDecision {
+	return {
+		confidence: "fail-closed",
+		expectedSampleCount,
+		facePositiveSampleCount,
+		faceSampleRatio: null,
+		reason,
+		route: "portrait-gru",
+		threshold: JIANYING_FACE_SAMPLE_RATIO_THRESHOLD,
+		validSampleCount,
+	};
+}
 
 export function resolvePersonCutoutRoutingMode({
 	automaticRoutingEnabled,
@@ -30,119 +168,323 @@ export function resolvePersonCutoutRoutingMode({
 }
 
 export function selectPersonCutoutRoute({
+	expectedSampleCount,
 	facePositiveSampleCount,
-	personPositiveSampleCount,
-	personValidSampleCount,
 	validSampleCount,
-	videoObjectAvailable,
+	videoObjectCandidateAvailable,
 }: {
+	expectedSampleCount: number;
 	facePositiveSampleCount: number;
-	personPositiveSampleCount: number;
-	personValidSampleCount: number;
 	validSampleCount: number;
-	videoObjectAvailable: boolean;
-}): PersonCutoutModelRoute {
-	if (!videoObjectAvailable || validSampleCount === 0) return "portrait-gru";
+	videoObjectCandidateAvailable: boolean;
+}): PersonCutoutRouteDecision {
+	if (!videoObjectCandidateAvailable) {
+		return failClosedDecision({
+			expectedSampleCount,
+			facePositiveSampleCount,
+			reason: "video-object-unavailable",
+			validSampleCount,
+		});
+	}
+	const countsAreValid =
+		Number.isSafeInteger(expectedSampleCount) &&
+		expectedSampleCount > 0 &&
+		Number.isSafeInteger(validSampleCount) &&
+		validSampleCount >= 0 &&
+		validSampleCount <= expectedSampleCount &&
+		Number.isSafeInteger(facePositiveSampleCount) &&
+		facePositiveSampleCount >= 0 &&
+		facePositiveSampleCount <= validSampleCount;
+	if (!countsAreValid) {
+		return failClosedDecision({
+			expectedSampleCount,
+			facePositiveSampleCount,
+			reason: "invalid-face-sample-counts",
+			validSampleCount,
+		});
+	}
+	if (validSampleCount !== expectedSampleCount) {
+		return failClosedDecision({
+			expectedSampleCount,
+			facePositiveSampleCount,
+			reason: "incomplete-face-samples",
+			validSampleCount,
+		});
+	}
 	const faceSampleRatio = facePositiveSampleCount / validSampleCount;
-	if (faceSampleRatio >= JIANYING_FACE_SAMPLE_RATIO_THRESHOLD) {
-		return "portrait-gru";
+	const keepsPortrait = faceSampleRatio >= JIANYING_FACE_SAMPLE_RATIO_THRESHOLD;
+	return {
+		confidence: "sampled-face-ratio",
+		expectedSampleCount,
+		facePositiveSampleCount,
+		faceSampleRatio,
+		reason: keepsPortrait
+			? "face-ratio-at-or-above-threshold"
+			: "face-ratio-below-threshold",
+		route: keepsPortrait ? "portrait-gru" : "video-object",
+		threshold: JIANYING_FACE_SAMPLE_RATIO_THRESHOLD,
+		validSampleCount,
+	};
+}
+
+function validVideoMetadata({
+	duration,
+	frameRate,
+	height,
+	width,
+}: {
+	duration: number;
+	frameRate: number;
+	height: number;
+	width: number;
+}) {
+	return (
+		Number.isFinite(duration) &&
+		duration > 0 &&
+		Number.isFinite(frameRate) &&
+		frameRate > 0 &&
+		Number.isSafeInteger(width) &&
+		width > 0 &&
+		Number.isSafeInteger(height) &&
+		height > 0 &&
+		Number.isSafeInteger(width * height * 4)
+	);
+}
+
+function warnWithoutThrowing({
+	dependencies,
+	error,
+	message,
+}: {
+	dependencies: PersonCutoutModelRouterDependencies;
+	error: unknown;
+	message: string;
+}) {
+	try {
+		dependencies.warn(message, error);
+	} catch {
+		// Diagnostics must not change the fail-closed routing result.
 	}
-	if (
-		personValidSampleCount !== validSampleCount ||
-		personPositiveSampleCount > 0
-	) {
-		return "portrait-gru";
+}
+
+async function detectFaceSamples({
+	dependencies,
+	detector,
+	frameRate,
+	height,
+	sampleFrames,
+	sampleIndex = 0,
+	sampleTimes,
+	signal,
+	width,
+}: {
+	dependencies: PersonCutoutModelRouterDependencies;
+	detector: FaceSampleDetector;
+	frameRate: number;
+	height: number;
+	sampleFrames: Array<Uint8Array | null>;
+	sampleIndex?: number;
+	sampleTimes: number[];
+	signal?: AbortSignal;
+	width: number;
+}): Promise<Array<boolean | null>> {
+	throwIfPersonCutoutAborted({ signal });
+	if (sampleIndex >= sampleFrames.length) return [];
+	const rgba = sampleFrames[sampleIndex];
+	if (!rgba) {
+		return [
+			null,
+			...(await detectFaceSamples({
+				dependencies,
+				detector,
+				frameRate,
+				height,
+				sampleFrames,
+				sampleIndex: sampleIndex + 1,
+				sampleTimes,
+				signal,
+				width,
+			})),
+		];
 	}
-	return "video-object";
+	let detected: boolean | null = null;
+	try {
+		detected = await detector.detectFace({
+			frameNumber: Math.round(sampleTimes[sampleIndex] * frameRate),
+			height,
+			rgba,
+			width,
+		});
+	} catch (error) {
+		if (signal?.aborted) throw createPersonCutoutAbortError();
+		warnWithoutThrowing({
+			dependencies,
+			error,
+			message: `Person cutout face sample ${sampleIndex} failed.`,
+		});
+	}
+	throwIfPersonCutoutAborted({ signal });
+	return [
+		detected,
+		...(await detectFaceSamples({
+			dependencies,
+			detector,
+			frameRate,
+			height,
+			sampleFrames,
+			sampleIndex: sampleIndex + 1,
+			sampleTimes,
+			signal,
+			width,
+		})),
+	];
 }
 
 export async function detectPersonCutoutModelRoute({
+	dependencies = defaultDependencies,
 	duration,
 	ffmpegPath,
 	frameRate,
 	height,
-	videoObjectAvailable,
+	signal,
+	videoObjectCandidateAvailable,
 	sourcePath,
 	width,
 }: {
+	dependencies?: PersonCutoutModelRouterDependencies;
 	duration: number;
 	ffmpegPath: string;
 	frameRate: number;
 	height: number;
-	videoObjectAvailable: boolean;
+	signal?: AbortSignal;
+	videoObjectCandidateAvailable: boolean;
 	sourcePath: string;
 	width: number;
-}): Promise<PersonCutoutModelRoute> {
-	if (!videoObjectAvailable) return "portrait-gru";
-	const directory = await mkdtemp(
-		path.join(os.tmpdir(), "qcut-matting-route-")
-	);
-	const sampleTimes = SAMPLE_POSITIONS.map((position) =>
-		Math.max(0, Math.min(duration - 1 / frameRate, duration * position))
-	);
-	const samplePaths = sampleTimes.map((_, index) =>
-		path.join(directory, `sample-${index}.rgba`)
-	);
-	const provider = createJianyingPortraitAdjustmentProvider();
+}): Promise<PersonCutoutRouteDecision> {
+	throwIfPersonCutoutAborted({ signal });
+	const expectedSampleCount = SAMPLE_POSITIONS.length;
+	if (!videoObjectCandidateAvailable) {
+		return selectPersonCutoutRoute({
+			expectedSampleCount,
+			facePositiveSampleCount: 0,
+			validSampleCount: 0,
+			videoObjectCandidateAvailable,
+		});
+	}
+	if (!validVideoMetadata({ duration, frameRate, height, width })) {
+		return failClosedDecision({
+			expectedSampleCount,
+			reason: "invalid-video-metadata",
+		});
+	}
+
+	let detector: FaceSampleDetector | null = null;
+	let directory: string | null = null;
+	let decision = failClosedDecision({
+		expectedSampleCount,
+		reason: "face-sampling-failed",
+	});
 	try {
-		await Promise.all(
-			sampleTimes.map((timestamp, index) =>
-				execFileAsync(
+		const workingDirectory = await dependencies.createTemporaryDirectory();
+		directory = workingDirectory;
+		throwIfPersonCutoutAborted({ signal });
+		const activeDetector = dependencies.createFaceDetector();
+		detector = activeDetector;
+		throwIfPersonCutoutAborted({ signal });
+		const sampleTimes = SAMPLE_POSITIONS.map((position) =>
+			Math.max(0, Math.min(duration - 1 / frameRate, duration * position))
+		);
+		const samplePaths = sampleTimes.map((_, index) =>
+			path.join(workingDirectory, `sample-${index}.rgba`)
+		);
+		const extractionResults = await Promise.allSettled(
+			sampleTimes.map((timestamp, sampleIndex) =>
+				dependencies.extractSample({
 					ffmpegPath,
-					[
-						"-y",
-						"-v",
-						"error",
-						"-ss",
-						String(timestamp),
-						"-i",
-						sourcePath,
-						"-frames:v",
-						"1",
-						"-pix_fmt",
-						"rgba",
-						"-f",
-						"rawvideo",
-						samplePaths[index],
-					],
-					{ maxBuffer: 4 * 1024 * 1024 }
-				)
+					outputPath: samplePaths[sampleIndex],
+					sampleIndex,
+					signal,
+					sourcePath,
+					timestamp,
+				})
 			)
 		);
-		let validSampleCount = 0;
-		let facePositiveSampleCount = 0;
+		throwIfPersonCutoutAborted({ signal });
 		const expectedBytes = width * height * 4;
-		for (let index = 0; index < samplePaths.length; index += 1) {
-			const rgba = new Uint8Array(await readFile(samplePaths[index]));
-			if (rgba.byteLength !== expectedBytes) continue;
-			validSampleCount += 1;
-			const result = await provider.detect({
-				frameNumber: Math.round(sampleTimes[index] * frameRate),
-				height,
-				personBindings: [],
-				rgba,
-				width,
-			});
-			if (result.faces.length === 0) continue;
-			facePositiveSampleCount += 1;
-			break;
-		}
-		return selectPersonCutoutRoute({
+		const sampleFrames = await Promise.all(
+			samplePaths.map(async (filePath, sampleIndex) => {
+				if (extractionResults[sampleIndex]?.status !== "fulfilled") return null;
+				try {
+					const rgba = await dependencies.readSample({ filePath });
+					return rgba.byteLength === expectedBytes ? rgba : null;
+				} catch (error) {
+					warnWithoutThrowing({
+						dependencies,
+						error,
+						message: `Person cutout face sample ${sampleIndex} failed.`,
+					});
+					return null;
+				}
+			})
+		);
+		const faceSampleResults = await detectFaceSamples({
+			dependencies,
+			detector: activeDetector,
+			frameRate,
+			height,
+			sampleFrames,
+			sampleTimes,
+			signal,
+			width,
+		});
+		const validSampleCount = faceSampleResults.filter(
+			(result) => result !== null
+		).length;
+		const facePositiveSampleCount = faceSampleResults.filter(
+			(result) => result === true
+		).length;
+		decision = selectPersonCutoutRoute({
+			expectedSampleCount,
 			facePositiveSampleCount,
-			// Face absence is not proof that a frame has no person.
-			personPositiveSampleCount: 0,
-			personValidSampleCount: 0,
 			validSampleCount,
-			videoObjectAvailable,
+			videoObjectCandidateAvailable,
 		});
 	} catch (error) {
-		console.warn(
-			"Person cutout model routing failed; keeping the portrait GRU route.",
-			error
-		);
-		return "portrait-gru";
+		if (
+			signal?.aborted ||
+			(error instanceof Error && error.name === "AbortError")
+		) {
+			throw createPersonCutoutAbortError();
+		}
+		warnWithoutThrowing({
+			dependencies,
+			error,
+			message:
+				"Person cutout model routing failed; keeping the portrait GRU route.",
+		});
 	} finally {
-		await provider.clear();
-		await rm(directory, { force: true, recursive: true });
+		const cleanupTasks: Array<() => Promise<void>> = [];
+		const detectorToClear = detector;
+		if (detectorToClear) {
+			cleanupTasks.push(() => detectorToClear.clear());
+		}
+		const directoryToRemove = directory;
+		if (directoryToRemove) {
+			cleanupTasks.push(() =>
+				dependencies.removeTemporaryDirectory({ directory: directoryToRemove })
+			);
+		}
+		const cleanupResults = await Promise.allSettled(
+			cleanupTasks.map((cleanup) => Promise.resolve().then(cleanup))
+		);
+		for (const cleanupResult of cleanupResults) {
+			if (cleanupResult.status === "fulfilled") continue;
+			warnWithoutThrowing({
+				dependencies,
+				error: cleanupResult.reason,
+				message: "Person cutout model routing cleanup failed.",
+			});
+		}
 	}
+	return decision;
 }

--- a/qcut/electron/jianying-person-cutout/model-router.ts
+++ b/qcut/electron/jianying-person-cutout/model-router.ts
@@ -1,0 +1,148 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { createJianyingPortraitAdjustmentProvider } from "../jianying-portrait-adjustment-runtime/provider.js";
+import type { PersonCutoutModelRoute } from "./mask-cache.js";
+
+const execFileAsync = promisify(execFile);
+const SAMPLE_POSITIONS = [0.15, 0.35, 0.6] as const;
+export const JIANYING_FACE_SAMPLE_RATIO_THRESHOLD = 0.5;
+
+export type PersonCutoutRoutingMode = PersonCutoutModelRoute | "auto";
+
+export function resolvePersonCutoutRoutingMode({
+	automaticRoutingEnabled,
+	requestedRoute,
+}: {
+	automaticRoutingEnabled: boolean;
+	requestedRoute?: string;
+}): PersonCutoutRoutingMode {
+	if (
+		requestedRoute === "portrait-gru" ||
+		requestedRoute === "video-object" ||
+		requestedRoute === "saliency-script"
+	) {
+		return requestedRoute;
+	}
+	return automaticRoutingEnabled ? "auto" : "portrait-gru";
+}
+
+export function selectPersonCutoutRoute({
+	facePositiveSampleCount,
+	personPositiveSampleCount,
+	personValidSampleCount,
+	validSampleCount,
+	videoObjectAvailable,
+}: {
+	facePositiveSampleCount: number;
+	personPositiveSampleCount: number;
+	personValidSampleCount: number;
+	validSampleCount: number;
+	videoObjectAvailable: boolean;
+}): PersonCutoutModelRoute {
+	if (!videoObjectAvailable || validSampleCount === 0) return "portrait-gru";
+	const faceSampleRatio = facePositiveSampleCount / validSampleCount;
+	if (faceSampleRatio >= JIANYING_FACE_SAMPLE_RATIO_THRESHOLD) {
+		return "portrait-gru";
+	}
+	if (
+		personValidSampleCount !== validSampleCount ||
+		personPositiveSampleCount > 0
+	) {
+		return "portrait-gru";
+	}
+	return "video-object";
+}
+
+export async function detectPersonCutoutModelRoute({
+	duration,
+	ffmpegPath,
+	frameRate,
+	height,
+	videoObjectAvailable,
+	sourcePath,
+	width,
+}: {
+	duration: number;
+	ffmpegPath: string;
+	frameRate: number;
+	height: number;
+	videoObjectAvailable: boolean;
+	sourcePath: string;
+	width: number;
+}): Promise<PersonCutoutModelRoute> {
+	if (!videoObjectAvailable) return "portrait-gru";
+	const directory = await mkdtemp(
+		path.join(os.tmpdir(), "qcut-matting-route-")
+	);
+	const sampleTimes = SAMPLE_POSITIONS.map((position) =>
+		Math.max(0, Math.min(duration - 1 / frameRate, duration * position))
+	);
+	const samplePaths = sampleTimes.map((_, index) =>
+		path.join(directory, `sample-${index}.rgba`)
+	);
+	const provider = createJianyingPortraitAdjustmentProvider();
+	try {
+		await Promise.all(
+			sampleTimes.map((timestamp, index) =>
+				execFileAsync(
+					ffmpegPath,
+					[
+						"-y",
+						"-v",
+						"error",
+						"-ss",
+						String(timestamp),
+						"-i",
+						sourcePath,
+						"-frames:v",
+						"1",
+						"-pix_fmt",
+						"rgba",
+						"-f",
+						"rawvideo",
+						samplePaths[index],
+					],
+					{ maxBuffer: 4 * 1024 * 1024 }
+				)
+			)
+		);
+		let validSampleCount = 0;
+		let facePositiveSampleCount = 0;
+		const expectedBytes = width * height * 4;
+		for (let index = 0; index < samplePaths.length; index += 1) {
+			const rgba = new Uint8Array(await readFile(samplePaths[index]));
+			if (rgba.byteLength !== expectedBytes) continue;
+			validSampleCount += 1;
+			const result = await provider.detect({
+				frameNumber: Math.round(sampleTimes[index] * frameRate),
+				height,
+				personBindings: [],
+				rgba,
+				width,
+			});
+			if (result.faces.length === 0) continue;
+			facePositiveSampleCount += 1;
+			break;
+		}
+		return selectPersonCutoutRoute({
+			facePositiveSampleCount,
+			// Face absence is not proof that a frame has no person.
+			personPositiveSampleCount: 0,
+			personValidSampleCount: 0,
+			validSampleCount,
+			videoObjectAvailable,
+		});
+	} catch (error) {
+		console.warn(
+			"Person cutout model routing failed; keeping the portrait GRU route.",
+			error
+		);
+		return "portrait-gru";
+	} finally {
+		await provider.clear();
+		await rm(directory, { force: true, recursive: true });
+	}
+}

--- a/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.cpp
@@ -1,0 +1,28 @@
+#include "alpha-mask-fusion.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace qcut::matting {
+
+std::vector<std::uint8_t>
+fusePersonAlpha(const std::vector<std::uint8_t> &portraitAlpha,
+                const std::vector<std::uint8_t> &visionAlpha,
+                PersonAlphaFusionConfig config) {
+  if (portraitAlpha.empty() || portraitAlpha.size() != visionAlpha.size() ||
+      !std::isfinite(config.visionConfidenceMultiplier) ||
+      config.visionConfidenceMultiplier <= 0.0F) {
+    throw std::invalid_argument("invalid person alpha fusion input");
+  }
+  std::vector<std::uint8_t> fused(portraitAlpha.size());
+  for (std::size_t index = 0; index < portraitAlpha.size(); ++index) {
+    const auto boostedVision = static_cast<std::uint8_t>(std::min(
+        255.0F, std::round(visionAlpha[index] *
+                           config.visionConfidenceMultiplier)));
+    fused[index] = std::max(portraitAlpha[index], boostedVision);
+  }
+  return fused;
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.cpp
@@ -25,4 +25,17 @@ fusePersonAlpha(const std::vector<std::uint8_t> &portraitAlpha,
   return fused;
 }
 
+void composeSourceAlphaInPlace(const std::vector<std::uint8_t> &rgba,
+                               std::vector<std::uint8_t> &matteAlpha) {
+  if (matteAlpha.empty() || rgba.size() != matteAlpha.size() * 4U) {
+    throw std::invalid_argument("invalid source alpha composition input");
+  }
+  for (std::size_t index = 0; index < matteAlpha.size(); ++index) {
+    const auto sourceAlpha = static_cast<unsigned int>(rgba[index * 4U + 3U]);
+    const auto matte = static_cast<unsigned int>(matteAlpha[index]);
+    matteAlpha[index] = static_cast<std::uint8_t>(
+        (sourceAlpha * matte + 127U) / 255U);
+  }
+}
+
 } // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.hpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.hpp
@@ -14,4 +14,7 @@ std::vector<std::uint8_t> fusePersonAlpha(
     const std::vector<std::uint8_t> &visionAlpha,
     PersonAlphaFusionConfig config = {});
 
+void composeSourceAlphaInPlace(const std::vector<std::uint8_t> &rgba,
+                               std::vector<std::uint8_t> &matteAlpha);
+
 } // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.hpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace qcut::matting {
+
+struct PersonAlphaFusionConfig {
+  float visionConfidenceMultiplier = 2.0F;
+};
+
+std::vector<std::uint8_t> fusePersonAlpha(
+    const std::vector<std::uint8_t> &portraitAlpha,
+    const std::vector<std::uint8_t> &visionAlpha,
+    PersonAlphaFusionConfig config = {});
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.test.cpp
@@ -1,0 +1,23 @@
+#include "alpha-mask-fusion.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+int main() {
+  const auto fused = qcut::matting::fusePersonAlpha(
+      std::vector<std::uint8_t>{0, 40, 180, 255},
+      std::vector<std::uint8_t>{20, 80, 120, 200});
+  assert((fused == std::vector<std::uint8_t>{40, 160, 240, 255}));
+
+  bool rejected = false;
+  try {
+    static_cast<void>(qcut::matting::fusePersonAlpha(
+        std::vector<std::uint8_t>{0}, std::vector<std::uint8_t>{0, 1}));
+  } catch (const std::invalid_argument &) {
+    rejected = true;
+  }
+  assert(rejected);
+  return 0;
+}

--- a/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-mask-fusion.test.cpp
@@ -11,10 +11,30 @@ int main() {
       std::vector<std::uint8_t>{20, 80, 120, 200});
   assert((fused == std::vector<std::uint8_t>{40, 160, 240, 255}));
 
+  std::vector<std::uint8_t> composed{255, 128, 64};
+  qcut::matting::composeSourceAlphaInPlace(
+      std::vector<std::uint8_t>{
+          10, 20, 30, 255,
+          40, 50, 60, 128,
+          70, 80, 90, 0,
+      },
+      composed);
+  assert((composed == std::vector<std::uint8_t>{255, 64, 0}));
+
   bool rejected = false;
   try {
     static_cast<void>(qcut::matting::fusePersonAlpha(
         std::vector<std::uint8_t>{0}, std::vector<std::uint8_t>{0, 1}));
+  } catch (const std::invalid_argument &) {
+    rejected = true;
+  }
+  assert(rejected);
+
+  rejected = false;
+  try {
+    std::vector<std::uint8_t> alpha{255};
+    qcut::matting::composeSourceAlphaInPlace(
+        std::vector<std::uint8_t>{0, 0, 0}, alpha);
   } catch (const std::invalid_argument &) {
     rejected = true;
   }

--- a/qcut/electron/jianying-person-cutout/native/alpha-refinement.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-refinement.cpp
@@ -1,0 +1,126 @@
+#include "alpha-refinement.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace {
+
+std::vector<float> morphAlpha(const std::vector<float> &input, int width,
+                              int height, int radius, bool dilate) {
+  if (radius == 0) {
+    return input;
+  }
+  std::vector<float> horizontal(input.size());
+  std::vector<float> output(input.size());
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      float value = dilate ? 0.0F : 1.0F;
+      for (int sampleX = std::max(0, x - radius);
+           sampleX <= std::min(width - 1, x + radius); ++sampleX) {
+        const float sample =
+            input[static_cast<std::size_t>(y) * width + sampleX];
+        value = dilate ? std::max(value, sample) : std::min(value, sample);
+      }
+      horizontal[static_cast<std::size_t>(y) * width + x] = value;
+    }
+  }
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      float value = dilate ? 0.0F : 1.0F;
+      for (int sampleY = std::max(0, y - radius);
+           sampleY <= std::min(height - 1, y + radius); ++sampleY) {
+        const float sample =
+            horizontal[static_cast<std::size_t>(sampleY) * width + x];
+        value = dilate ? std::max(value, sample) : std::min(value, sample);
+      }
+      output[static_cast<std::size_t>(y) * width + x] = value;
+    }
+  }
+  return output;
+}
+
+} // namespace
+
+namespace qcut::matting {
+
+std::vector<std::uint8_t> applyJianyingPortraitBorderLut(
+    const std::vector<std::uint8_t> &input) {
+  static const std::array<std::uint8_t, 256> lut = [] {
+    constexpr float slope = 8.0F;
+    constexpr float center = 0.65F;
+    constexpr float halfPi = 1.57079632679489661923F;
+    const float halfWidth = halfPi / slope;
+    std::array<std::uint8_t, 256> values{};
+    for (std::size_t index = 0; index < values.size(); ++index) {
+      const float normalized = static_cast<float>(
+          static_cast<double>(index) * (1.0 / 255.0));
+      if (normalized < center - halfWidth) {
+        values[index] = 0;
+        continue;
+      }
+      if (normalized > center + halfWidth) {
+        values[index] = 255;
+        continue;
+      }
+      const float mapped = static_cast<float>(
+          static_cast<double>(std::sin((normalized - center) * slope)) * 0.5 +
+          0.5);
+      values[index] = static_cast<std::uint8_t>(mapped * 255.0F);
+    }
+    return values;
+  }();
+
+  std::vector<std::uint8_t> output(input.size());
+  for (std::size_t index = 0; index < input.size(); ++index) {
+    output[index] = lut[input[index]];
+  }
+  return output;
+}
+
+std::vector<std::uint8_t>
+refineAlpha(const std::vector<std::uint8_t> &input,
+            std::vector<float> &temporalState, int width, int height,
+            float threshold, float temporalSmoothing, float edgeShift,
+            float feather) {
+  std::vector<float> current(input.size());
+  for (std::size_t index = 0; index < input.size(); ++index) {
+    current[index] = static_cast<float>(input[index]) / 255.0F;
+  }
+  if (temporalState.size() != current.size()) {
+    temporalState = current;
+  } else {
+    for (std::size_t index = 0; index < current.size(); ++index) {
+      temporalState[index] = temporalState[index] * temporalSmoothing +
+                             current[index] * (1.0F - temporalSmoothing);
+    }
+  }
+  const int radius =
+      std::min(12, static_cast<int>(std::round(std::abs(edgeShift))));
+  const auto shifted =
+      morphAlpha(temporalState, width, height, radius, edgeShift > 0.0F);
+  if (std::abs(threshold - 0.5F) < 0.0001F && feather == 0.0F) {
+    std::vector<std::uint8_t> output(input.size());
+    for (std::size_t index = 0; index < shifted.size(); ++index) {
+      output[index] = static_cast<std::uint8_t>(
+          std::round(std::clamp(shifted[index], 0.0F, 1.0F) * 255.0F));
+    }
+    return output;
+  }
+  const float transition =
+      std::min(0.45F, 0.04F + std::max(0.0F, feather) * 0.04F);
+  const float lower = threshold - transition;
+  const float upper = threshold + transition;
+  std::vector<std::uint8_t> output(input.size());
+  for (std::size_t index = 0; index < shifted.size(); ++index) {
+    const float normalized =
+        std::clamp((shifted[index] - lower) /
+                       std::max(0.0001F, upper - lower),
+                   0.0F, 1.0F);
+    const float alpha = normalized * normalized * (3.0F - 2.0F * normalized);
+    output[index] = static_cast<std::uint8_t>(std::round(alpha * 255.0F));
+  }
+  return output;
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-refinement.hpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-refinement.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace qcut::matting {
+
+std::vector<std::uint8_t> applyJianyingPortraitBorderLut(
+    const std::vector<std::uint8_t> &input);
+
+std::vector<std::uint8_t>
+refineAlpha(const std::vector<std::uint8_t> &input,
+            std::vector<float> &temporalState, int width, int height,
+            float threshold, float temporalSmoothing, float edgeShift,
+            float feather);
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-refinement.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-refinement.test.cpp
@@ -1,0 +1,34 @@
+#include "alpha-refinement.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+int main() {
+  const auto jianyingBorder = qcut::matting::applyJianyingPortraitBorderLut(
+      {0, 64, 96, 112, 115, 116, 117, 128, 155, 165, 166, 167, 192, 214,
+       215, 216, 224, 255});
+  assert(jianyingBorder ==
+         std::vector<std::uint8_t>({0, 0, 0, 0, 0, 0, 0, 9, 85, 124, 128,
+                                    132, 221, 254, 254, 255, 255, 255}));
+
+  std::vector<float> temporalState;
+  const std::vector<std::uint8_t> source = {0, 64, 128, 255};
+  const auto unchanged = qcut::matting::refineAlpha(
+      source, temporalState, 2, 2, 0.5F, 0.0F, 0.0F, 0.0F);
+  assert(unchanged == source);
+
+  temporalState.clear();
+  const auto shifted = qcut::matting::refineAlpha(
+      source, temporalState, 2, 2, 0.7F, 0.0F, 0.0F, 2.0F);
+  assert(shifted[2] < source[2]);
+  assert(shifted[3] == 255);
+
+  temporalState.clear();
+  const auto first = qcut::matting::refineAlpha(
+      {255}, temporalState, 1, 1, 0.5F, 0.5F, 0.0F, 0.0F);
+  const auto second = qcut::matting::refineAlpha(
+      {0}, temporalState, 1, 1, 0.5F, 0.5F, 0.0F, 0.0F);
+  assert(first[0] == 255);
+  assert(second[0] == 128);
+}

--- a/qcut/electron/jianying-person-cutout/native/alpha-resize.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-resize.cpp
@@ -1,0 +1,54 @@
+#include "alpha-resize.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace qcut::matting {
+
+std::vector<std::uint8_t>
+resizeAlphaBilinear(const std::vector<std::uint8_t> &source, int sourceWidth,
+                    int sourceHeight, int targetWidth, int targetHeight) {
+  if (sourceWidth <= 0 || sourceHeight <= 0 || targetWidth <= 0 ||
+      targetHeight <= 0 ||
+      source.size() != static_cast<std::size_t>(sourceWidth) * sourceHeight) {
+    throw std::invalid_argument("invalid alpha resize dimensions");
+  }
+  std::vector<std::uint8_t> target(static_cast<std::size_t>(targetWidth) *
+                                   targetHeight);
+  for (int targetY = 0; targetY < targetHeight; ++targetY) {
+    const float sourceY =
+        (static_cast<float>(targetY) + 0.5F) * sourceHeight / targetHeight -
+        0.5F;
+    const int top = std::clamp(static_cast<int>(std::floor(sourceY)), 0,
+                               sourceHeight - 1);
+    const int bottom = std::min(top + 1, sourceHeight - 1);
+    const float verticalWeight = std::clamp(sourceY - top, 0.0F, 1.0F);
+    for (int targetX = 0; targetX < targetWidth; ++targetX) {
+      const float sourceX =
+          (static_cast<float>(targetX) + 0.5F) * sourceWidth / targetWidth -
+          0.5F;
+      const int left = std::clamp(static_cast<int>(std::floor(sourceX)), 0,
+                                  sourceWidth - 1);
+      const int right = std::min(left + 1, sourceWidth - 1);
+      const float horizontalWeight = std::clamp(sourceX - left, 0.0F, 1.0F);
+      const float topValue =
+          source[static_cast<std::size_t>(top) * sourceWidth + left] *
+              (1.0F - horizontalWeight) +
+          source[static_cast<std::size_t>(top) * sourceWidth + right] *
+              horizontalWeight;
+      const float bottomValue =
+          source[static_cast<std::size_t>(bottom) * sourceWidth + left] *
+              (1.0F - horizontalWeight) +
+          source[static_cast<std::size_t>(bottom) * sourceWidth + right] *
+              horizontalWeight;
+      target[static_cast<std::size_t>(targetY) * targetWidth + targetX] =
+          static_cast<std::uint8_t>(std::round(
+              topValue * (1.0F - verticalWeight) +
+              bottomValue * verticalWeight));
+    }
+  }
+  return target;
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-resize.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-resize.cpp
@@ -14,6 +14,9 @@ resizeAlphaBilinear(const std::vector<std::uint8_t> &source, int sourceWidth,
       source.size() != static_cast<std::size_t>(sourceWidth) * sourceHeight) {
     throw std::invalid_argument("invalid alpha resize dimensions");
   }
+  if (sourceWidth == targetWidth && sourceHeight == targetHeight) {
+    return source;
+  }
   std::vector<std::uint8_t> target(static_cast<std::size_t>(targetWidth) *
                                    targetHeight);
   for (int targetY = 0; targetY < targetHeight; ++targetY) {

--- a/qcut/electron/jianying-person-cutout/native/alpha-resize.hpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-resize.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace qcut::matting {
+
+std::vector<std::uint8_t>
+resizeAlphaBilinear(const std::vector<std::uint8_t> &source, int sourceWidth,
+                    int sourceHeight, int targetWidth, int targetHeight);
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-resize.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-resize.test.cpp
@@ -3,11 +3,26 @@
 #include <cassert>
 #include <cstdint>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 int main() {
   const std::vector<std::uint8_t> source{0, 64, 128, 255};
   assert(qcut::matting::resizeAlphaBilinear(source, 2, 2, 2, 2) == source);
+
+  std::uint32_t state = 0x9e3779b9U;
+  for (const auto &[width, height] :
+       std::vector<std::pair<int, int>>{
+           {1, 1}, {3, 5}, {17, 9}, {64, 33}, {360, 640}}) {
+    std::vector<std::uint8_t> sameSize(
+        static_cast<std::size_t>(width) * height);
+    for (auto &value : sameSize) {
+      state = state * 1'664'525U + 1'013'904'223U;
+      value = static_cast<std::uint8_t>(state >> 24U);
+    }
+    assert(qcut::matting::resizeAlphaBilinear(sameSize, width, height, width,
+                                               height) == sameSize);
+  }
 
   const auto resized =
       qcut::matting::resizeAlphaBilinear(source, 2, 2, 4, 4);

--- a/qcut/electron/jianying-person-cutout/native/alpha-resize.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-resize.test.cpp
@@ -1,0 +1,26 @@
+#include "alpha-resize.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+int main() {
+  const std::vector<std::uint8_t> source{0, 64, 128, 255};
+  assert(qcut::matting::resizeAlphaBilinear(source, 2, 2, 2, 2) == source);
+
+  const auto resized =
+      qcut::matting::resizeAlphaBilinear(source, 2, 2, 4, 4);
+  assert(resized.size() == 16);
+  assert(resized.front() == 0);
+  assert(resized.back() == 255);
+
+  bool rejected = false;
+  try {
+    static_cast<void>(qcut::matting::resizeAlphaBilinear(source, 3, 2, 4, 4));
+  } catch (const std::invalid_argument &) {
+    rejected = true;
+  }
+  assert(rejected);
+  return 0;
+}

--- a/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.cpp
@@ -23,6 +23,7 @@ struct ForegroundCentroid {
 struct RegisteredFrame {
   const TemporalForegroundFrameView *frame;
   MotionTranslation translation;
+  float alphaDecay;
 };
 
 int colorDistance(const std::vector<std::uint8_t> &first,
@@ -125,6 +126,9 @@ MotionTranslation estimateTranslation(
     const TemporalForegroundFrameView &target,
     const TemporalForegroundFrameView &candidate, int width, int height,
     const TemporalForegroundConfig &config) {
+  if (config.maximumMotionPixels == 0) {
+    return {};
+  }
   const auto targetCentroid =
       foregroundCentroid(*target.alpha, width, height, config);
   const auto candidateCentroid =
@@ -260,6 +264,9 @@ std::vector<std::uint8_t> stabilizeTemporalForeground(
         .frame = &candidate,
         .translation =
             estimateTranslation(target, candidate, width, height, config),
+        .alphaDecay = std::pow(
+            config.decayPerFrame,
+            static_cast<float>(std::abs(candidate.frameOffset))),
     });
   }
   auto stabilized = *target.alpha;
@@ -309,8 +316,7 @@ std::vector<std::uint8_t> stabilizeTemporalForeground(
       }
       referenceCount += 1;
       const auto carried = static_cast<std::uint8_t>(std::round(
-          static_cast<float>(candidateAlpha) *
-          std::pow(config.decayPerFrame, static_cast<float>(frameDistance))));
+          static_cast<float>(candidateAlpha) * registered.alphaDecay));
       bestCarriedAlpha = std::max(bestCarriedAlpha, carried);
     }
     if (currentAlpha < config.minimumCurrentAlpha &&

--- a/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.cpp
@@ -1,0 +1,326 @@
+#include "alpha-temporal-stabilizer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <stdexcept>
+
+namespace qcut::matting {
+namespace {
+
+struct MotionTranslation {
+  int x = 0;
+  int y = 0;
+};
+
+struct ForegroundCentroid {
+  double x = 0.0;
+  double y = 0.0;
+  double weight = 0.0;
+};
+
+struct RegisteredFrame {
+  const TemporalForegroundFrameView *frame;
+  MotionTranslation translation;
+};
+
+int colorDistance(const std::vector<std::uint8_t> &first,
+                  const std::vector<std::uint8_t> &second,
+                  std::size_t firstPixelIndex,
+                  std::size_t secondPixelIndex) {
+  const auto firstOffset = firstPixelIndex * 4;
+  const auto secondOffset = secondPixelIndex * 4;
+  int distance = 0;
+  for (std::size_t channel = 0; channel < 3; ++channel) {
+    distance += std::abs(static_cast<int>(first[firstOffset + channel]) -
+                         static_cast<int>(second[secondOffset + channel]));
+  }
+  return distance / 3;
+}
+
+const TemporalForegroundFrameView &
+targetFrame(const std::vector<TemporalForegroundFrameView> &frames) {
+  const auto target = std::find_if(
+      frames.begin(), frames.end(),
+      [](const auto &frame) { return frame.frameOffset == 0; });
+  if (target == frames.end()) {
+    throw std::invalid_argument("temporal window has no target frame");
+  }
+  return *target;
+}
+
+ForegroundCentroid foregroundCentroid(
+    const std::vector<std::uint8_t> &alpha, int width, int height,
+    const TemporalForegroundConfig &config) {
+  ForegroundCentroid centroid;
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      const auto index = static_cast<std::size_t>(y) * width + x;
+      if (alpha[index] < config.minimumReferenceAlpha) {
+        continue;
+      }
+      const double weight = static_cast<double>(alpha[index]);
+      centroid.x += static_cast<double>(x) * weight;
+      centroid.y += static_cast<double>(y) * weight;
+      centroid.weight += weight;
+    }
+  }
+  if (centroid.weight > 0.0) {
+    centroid.x /= centroid.weight;
+    centroid.y /= centroid.weight;
+  }
+  return centroid;
+}
+
+bool translatedPixelIndex(int x, int y, MotionTranslation translation,
+                          int width, int height, std::size_t *index) {
+  const int candidateX = x - translation.x;
+  const int candidateY = y - translation.y;
+  if (candidateX < 0 || candidateY < 0 || candidateX >= width ||
+      candidateY >= height) {
+    return false;
+  }
+  *index = static_cast<std::size_t>(candidateY) * width + candidateX;
+  return true;
+}
+
+double translationScore(
+    const TemporalForegroundFrameView &target,
+    const TemporalForegroundFrameView &candidate,
+    MotionTranslation translation, MotionTranslation centroidTranslation,
+    int width, int height, const TemporalForegroundConfig &config) {
+  std::uint64_t colorDistanceSum = 0;
+  std::size_t sampleCount = 0;
+  const int stride = config.motionSampleStride;
+  for (int y = stride / 2; y < height; y += stride) {
+    for (int x = stride / 2; x < width; x += stride) {
+      const auto targetIndex = static_cast<std::size_t>(y) * width + x;
+      if ((*target.alpha)[targetIndex] < config.minimumReferenceAlpha) {
+        continue;
+      }
+      std::size_t candidateIndex = 0;
+      if (!translatedPixelIndex(x, y, translation, width, height,
+                                &candidateIndex) ||
+          (*candidate.alpha)[candidateIndex] <
+              config.minimumReferenceAlpha) {
+        continue;
+      }
+      colorDistanceSum += colorDistance(*target.rgba, *candidate.rgba,
+                                        targetIndex, candidateIndex);
+      sampleCount += 1;
+    }
+  }
+  if (sampleCount == 0) {
+    return std::numeric_limits<double>::infinity();
+  }
+  const int refinementDistance =
+      std::abs(translation.x - centroidTranslation.x) +
+      std::abs(translation.y - centroidTranslation.y);
+  return static_cast<double>(colorDistanceSum) / sampleCount +
+         static_cast<double>(refinementDistance);
+}
+
+MotionTranslation estimateTranslation(
+    const TemporalForegroundFrameView &target,
+    const TemporalForegroundFrameView &candidate, int width, int height,
+    const TemporalForegroundConfig &config) {
+  const auto targetCentroid =
+      foregroundCentroid(*target.alpha, width, height, config);
+  const auto candidateCentroid =
+      foregroundCentroid(*candidate.alpha, width, height, config);
+  if (targetCentroid.weight == 0.0 || candidateCentroid.weight == 0.0) {
+    return {};
+  }
+  const MotionTranslation centroidTranslation{
+      .x = std::clamp(
+          static_cast<int>(std::lround(targetCentroid.x - candidateCentroid.x)),
+          -config.maximumMotionPixels, config.maximumMotionPixels),
+      .y = std::clamp(
+          static_cast<int>(std::lround(targetCentroid.y - candidateCentroid.y)),
+          -config.maximumMotionPixels, config.maximumMotionPixels),
+  };
+  MotionTranslation best = centroidTranslation;
+  double bestScore = translationScore(target, candidate, best,
+                                      centroidTranslation, width, height,
+                                      config);
+  for (int offsetY = -config.motionRefinementRadius;
+       offsetY <= config.motionRefinementRadius; ++offsetY) {
+    for (int offsetX = -config.motionRefinementRadius;
+         offsetX <= config.motionRefinementRadius; ++offsetX) {
+      const MotionTranslation candidateTranslation{
+          .x = std::clamp(centroidTranslation.x + offsetX,
+                          -config.maximumMotionPixels,
+                          config.maximumMotionPixels),
+          .y = std::clamp(centroidTranslation.y + offsetY,
+                          -config.maximumMotionPixels,
+                          config.maximumMotionPixels),
+      };
+      const double score =
+          translationScore(target, candidate, candidateTranslation,
+                           centroidTranslation, width, height, config);
+      if (score >= bestScore) {
+        continue;
+      }
+      best = candidateTranslation;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+bool isReferenceInterior(const std::vector<std::uint8_t> &alpha, int x, int y,
+                         int width, int height,
+                         const TemporalForegroundConfig &config) {
+  const int radius = config.referenceInteriorRadius;
+  if (x < radius || y < radius || x + radius >= width ||
+      y + radius >= height) {
+    return false;
+  }
+  for (int sampleY = y - radius; sampleY <= y + radius; ++sampleY) {
+    for (int sampleX = x - radius; sampleX <= x + radius; ++sampleX) {
+      if (alpha[static_cast<std::size_t>(sampleY) * width + sampleX] <
+          config.minimumReferenceAlpha) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+void solidifyForegroundInterior(std::vector<std::uint8_t> &alpha, int width,
+                                int height,
+                                const TemporalForegroundConfig &config) {
+  const int radius = config.interiorRadius;
+  if (radius == 0 || width <= radius * 2 || height <= radius * 2) {
+    return;
+  }
+  std::vector<std::uint8_t> horizontal(alpha.size(), 0);
+  for (int y = 0; y < height; ++y) {
+    for (int x = radius; x < width - radius; ++x) {
+      bool supported = true;
+      for (int sampleX = x - radius; sampleX <= x + radius; ++sampleX) {
+        if (alpha[static_cast<std::size_t>(y) * width + sampleX] >=
+            config.interiorSupportAlpha) {
+          continue;
+        }
+        supported = false;
+        break;
+      }
+      horizontal[static_cast<std::size_t>(y) * width + x] = supported ? 1 : 0;
+    }
+  }
+  for (int y = radius; y < height - radius; ++y) {
+    for (int x = radius; x < width - radius; ++x) {
+      bool interior = true;
+      for (int sampleY = y - radius; sampleY <= y + radius; ++sampleY) {
+        if (horizontal[static_cast<std::size_t>(sampleY) * width + x] != 0) {
+          continue;
+        }
+        interior = false;
+        break;
+      }
+      if (!interior) {
+        continue;
+      }
+      const auto index = static_cast<std::size_t>(y) * width + x;
+      alpha[index] = std::max(alpha[index], config.interiorTargetAlpha);
+    }
+  }
+}
+
+} // namespace
+
+std::vector<std::uint8_t> stabilizeTemporalForeground(
+    const std::vector<TemporalForegroundFrameView> &frames, int width,
+    int height, TemporalForegroundConfig config) {
+  if (width <= 0 || height <= 0 || config.interiorRadius < 0 ||
+      config.maximumMotionPixels < 0 || config.motionRefinementRadius < 0 ||
+      config.motionSampleStride <= 0 || config.referenceInteriorRadius < 0 ||
+      config.minimumZeroAlphaReferences <= 0 ||
+      config.decayPerFrame <= 0.0F || config.decayPerFrame > 1.0F) {
+    throw std::invalid_argument("invalid temporal foreground configuration");
+  }
+  const auto pixelCount = static_cast<std::size_t>(width) * height;
+  for (const auto &frame : frames) {
+    if (!frame.rgba || !frame.alpha || frame.rgba->size() != pixelCount * 4 ||
+        frame.alpha->size() != pixelCount) {
+      throw std::invalid_argument("frame dimensions do not match stabilizer");
+    }
+  }
+
+  const auto &target = targetFrame(frames);
+  std::vector<RegisteredFrame> registeredFrames;
+  registeredFrames.reserve(frames.size());
+  for (const auto &candidate : frames) {
+    if (candidate.frameOffset == 0) {
+      continue;
+    }
+    registeredFrames.push_back(RegisteredFrame{
+        .frame = &candidate,
+        .translation =
+            estimateTranslation(target, candidate, width, height, config),
+    });
+  }
+  auto stabilized = *target.alpha;
+  for (std::size_t index = 0; index < pixelCount; ++index) {
+    const auto currentAlpha = (*target.alpha)[index];
+    if (currentAlpha >= config.minimumReferenceAlpha) {
+      continue;
+    }
+    if (currentAlpha < config.minimumCurrentAlpha &&
+        config.maximumMotionPixels == 0) {
+      continue;
+    }
+
+    std::uint8_t bestCarriedAlpha = currentAlpha;
+    int referenceCount = 0;
+    const int x = static_cast<int>(index % static_cast<std::size_t>(width));
+    const int y = static_cast<int>(index / static_cast<std::size_t>(width));
+    for (const auto &registered : registeredFrames) {
+      std::size_t candidateIndex = 0;
+      if (currentAlpha < config.minimumCurrentAlpha) {
+        if (!translatedPixelIndex(x, y, registered.translation, width, height,
+                                  &candidateIndex)) {
+          continue;
+        }
+      } else {
+        candidateIndex = index;
+      }
+      const auto &candidate = *registered.frame;
+      const auto candidateAlpha = (*candidate.alpha)[candidateIndex];
+      if (candidateAlpha < config.minimumReferenceAlpha ||
+          candidateAlpha <= currentAlpha + 12) {
+        continue;
+      }
+      const int candidateX = x - registered.translation.x;
+      const int candidateY = y - registered.translation.y;
+      if (currentAlpha < config.minimumCurrentAlpha &&
+          !isReferenceInterior(*candidate.alpha, candidateX, candidateY, width,
+                               height, config)) {
+        continue;
+      }
+      const int frameDistance = std::abs(candidate.frameOffset);
+      const int score = colorDistance(*target.rgba, *candidate.rgba, index,
+                                      candidateIndex) +
+                        frameDistance * 2;
+      if (score > config.maximumColorDistance) {
+        continue;
+      }
+      referenceCount += 1;
+      const auto carried = static_cast<std::uint8_t>(std::round(
+          static_cast<float>(candidateAlpha) *
+          std::pow(config.decayPerFrame, static_cast<float>(frameDistance))));
+      bestCarriedAlpha = std::max(bestCarriedAlpha, carried);
+    }
+    if (currentAlpha < config.minimumCurrentAlpha &&
+        referenceCount < config.minimumZeroAlphaReferences) {
+      continue;
+    }
+    stabilized[index] = bestCarriedAlpha;
+  }
+  solidifyForegroundInterior(stabilized, width, height, config);
+  return stabilized;
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.hpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace qcut::matting {
+
+struct TemporalForegroundConfig {
+  std::uint8_t minimumCurrentAlpha = 48;
+  std::uint8_t minimumReferenceAlpha = 192;
+  std::uint8_t maximumColorDistance = 42;
+  std::uint8_t interiorSupportAlpha = 48;
+  std::uint8_t interiorTargetAlpha = 244;
+  float decayPerFrame = 0.985F;
+  int interiorRadius = 3;
+  int maximumMotionPixels = 0;
+  int motionRefinementRadius = 2;
+  int motionSampleStride = 8;
+  int referenceInteriorRadius = 2;
+  int minimumZeroAlphaReferences = 2;
+};
+
+struct TemporalForegroundFrameView {
+  const std::vector<std::uint8_t> *rgba;
+  const std::vector<std::uint8_t> *alpha;
+  int frameOffset;
+};
+
+std::vector<std::uint8_t> stabilizeTemporalForeground(
+    const std::vector<TemporalForegroundFrameView> &frames, int width,
+    int height, TemporalForegroundConfig config = {});
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.test.cpp
@@ -1,0 +1,122 @@
+#include "alpha-temporal-stabilizer.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+std::vector<std::uint8_t> solidRgba(std::uint8_t value) {
+  return std::vector<std::uint8_t>{value, value, value, 255};
+}
+
+std::vector<std::uint8_t> objectFrame(int width, int height, int left,
+                                      int top, int right, int bottom) {
+  std::vector<std::uint8_t> rgba(static_cast<std::size_t>(width) * height * 4,
+                                 20);
+  for (std::size_t offset = 3; offset < rgba.size(); offset += 4) {
+    rgba[offset] = 255;
+  }
+  for (int y = top; y <= bottom; ++y) {
+    for (int x = left; x <= right; ++x) {
+      const auto offset = (static_cast<std::size_t>(y) * width + x) * 4;
+      rgba[offset] = 90;
+      rgba[offset + 1] = 110;
+      rgba[offset + 2] = 130;
+    }
+  }
+  return rgba;
+}
+
+std::vector<std::uint8_t> objectAlpha(int width, int height, int left,
+                                      int top, int right, int bottom) {
+  std::vector<std::uint8_t> alpha(static_cast<std::size_t>(width) * height);
+  for (int y = top; y <= bottom; ++y) {
+    for (int x = left; x <= right; ++x) {
+      alpha[static_cast<std::size_t>(y) * width + x] = 255;
+    }
+  }
+  return alpha;
+}
+
+qcut::matting::TemporalForegroundFrameView
+view(const std::vector<std::uint8_t> &rgba,
+     const std::vector<std::uint8_t> &alpha, int frameOffset) {
+  return {.rgba = &rgba, .alpha = &alpha, .frameOffset = frameOffset};
+}
+
+} // namespace
+
+int main() {
+  const auto stableColor = solidRgba(80);
+  const std::vector<std::uint8_t> solidAlpha{255};
+  const std::vector<std::uint8_t> droppedAlpha{100};
+  const std::vector<std::uint8_t> backgroundAlpha{0};
+
+  assert(qcut::matting::stabilizeTemporalForeground(
+             {view(stableColor, solidAlpha, -1),
+              view(stableColor, droppedAlpha, 0)},
+             1, 1)[0] >= 250);
+  assert(qcut::matting::stabilizeTemporalForeground(
+             {view(stableColor, droppedAlpha, 0),
+              view(stableColor, solidAlpha, 1)},
+             1, 1)[0] >= 250);
+
+  const auto changedColor = solidRgba(220);
+  assert(qcut::matting::stabilizeTemporalForeground(
+             {view(stableColor, solidAlpha, -1),
+              view(changedColor, droppedAlpha, 0)},
+             1, 1)[0] == 100);
+  assert(qcut::matting::stabilizeTemporalForeground(
+             {view(stableColor, solidAlpha, -1),
+              view(stableColor, backgroundAlpha, 0)},
+             1, 1)[0] == 0);
+
+  const std::vector<std::uint8_t> interiorRgba(9 * 9 * 4, 80);
+  const std::vector<std::uint8_t> softInteriorAlpha(9 * 9, 100);
+  const auto solidInterior = qcut::matting::stabilizeTemporalForeground(
+      {view(interiorRgba, softInteriorAlpha, 0)}, 9, 9);
+  assert(solidInterior[4 * 9 + 4] == 244);
+  assert(solidInterior[0] == 100);
+
+  constexpr int motionWidth = 13;
+  constexpr int motionHeight = 9;
+  const auto previousRgba =
+      objectFrame(motionWidth, motionHeight, 2, 2, 6, 6);
+  const auto targetRgba =
+      objectFrame(motionWidth, motionHeight, 4, 2, 8, 6);
+  const auto futureRgba =
+      objectFrame(motionWidth, motionHeight, 6, 2, 10, 6);
+  const auto previousAlpha =
+      objectAlpha(motionWidth, motionHeight, 2, 2, 6, 6);
+  auto targetAlpha = objectAlpha(motionWidth, motionHeight, 4, 2, 8, 6);
+  const auto futureAlpha =
+      objectAlpha(motionWidth, motionHeight, 6, 2, 10, 6);
+  const auto missingInteriorIndex = static_cast<std::size_t>(4) * motionWidth + 6;
+  targetAlpha[missingInteriorIndex] = 0;
+  const qcut::matting::TemporalForegroundConfig motionConfig{
+      .interiorRadius = 0,
+      .maximumMotionPixels = 4,
+      .motionRefinementRadius = 0,
+      .motionSampleStride = 1,
+      .referenceInteriorRadius = 1,
+      .minimumZeroAlphaReferences = 2,
+  };
+  const auto motionStabilized = qcut::matting::stabilizeTemporalForeground(
+      {view(previousRgba, previousAlpha, -1),
+       view(targetRgba, targetAlpha, 0),
+       view(futureRgba, futureAlpha, 1)},
+      motionWidth, motionHeight, motionConfig);
+  assert(motionStabilized[missingInteriorIndex] >= 250);
+  assert(motionStabilized[static_cast<std::size_t>(4) * motionWidth + 3] == 0);
+
+  auto noMotionConfig = motionConfig;
+  noMotionConfig.maximumMotionPixels = 0;
+  assert(qcut::matting::stabilizeTemporalForeground(
+             {view(previousRgba, previousAlpha, -1),
+              view(targetRgba, targetAlpha, 0),
+              view(futureRgba, futureAlpha, 1)},
+             motionWidth, motionHeight, noMotionConfig)[missingInteriorIndex] ==
+         0);
+  return 0;
+}

--- a/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/alpha-temporal-stabilizer.test.cpp
@@ -1,6 +1,8 @@
 #include "alpha-temporal-stabilizer.hpp"
 
+#include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstdint>
 #include <vector>
 
@@ -43,6 +45,31 @@ qcut::matting::TemporalForegroundFrameView
 view(const std::vector<std::uint8_t> &rgba,
      const std::vector<std::uint8_t> &alpha, int frameOffset) {
   return {.rgba = &rgba, .alpha = &alpha, .frameOffset = frameOffset};
+}
+
+std::vector<std::uint8_t>
+expectedNoMotionAlpha(const std::vector<std::uint8_t> &target,
+                      const std::vector<const std::vector<std::uint8_t> *>
+                          &references,
+                      const std::vector<int> &frameOffsets,
+                      float decayPerFrame) {
+  auto expected = target;
+  for (std::size_t index = 0; index < target.size(); ++index) {
+    for (std::size_t referenceIndex = 0; referenceIndex < references.size();
+         ++referenceIndex) {
+      const auto referenceAlpha = (*references[referenceIndex])[index];
+      if (referenceAlpha < 192 || referenceAlpha <= target[index] + 12) {
+        continue;
+      }
+      const auto decay = std::pow(
+          decayPerFrame,
+          static_cast<float>(std::abs(frameOffsets[referenceIndex])));
+      const auto carried = static_cast<std::uint8_t>(
+          std::round(static_cast<float>(referenceAlpha) * decay));
+      expected[index] = std::max(expected[index], carried);
+    }
+  }
+  return expected;
 }
 
 } // namespace
@@ -118,5 +145,55 @@ int main() {
               view(futureRgba, futureAlpha, 1)},
              motionWidth, motionHeight, noMotionConfig)[missingInteriorIndex] ==
          0);
+
+  constexpr int randomizedWidth = 257;
+  const std::vector<std::uint8_t> randomizedRgba(randomizedWidth * 4, 80);
+  std::vector<std::uint8_t> randomizedTarget(randomizedWidth);
+  std::vector<std::uint8_t> referenceMinusFive(randomizedWidth);
+  std::vector<std::uint8_t> referenceMinusTwo(randomizedWidth);
+  std::vector<std::uint8_t> referencePlusOne(randomizedWidth);
+  std::vector<std::uint8_t> referencePlusThree(randomizedWidth);
+  std::uint32_t randomState = 0x243f6a88U;
+  const auto nextRandom = [&randomState]() {
+    randomState = randomState * 1'664'525U + 1'013'904'223U;
+    return static_cast<std::uint8_t>(randomState >> 24U);
+  };
+  for (std::size_t index = 0; index < randomizedTarget.size(); ++index) {
+    randomizedTarget[index] =
+        static_cast<std::uint8_t>(48 + nextRandom() % 144);
+    referenceMinusFive[index] =
+        static_cast<std::uint8_t>(192 + nextRandom() % 64);
+    referenceMinusTwo[index] =
+        static_cast<std::uint8_t>(192 + nextRandom() % 64);
+    referencePlusOne[index] =
+        static_cast<std::uint8_t>(192 + nextRandom() % 64);
+    referencePlusThree[index] =
+        static_cast<std::uint8_t>(192 + nextRandom() % 64);
+  }
+  const qcut::matting::TemporalForegroundConfig randomizedConfig{
+      .decayPerFrame = 0.973F,
+      .interiorRadius = 0,
+      .maximumMotionPixels = 0,
+      .motionRefinementRadius = 64,
+  };
+  const std::vector<const std::vector<std::uint8_t> *> references{
+      &referenceMinusFive,
+      &referenceMinusTwo,
+      &referencePlusOne,
+      &referencePlusThree,
+  };
+  const std::vector<int> referenceOffsets{-5, -2, 1, 3};
+  const auto expectedRandomized = expectedNoMotionAlpha(
+      randomizedTarget, references, referenceOffsets,
+      randomizedConfig.decayPerFrame);
+  const auto stabilizedRandomized =
+      qcut::matting::stabilizeTemporalForeground(
+          {view(randomizedRgba, referenceMinusFive, -5),
+           view(randomizedRgba, referenceMinusTwo, -2),
+           view(randomizedRgba, randomizedTarget, 0),
+           view(randomizedRgba, referencePlusOne, 1),
+           view(randomizedRgba, referencePlusThree, 3)},
+          randomizedWidth, 1, randomizedConfig);
+  assert(stabilizedRandomized == expectedRandomized);
   return 0;
 }

--- a/qcut/electron/jianying-person-cutout/native/effect-input-probe.cpp
+++ b/qcut/electron/jianying-person-cutout/native/effect-input-probe.cpp
@@ -1,0 +1,76 @@
+#include "effect-input-probe.hpp"
+
+#include <OpenGL/OpenGL.h>
+
+#include <dlfcn.h>
+
+#include <cstdlib>
+#include <string>
+
+namespace qcut::matting {
+namespace {
+
+using ObjcGetClass = void *(*)(const char *);
+using ObjcSelector = void *(*)(const char *);
+using ObjcSendNoArguments = void *(*)(void *, void *);
+using ObjcSendBoolean = void (*)(void *, void *, signed char);
+
+bool environmentFlagEnabled(const char *name) {
+  const char *value = std::getenv(name);
+  return value != nullptr && std::string(value) == "1";
+}
+
+} // namespace
+
+bool bufferInputProbeEnabled() {
+  return environmentFlagEnabled("QCUT_JIANYING_BUFFER_INPUT_PROBE");
+}
+
+bool engineImageProcessingContextProbeEnabled() {
+  return environmentFlagEnabled("QCUT_JIANYING_ENGINE_CONTEXT_PROBE");
+}
+
+bool bindEngineImageProcessingContext() {
+  const auto getClass = reinterpret_cast<ObjcGetClass>(
+      dlsym(RTLD_DEFAULT, "objc_getClass"));
+  const auto selector = reinterpret_cast<ObjcSelector>(
+      dlsym(RTLD_DEFAULT, "sel_registerName"));
+  void *sendSymbol = dlsym(RTLD_DEFAULT, "objc_msgSend");
+  if (getClass == nullptr || selector == nullptr || sendSymbol == nullptr) {
+    return false;
+  }
+
+  void *contextClass = getClass("HTSGLContext");
+  if (contextClass == nullptr) {
+    return false;
+  }
+  const auto sendNoArguments =
+      reinterpret_cast<ObjcSendNoArguments>(sendSymbol);
+  const auto sendBoolean = reinterpret_cast<ObjcSendBoolean>(sendSymbol);
+  void *applicationClass = getClass("NSApplication");
+  if (applicationClass != nullptr) {
+    sendNoArguments(applicationClass, selector("sharedApplication"));
+  }
+  sendNoArguments(contextClass, selector("preloadGLContext"));
+
+  void *context = nullptr;
+  constexpr const char *contextSelectors[] = {
+      "sharedImageProcessingContext",
+      "shareProcesingContext",
+      "defaultImageProcessingContext",
+  };
+  for (const char *contextSelector : contextSelectors) {
+    context = sendNoArguments(contextClass, selector(contextSelector));
+    if (context != nullptr) {
+      break;
+    }
+  }
+  if (context == nullptr ||
+      sendNoArguments(context, selector("getCppContext")) == nullptr) {
+    return false;
+  }
+  sendBoolean(context, selector("bind:"), 1);
+  return CGLGetCurrentContext() != nullptr;
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/effect-input-probe.hpp
+++ b/qcut/electron/jianying-person-cutout/native/effect-input-probe.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace qcut::matting {
+
+bool bufferInputProbeEnabled();
+bool engineImageProcessingContextProbeEnabled();
+bool bindEngineImageProcessingContext();
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/effect-texture-context.cpp
+++ b/qcut/electron/jianying-person-cutout/native/effect-texture-context.cpp
@@ -1,0 +1,97 @@
+#include "effect-texture-context.hpp"
+
+#include <OpenGL/OpenGL.h>
+#include <OpenGL/gl.h>
+
+#include <stdexcept>
+
+namespace qcut::matting {
+
+struct EffectTextureContext::Implementation {
+  CGLPixelFormatObj pixelFormat = nullptr;
+  CGLContextObj context = nullptr;
+
+  Implementation() {
+    const CGLPixelFormatAttribute attributes[] = {
+        kCGLPFAOpenGLProfile,
+        static_cast<CGLPixelFormatAttribute>(kCGLOGLPVersion_Legacy),
+        kCGLPFAAccelerated,
+        kCGLPFAAllowOfflineRenderers,
+        kCGLPFAColorSize,
+        static_cast<CGLPixelFormatAttribute>(32),
+        kCGLPFAAlphaSize,
+        static_cast<CGLPixelFormatAttribute>(8),
+        static_cast<CGLPixelFormatAttribute>(0),
+    };
+    GLint count = 0;
+    if (CGLChoosePixelFormat(attributes, &pixelFormat, &count) != kCGLNoError ||
+        pixelFormat == nullptr || count == 0) {
+      throw std::runtime_error("cannot choose an accelerated OpenGL context");
+    }
+    if (CGLCreateContext(pixelFormat, nullptr, &context) != kCGLNoError ||
+        context == nullptr) {
+      throw std::runtime_error("cannot create the OpenGL context");
+    }
+    if (CGLSetCurrentContext(context) != kCGLNoError) {
+      throw std::runtime_error("cannot activate the OpenGL context");
+    }
+  }
+
+  ~Implementation() {
+    CGLSetCurrentContext(nullptr);
+    if (context != nullptr) {
+      CGLDestroyContext(context);
+    }
+    if (pixelFormat != nullptr) {
+      CGLDestroyPixelFormat(pixelFormat);
+    }
+  }
+};
+
+EffectTextureContext::EffectTextureContext()
+    : implementation_(std::make_unique<Implementation>()) {}
+
+EffectTextureContext::~EffectTextureContext() = default;
+
+std::uint32_t EffectTextureContext::createTexture(
+    int width, int height, const std::vector<std::uint8_t> &pixels) {
+  GLuint texture = 0;
+  glGenTextures(1, &texture);
+  glBindTexture(GL_TEXTURE_2D, texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, pixels.data());
+  glBindTexture(GL_TEXTURE_2D, 0);
+  if (texture == 0 || glGetError() != GL_NO_ERROR) {
+    throw std::runtime_error("cannot create the segmentation input texture");
+  }
+  return texture;
+}
+
+void EffectTextureContext::deleteTextures(
+    const std::vector<std::uint32_t> &textures) {
+  glDeleteTextures(static_cast<GLsizei>(textures.size()), textures.data());
+}
+
+void EffectTextureContext::setUnpackAlignment(int alignment) {
+  glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
+}
+
+void EffectTextureContext::updateTexture(
+    std::uint32_t texture, int width, int height,
+    const std::vector<std::uint8_t> &pixels) {
+  glBindTexture(GL_TEXTURE_2D, texture);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA,
+                  GL_UNSIGNED_BYTE, pixels.data());
+  glBindTexture(GL_TEXTURE_2D, 0);
+  if (glGetError() != GL_NO_ERROR) {
+    throw std::runtime_error("cannot update the segmentation input texture");
+  }
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/effect-texture-context.cpp
+++ b/qcut/electron/jianying-person-cutout/native/effect-texture-context.cpp
@@ -10,8 +10,16 @@ namespace qcut::matting {
 struct EffectTextureContext::Implementation {
   CGLPixelFormatObj pixelFormat = nullptr;
   CGLContextObj context = nullptr;
+  bool ownsContext = false;
 
-  Implementation() {
+  explicit Implementation(EffectTextureContextMode mode) {
+    if (mode == EffectTextureContextMode::AdoptCurrent) {
+      context = CGLGetCurrentContext();
+      if (context == nullptr) {
+        throw std::runtime_error("cannot adopt the current OpenGL context");
+      }
+      return;
+    }
     const CGLPixelFormatAttribute attributes[] = {
         kCGLPFAOpenGLProfile,
         static_cast<CGLPixelFormatAttribute>(kCGLOGLPVersion_Legacy),
@@ -35,9 +43,13 @@ struct EffectTextureContext::Implementation {
     if (CGLSetCurrentContext(context) != kCGLNoError) {
       throw std::runtime_error("cannot activate the OpenGL context");
     }
+    ownsContext = true;
   }
 
   ~Implementation() {
+    if (!ownsContext) {
+      return;
+    }
     CGLSetCurrentContext(nullptr);
     if (context != nullptr) {
       CGLDestroyContext(context);
@@ -46,15 +58,27 @@ struct EffectTextureContext::Implementation {
       CGLDestroyPixelFormat(pixelFormat);
     }
   }
+
+  void activate() const {
+    if (CGLGetCurrentContext() != context &&
+        CGLSetCurrentContext(context) != kCGLNoError) {
+      throw std::runtime_error("cannot reactivate the OpenGL context");
+    }
+    // Vendor effect calls can switch contexts and leave their GL errors behind.
+    for (int attempt = 0; attempt < 16 && glGetError() != GL_NO_ERROR;
+         ++attempt) {
+    }
+  }
 };
 
-EffectTextureContext::EffectTextureContext()
-    : implementation_(std::make_unique<Implementation>()) {}
+EffectTextureContext::EffectTextureContext(EffectTextureContextMode mode)
+    : implementation_(std::make_unique<Implementation>(mode)) {}
 
 EffectTextureContext::~EffectTextureContext() = default;
 
 std::uint32_t EffectTextureContext::createTexture(
     int width, int height, const std::vector<std::uint8_t> &pixels) {
+  implementation_->activate();
   GLuint texture = 0;
   glGenTextures(1, &texture);
   glBindTexture(GL_TEXTURE_2D, texture);
@@ -75,16 +99,19 @@ std::uint32_t EffectTextureContext::createTexture(
 
 void EffectTextureContext::deleteTextures(
     const std::vector<std::uint32_t> &textures) {
+  implementation_->activate();
   glDeleteTextures(static_cast<GLsizei>(textures.size()), textures.data());
 }
 
 void EffectTextureContext::setUnpackAlignment(int alignment) {
+  implementation_->activate();
   glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 }
 
 void EffectTextureContext::updateTexture(
     std::uint32_t texture, int width, int height,
     const std::vector<std::uint8_t> &pixels) {
+  implementation_->activate();
   glBindTexture(GL_TEXTURE_2D, texture);
   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA,
                   GL_UNSIGNED_BYTE, pixels.data());

--- a/qcut/electron/jianying-person-cutout/native/effect-texture-context.hpp
+++ b/qcut/electron/jianying-person-cutout/native/effect-texture-context.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace qcut::matting {
+
+class EffectTextureContext {
+public:
+  EffectTextureContext();
+  ~EffectTextureContext();
+
+  EffectTextureContext(const EffectTextureContext &) = delete;
+  EffectTextureContext &operator=(const EffectTextureContext &) = delete;
+
+  std::uint32_t createTexture(int width, int height,
+                              const std::vector<std::uint8_t> &pixels);
+  void deleteTextures(const std::vector<std::uint32_t> &textures);
+  void setUnpackAlignment(int alignment);
+  void updateTexture(std::uint32_t texture, int width, int height,
+                     const std::vector<std::uint8_t> &pixels);
+
+private:
+  struct Implementation;
+  std::unique_ptr<Implementation> implementation_;
+};
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/effect-texture-context.hpp
+++ b/qcut/electron/jianying-person-cutout/native/effect-texture-context.hpp
@@ -6,9 +6,16 @@
 
 namespace qcut::matting {
 
+enum class EffectTextureContextMode {
+  CreateStandalone,
+  AdoptCurrent,
+};
+
 class EffectTextureContext {
 public:
-  EffectTextureContext();
+  explicit EffectTextureContext(
+      EffectTextureContextMode mode =
+          EffectTextureContextMode::CreateStandalone);
   ~EffectTextureContext();
 
   EffectTextureContext(const EffectTextureContext &) = delete;

--- a/qcut/electron/jianying-person-cutout/native/matting-gru-bridge.cpp
+++ b/qcut/electron/jianying-person-cutout/native/matting-gru-bridge.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstddef>
 #include <cmath>
 #include <cstdint>
@@ -24,6 +25,45 @@
 #include <vector>
 
 namespace {
+
+using SteadyClock = std::chrono::steady_clock;
+
+std::uint64_t elapsedMicros(SteadyClock::time_point startedAt) {
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          SteadyClock::now() - startedAt)
+          .count());
+}
+
+struct BridgeTiming {
+  std::uint64_t inputReadMicros = 0;
+  std::uint64_t rgbaToBgrMicros = 0;
+  std::uint64_t gruInferenceMicros = 0;
+  std::uint64_t alphaResizeMicros = 0;
+  std::uint64_t visionInferenceMicros = 0;
+  std::uint64_t postprocessMicros = 0;
+  std::uint64_t nativeValidationMicros = 0;
+  std::uint64_t cacheWriteMicros = 0;
+  std::uint64_t outputFlushMicros = 0;
+};
+
+struct DlCloser {
+  void operator()(void *library) const {
+    if (library != nullptr) {
+      dlclose(library);
+    }
+  }
+};
+
+void flushFile(std::unique_ptr<std::ofstream> &file, const char *label) {
+  if (!file) {
+    return;
+  }
+  file->flush();
+  if (!*file) {
+    throw std::runtime_error(std::string("cannot flush ") + label);
+  }
+}
 
 struct MattingInput {
   const std::uint8_t *data;
@@ -105,8 +145,9 @@ std::size_t readAll(int fileDescriptor, std::uint8_t *data, std::size_t size) {
 } // namespace
 
 int main(int argc, char **argv) {
-  bool useNativeMetal = false;
+  bool validateNativeMetalCanary = false;
   bool useVisionPersonFusion = false;
+  bool emitTimingJson = false;
   bool validOptions = argc >= 12;
   for (int optionIndex = 12; validOptions && optionIndex < argc;
        ++optionIndex) {
@@ -115,9 +156,17 @@ int main(int argc, char **argv) {
       useVisionPersonFusion = true;
       continue;
     }
+    if (option == "--timing-json") {
+      emitTimingJson = true;
+      continue;
+    }
+    if (option == "--native-metal-canary") {
+      validateNativeMetalCanary = true;
+      continue;
+    }
     if (option == "--blend" && optionIndex + 1 < argc &&
         std::string(argv[optionIndex + 1]) == "native-metal") {
-      useNativeMetal = true;
+      validateNativeMetalCanary = true;
       optionIndex += 1;
       continue;
     }
@@ -127,11 +176,14 @@ int main(int argc, char **argv) {
     std::cerr << "usage: portrait-matting-gru-bridge <libcccreator> <model> "
                  "<model-type> <input.rgba> <width> <height> <output.gray> "
                  "<threshold> <temporal-smoothing> <edge-shift> <feather> "
-                 "[--vision-person-fusion] [--blend native-metal]\n";
+                 "[--vision-person-fusion] [--timing-json] "
+                 "[--native-metal-canary]\n";
     return 2;
   }
 
   try {
+    const auto programStartedAt = SteadyClock::now();
+    BridgeTiming timing;
     const int modelType = std::stoi(argv[3]);
     const int width = parsePositiveInteger(argv[5], "width");
     const int height = parsePositiveInteger(argv[6], "height");
@@ -208,8 +260,11 @@ int main(int argc, char **argv) {
 
     std::vector<std::uint8_t> rgba(frameBytes);
     std::vector<std::uint8_t> bgr(frameBytes / 4 * 3);
-    void *library = dlopen(
-        argv[1], RTLD_NOW | (useNativeMetal ? RTLD_GLOBAL : RTLD_LOCAL));
+    std::unique_ptr<void, DlCloser> libraryOwner(
+        dlopen(argv[1],
+               RTLD_NOW |
+                   (validateNativeMetalCanary ? RTLD_GLOBAL : RTLD_LOCAL)));
+    void *library = libraryOwner.get();
     if (!library) {
       throw std::runtime_error(std::string("cannot load runtime: ") +
                                dlerror());
@@ -288,14 +343,16 @@ int main(int argc, char **argv) {
       };
     };
     const auto initializedHandle = initializeHandle();
-    void *handle = initializedHandle.handle;
+    std::unique_ptr<void, ReleaseHandle> handleOwner(initializedHandle.handle,
+                                                     releaseHandle);
+    void *handle = handleOwner.get();
     const int alphaWidth = initializedHandle.alphaWidth;
     const int alphaHeight = initializedHandle.alphaHeight;
     const int internalModelType = initializedHandle.internalModelType;
     std::vector<std::uint8_t> alpha(static_cast<std::size_t>(alphaWidth) *
                                     alphaHeight);
     std::unique_ptr<qcut::matting::MetalMattingBlend> metalBlend;
-    if (useNativeMetal) {
+    if (validateNativeMetalCanary) {
       metalBlend = std::make_unique<qcut::matting::MetalMattingBlend>(
           qcut::matting::MetalMattingBlendConfig{
               .library = library,
@@ -305,18 +362,15 @@ int main(int argc, char **argv) {
     }
     std::unique_ptr<qcut::matting::VisionPersonSegmentation>
         visionSegmentation;
+    const char *visionDisableValue =
+        std::getenv("QCUT_DISABLE_VISION_PERSON_FUSION");
     const bool visionFusionEnabled =
         useVisionPersonFusion &&
-        std::getenv("QCUT_DISABLE_VISION_PERSON_FUSION") == nullptr;
+        (!visionDisableValue || std::string(visionDisableValue) != "1");
     if (visionFusionEnabled) {
-      try {
-        visionSegmentation =
-            std::make_unique<qcut::matting::VisionPersonSegmentation>(width,
-                                                                     height);
-      } catch (const std::exception &error) {
-        std::cerr << "Vision-person-fusion-v1 unavailable: " << error.what()
-                  << '\n';
-      }
+      visionSegmentation =
+          std::make_unique<qcut::matting::VisionPersonSegmentation>(width,
+                                                                   height);
     }
 
     MattingInput input{
@@ -346,6 +400,8 @@ int main(int argc, char **argv) {
     std::vector<float> temporalState;
     std::size_t frameCount = 0;
     std::size_t nextOutputFrame = 0;
+    bool nativeMetalCanaryPassed = false;
+    std::size_t nativeMetalCanaryFrames = 0;
     const auto writeAlpha = [&](const std::vector<std::uint8_t> &finalAlpha) {
       if (streamOutput) {
         writeAll(alphaOutputDescriptor, finalAlpha.data(), finalAlpha.size());
@@ -369,7 +425,9 @@ int main(int argc, char **argv) {
         if (target == temporalWindow.end()) {
           throw std::runtime_error("temporal window lost an output frame");
         }
+        const auto postprocessStartedAt = SteadyClock::now();
         std::vector<qcut::matting::TemporalForegroundFrameView> frameViews;
+        frameViews.reserve(temporalRadius * 2U + 1U);
         for (const auto &frame : temporalWindow) {
           const auto distance = static_cast<long long>(frame.index) -
                                 static_cast<long long>(nextOutputFrame);
@@ -404,20 +462,37 @@ int main(int argc, char **argv) {
         const auto borderProcessedAlpha =
             qcut::matting::applyJianyingPortraitBorderLut(
                 fusedAlpha);
-        const auto refinedAlpha = qcut::matting::refineAlpha(
+        auto refinedAlpha = qcut::matting::refineAlpha(
             borderProcessedAlpha, temporalState, width, height, threshold,
             temporalSmoothing, edgeShift, feather);
-        const auto finalAlpha =
-            metalBlend
-                ? metalBlend->blendAlpha(
-                      qcut::matting::MetalMattingBlendFrame{
-                          .rgba = target->rgba,
-                          .alpha = refinedAlpha,
-                          .alphaWidth = width,
-                          .alphaHeight = height,
-                      })
-                : refinedAlpha;
-        writeAlpha(finalAlpha);
+        timing.postprocessMicros += elapsedMicros(postprocessStartedAt);
+        std::vector<std::uint8_t> nativeAlpha;
+        if (metalBlend && !nativeMetalCanaryPassed) {
+          const auto nativeValidationStartedAt = SteadyClock::now();
+          nativeAlpha = metalBlend->blendAlpha(
+              qcut::matting::MetalMattingBlendFrame{
+                  .rgba = target->rgba,
+                  .alpha = refinedAlpha,
+                  .alphaWidth = width,
+                  .alphaHeight = height,
+              });
+          timing.nativeValidationMicros +=
+              elapsedMicros(nativeValidationStartedAt);
+          nativeMetalCanaryFrames += 1U;
+        }
+        const auto sourceAlphaStartedAt = SteadyClock::now();
+        qcut::matting::composeSourceAlphaInPlace(target->rgba, refinedAlpha);
+        timing.postprocessMicros += elapsedMicros(sourceAlphaStartedAt);
+        if (!nativeAlpha.empty()) {
+          if (nativeAlpha != refinedAlpha) {
+            throw std::runtime_error(
+                "native blend canary does not match verified alpha formula");
+          }
+          nativeMetalCanaryPassed = true;
+        }
+        const auto cacheWriteStartedAt = SteadyClock::now();
+        writeAlpha(refinedAlpha);
+        timing.cacheWriteMicros += elapsedMicros(cacheWriteStartedAt);
         nextOutputFrame += 1;
         while (!temporalWindow.empty() &&
                temporalWindow.front().index + temporalRadius <
@@ -426,7 +501,23 @@ int main(int argc, char **argv) {
         }
       }
     };
+    const auto setupMicros = elapsedMicros(programStartedAt);
+    const auto processingStartedAt = SteadyClock::now();
+    auto lastProgressReportAt = processingStartedAt;
+    const auto reportProgress = [&](bool force) {
+      const auto now = SteadyClock::now();
+      const auto sinceLastReport =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              now - lastProgressReportAt);
+      if (!force && sinceLastReport.count() < 250) {
+        return;
+      }
+      std::cerr << "progress frame=" << frameCount
+                << " total=" << expectedFrameCount << '\n';
+      lastProgressReportAt = now;
+    };
     while (true) {
+      const auto inputReadStartedAt = SteadyClock::now();
       std::size_t bytesRead = 0;
       if (streamInput) {
         bytesRead = readAll(STDIN_FILENO, rgba.data(), rgba.size());
@@ -435,27 +526,29 @@ int main(int argc, char **argv) {
                         static_cast<std::streamsize>(rgba.size()));
         bytesRead = static_cast<std::size_t>(rgbaInput->gcount());
       }
+      timing.inputReadMicros += elapsedMicros(inputReadStartedAt);
       if (bytesRead == 0) {
         break;
       }
       if (bytesRead != rgba.size()) {
-        releaseHandle(handle);
         throw std::runtime_error("input ended with an incomplete RGBA frame");
       }
+      const auto rgbaToBgrStartedAt = SteadyClock::now();
       for (std::size_t source = 0, target = 0; source < rgba.size();
            source += 4, target += 3) {
         bgr[target] = rgba[source + 2];
         bgr[target + 1] = rgba[source + 1];
         bgr[target + 2] = rgba[source];
       }
+      timing.rgbaToBgrMicros += elapsedMicros(rgbaToBgrStartedAt);
+      const auto gruInferenceStartedAt = SteadyClock::now();
       const int processStatus = processFrame(handle, &input, &output);
+      timing.gruInferenceMicros += elapsedMicros(gruInferenceStartedAt);
       if (processStatus != 0) {
-        releaseHandle(handle);
         throw std::runtime_error("cannot process matting frame: " +
                                  std::to_string(processStatus));
       }
       if (output.width != alphaWidth || output.height != alphaHeight) {
-        releaseHandle(handle);
         throw std::runtime_error(
             "matting output dimensions changed unexpectedly");
       }
@@ -463,21 +556,23 @@ int main(int argc, char **argv) {
         rawAlphaFile->write(reinterpret_cast<const char *>(alpha.data()),
                             static_cast<std::streamsize>(alpha.size()));
         if (!*rawAlphaFile) {
-          releaseHandle(handle);
           throw std::runtime_error("cannot write raw alpha diagnostic frame");
         }
       }
+      const auto alphaResizeStartedAt = SteadyClock::now();
       const auto fullSizeAlpha = qcut::matting::resizeAlphaBilinear(
           alpha, alphaWidth, alphaHeight, width, height);
+      timing.alphaResizeMicros += elapsedMicros(alphaResizeStartedAt);
+      const auto visionInferenceStartedAt = SteadyClock::now();
       const auto visionAlpha = visionSegmentation
                                    ? visionSegmentation->segment(rgba)
                                    : std::vector<std::uint8_t>{};
+      timing.visionInferenceMicros += elapsedMicros(visionInferenceStartedAt);
       if (preTemporalAlphaFile) {
         preTemporalAlphaFile->write(
             reinterpret_cast<const char *>(fullSizeAlpha.data()),
             static_cast<std::streamsize>(fullSizeAlpha.size()));
         if (!*preTemporalAlphaFile) {
-          releaseHandle(handle);
           throw std::runtime_error(
               "cannot write pre-temporal alpha diagnostic frame");
         }
@@ -490,34 +585,82 @@ int main(int argc, char **argv) {
       });
       frameCount += 1;
       flushTemporalWindow(false);
-      std::cerr << "progress frame=" << frameCount
-                << " total=" << expectedFrameCount << '\n';
+      reportProgress(false);
     }
     if (frameCount == 0 ||
         (expectedFrameCount > 0 && frameCount != expectedFrameCount)) {
-      releaseHandle(handle);
       throw std::runtime_error("input does not contain complete RGBA frames");
     }
     flushTemporalWindow(true);
+    reportProgress(true);
     if (nextOutputFrame != frameCount) {
-      releaseHandle(handle);
       throw std::runtime_error("temporal window did not emit every frame");
     }
-    releaseHandle(handle);
+    if (metalBlend && !nativeMetalCanaryPassed) {
+      throw std::runtime_error("native blend canary did not run");
+    }
+    const auto processingMicros = elapsedMicros(processingStartedAt);
+    const auto teardownStartedAt = SteadyClock::now();
+    const auto outputFlushStartedAt = SteadyClock::now();
+    flushFile(outputFile, "alpha output");
+    timing.outputFlushMicros += elapsedMicros(outputFlushStartedAt);
+    flushFile(rawAlphaFile, "raw alpha diagnostic output");
+    flushFile(preTemporalAlphaFile, "pre-temporal alpha diagnostic output");
+    flushFile(preBorderTemporalAlphaFile,
+              "pre-border temporal alpha diagnostic output");
+    outputFile.reset();
+    rawAlphaFile.reset();
+    preTemporalAlphaFile.reset();
+    preBorderTemporalAlphaFile.reset();
+    inputFile.reset();
     if (alphaOutputDescriptor >= 0) {
       ::close(alphaOutputDescriptor);
+      alphaOutputDescriptor = -1;
     }
+    const bool visionPersonFusionRan = visionSegmentation != nullptr;
+    visionSegmentation.reset();
+    metalBlend.reset();
+    handleOwner.reset();
+    libraryOwner.reset();
+    const auto teardownMicros = elapsedMicros(teardownStartedAt);
+    const auto wallMicros = elapsedMicros(programStartedAt);
     std::cerr << "ok width=" << width << " height=" << height
               << " alphaWidth=" << alphaWidth << " alphaHeight=" << alphaHeight
               << " frames=" << frameCount << " modelType=" << modelType
               << " internalModelType=" << internalModelType
-              << " blend="
-              << (useNativeMetal ? "TEMattingBlendEffectV2-native-metal"
-                                 : "TEMattingBlendEffectV2-compatible")
+              << " blend=TEMattingBlendEffectV2-compatible"
+              << " nativeMetalCanary="
+              << (nativeMetalCanaryPassed
+                      ? "TEMattingBlendEffectV2-native-metal-canary"
+                      : "not-run")
               << " visionFusion="
-              << (visionSegmentation ? "Vision-person-fusion-v1" : "disabled")
+              << (visionPersonFusionRan ? "Vision-person-fusion-v1" : "disabled")
+              << " nativeMetalCanaryFrames=" << nativeMetalCanaryFrames
               << '\n';
-    dlclose(library);
+    if (emitTimingJson) {
+      std::cerr
+          << "qcut-person-cutout-timing {\"schema\":1,\"frames\":"
+          << frameCount << ",\"total_us\":" << wallMicros
+          << ",\"wall_us\":" << wallMicros
+          << ",\"setup_us\":" << setupMicros
+          << ",\"processing_us\":" << processingMicros
+          << ",\"teardown_us\":" << teardownMicros
+          << ",\"input_read_us\":" << timing.inputReadMicros
+          << ",\"rgba_to_bgr_us\":" << timing.rgbaToBgrMicros
+          << ",\"gru_infer_us\":" << timing.gruInferenceMicros
+          << ",\"alpha_resize_us\":" << timing.alphaResizeMicros
+          << ",\"vision_infer_us\":" << timing.visionInferenceMicros
+          << ",\"postprocess_us\":" << timing.postprocessMicros
+          << ",\"native_validation_us\":"
+          << timing.nativeValidationMicros
+          << ",\"native_canary_us\":" << timing.nativeValidationMicros
+          << ",\"cache_write_us\":" << timing.cacheWriteMicros
+          << ",\"output_flush_us\":" << timing.outputFlushMicros
+          << ",\"native_validation_frames\":"
+          << nativeMetalCanaryFrames
+          << ",\"native_canary_frames\":" << nativeMetalCanaryFrames
+          << "}\n";
+    }
     return 0;
   } catch (const std::exception &error) {
     std::cerr << error.what() << '\n';

--- a/qcut/electron/jianying-person-cutout/native/matting-gru-bridge.cpp
+++ b/qcut/electron/jianying-person-cutout/native/matting-gru-bridge.cpp
@@ -1,0 +1,526 @@
+#include "alpha-mask-fusion.hpp"
+#include "alpha-refinement.hpp"
+#include "alpha-resize.hpp"
+#include "alpha-temporal-stabilizer.hpp"
+#include "metal-matting-blend.hpp"
+#include "vision-person-segmentation.hpp"
+
+#include <dlfcn.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstddef>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <deque>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct MattingInput {
+  const std::uint8_t *data;
+  std::int32_t pixelFormat;
+  std::int32_t width;
+  std::int32_t height;
+  std::int32_t stride;
+  std::int32_t orientation;
+  std::int32_t reserved;
+  bool invertAlpha;
+};
+
+static_assert(offsetof(MattingInput, invertAlpha) == 0x20);
+
+struct MattingOutput {
+  std::uint8_t *alpha;
+  std::int32_t width;
+  std::int32_t height;
+};
+
+using CreateHandle = int (*)(void **);
+using InitModel = int (*)(void *, int, const char *);
+using GetParam = int (*)(void *, int, int *);
+using GetAlphaSize = int (*)(void *, int, int, int *, int *);
+using SetParam = int (*)(void *, int, int);
+using ProcessFrame = int (*)(void *, const MattingInput *, MattingOutput *);
+using ReleaseHandle = int (*)(void *);
+
+template <typename Function>
+Function requireSymbol(void *library, const char *name) {
+  auto *symbol = dlsym(library, name);
+  if (!symbol) {
+    throw std::runtime_error(std::string("missing symbol: ") + name);
+  }
+  return reinterpret_cast<Function>(symbol);
+}
+
+int parsePositiveInteger(const char *text, const char *label) {
+  const int value = std::stoi(text);
+  if (value <= 0) {
+    throw std::runtime_error(std::string(label) + " must be positive");
+  }
+  return value;
+}
+
+void writeAll(int fileDescriptor, const std::uint8_t *data, std::size_t size) {
+  std::size_t written = 0;
+  while (written < size) {
+    const auto result = ::write(fileDescriptor, data + written, size - written);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    if (result <= 0) {
+      throw std::runtime_error("cannot write alpha frame");
+    }
+    written += static_cast<std::size_t>(result);
+  }
+}
+
+std::size_t readAll(int fileDescriptor, std::uint8_t *data, std::size_t size) {
+  std::size_t bytesRead = 0;
+  while (bytesRead < size) {
+    const auto result =
+        ::read(fileDescriptor, data + bytesRead, size - bytesRead);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    if (result < 0) {
+      throw std::runtime_error("cannot read RGBA input");
+    }
+    if (result == 0) {
+      break;
+    }
+    bytesRead += static_cast<std::size_t>(result);
+  }
+  return bytesRead;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  bool useNativeMetal = false;
+  bool useVisionPersonFusion = false;
+  bool validOptions = argc >= 12;
+  for (int optionIndex = 12; validOptions && optionIndex < argc;
+       ++optionIndex) {
+    const std::string option = argv[optionIndex];
+    if (option == "--vision-person-fusion") {
+      useVisionPersonFusion = true;
+      continue;
+    }
+    if (option == "--blend" && optionIndex + 1 < argc &&
+        std::string(argv[optionIndex + 1]) == "native-metal") {
+      useNativeMetal = true;
+      optionIndex += 1;
+      continue;
+    }
+    validOptions = false;
+  }
+  if (!validOptions) {
+    std::cerr << "usage: portrait-matting-gru-bridge <libcccreator> <model> "
+                 "<model-type> <input.rgba> <width> <height> <output.gray> "
+                 "<threshold> <temporal-smoothing> <edge-shift> <feather> "
+                 "[--vision-person-fusion] [--blend native-metal]\n";
+    return 2;
+  }
+
+  try {
+    const int modelType = std::stoi(argv[3]);
+    const int width = parsePositiveInteger(argv[5], "width");
+    const int height = parsePositiveInteger(argv[6], "height");
+    const float threshold = std::clamp(std::stof(argv[8]), 0.0F, 1.0F);
+    const float temporalSmoothing = std::clamp(std::stof(argv[9]), 0.0F, 0.95F);
+    const float edgeShift = std::clamp(std::stof(argv[10]), -12.0F, 12.0F);
+    const float feather = std::clamp(std::stof(argv[11]), 0.0F, 16.0F);
+    const auto frameBytes = static_cast<std::size_t>(width) * height * 4;
+    const bool streamInput = std::string(argv[4]) == "-";
+    const bool streamOutput = std::string(argv[7]) == "-";
+    std::unique_ptr<std::ifstream> inputFile;
+    std::istream *rgbaInput = &std::cin;
+    std::size_t expectedFrameCount = 0;
+    if (!streamInput) {
+      inputFile = std::make_unique<std::ifstream>(
+          argv[4], std::ios::binary | std::ios::ate);
+      if (!*inputFile) {
+        throw std::runtime_error("cannot open input file");
+      }
+      const auto inputBytes = inputFile->tellg();
+      if (inputBytes <= 0 ||
+          static_cast<std::size_t>(inputBytes) % frameBytes != 0) {
+        throw std::runtime_error("input does not contain complete RGBA frames");
+      }
+      expectedFrameCount =
+          static_cast<std::size_t>(inputBytes) / frameBytes;
+      inputFile->seekg(0);
+      rgbaInput = inputFile.get();
+    }
+    std::unique_ptr<std::ofstream> outputFile;
+    std::unique_ptr<std::ofstream> rawAlphaFile;
+    std::unique_ptr<std::ofstream> preTemporalAlphaFile;
+    std::unique_ptr<std::ofstream> preBorderTemporalAlphaFile;
+    int alphaOutputDescriptor = -1;
+    if (streamOutput) {
+      alphaOutputDescriptor = ::dup(STDOUT_FILENO);
+      if (alphaOutputDescriptor < 0 ||
+          ::dup2(STDERR_FILENO, STDOUT_FILENO) < 0) {
+        throw std::runtime_error("cannot isolate alpha output stream");
+      }
+    } else {
+      outputFile =
+          std::make_unique<std::ofstream>(argv[7], std::ios::binary);
+      if (!*outputFile) {
+        throw std::runtime_error("cannot open output file");
+      }
+    }
+    if (const char *rawAlphaPath =
+            std::getenv("QCUT_PERSON_CUTOUT_RAW_ALPHA_PATH")) {
+      rawAlphaFile =
+          std::make_unique<std::ofstream>(rawAlphaPath, std::ios::binary);
+      if (!*rawAlphaFile) {
+        throw std::runtime_error("cannot open raw alpha diagnostic file");
+      }
+    }
+    if (const char *preBorderTemporalAlphaPath =
+            std::getenv("QCUT_PERSON_CUTOUT_PRE_BORDER_ALPHA_PATH")) {
+      preBorderTemporalAlphaFile = std::make_unique<std::ofstream>(
+          preBorderTemporalAlphaPath, std::ios::binary);
+      if (!*preBorderTemporalAlphaFile) {
+        throw std::runtime_error(
+            "cannot open pre-border temporal alpha diagnostic file");
+      }
+    }
+    if (const char *preTemporalAlphaPath =
+            std::getenv("QCUT_PERSON_CUTOUT_PRE_TEMPORAL_ALPHA_PATH")) {
+      preTemporalAlphaFile = std::make_unique<std::ofstream>(
+          preTemporalAlphaPath, std::ios::binary);
+      if (!*preTemporalAlphaFile) {
+        throw std::runtime_error(
+            "cannot open pre-temporal alpha diagnostic file");
+      }
+    }
+
+    std::vector<std::uint8_t> rgba(frameBytes);
+    std::vector<std::uint8_t> bgr(frameBytes / 4 * 3);
+    void *library = dlopen(
+        argv[1], RTLD_NOW | (useNativeMetal ? RTLD_GLOBAL : RTLD_LOCAL));
+    if (!library) {
+      throw std::runtime_error(std::string("cannot load runtime: ") +
+                               dlerror());
+    }
+    const auto createHandle = requireSymbol<CreateHandle>(
+        library, "bef_Portrait_Matting_CreateHandle");
+    const auto initModel =
+        requireSymbol<InitModel>(library, "bef_Portrait_Matting_InitModel");
+    const auto getParam = requireSymbol<GetParam>(
+        library, "bef_Portrait_Matting_GetParam");
+    const auto getAlphaSize =
+        requireSymbol<GetAlphaSize>(library, "bef_MP_GetAlphaSize");
+    const auto setParam = requireSymbol<SetParam>(library, "bef_MP_SetParam");
+    const auto processFrame = requireSymbol<ProcessFrame>(
+        library, "bef_Portrait_Matting_DoPortraitMatting");
+    const auto releaseHandle = requireSymbol<ReleaseHandle>(
+        library, "bef_Portrait_Matting_ReleaseHandle");
+
+    constexpr std::pair<int, int> graphParameters[] = {
+        {5, 1}, {6, -1}, {7, 1}, {8, 1}, {1, 15}, {0, 1}, {5, 1},
+    };
+    struct InitializedMattingHandle {
+      void *handle;
+      int alphaWidth;
+      int alphaHeight;
+      int internalModelType;
+    };
+    const auto initializeHandle = [&]() {
+      void *newHandle = nullptr;
+      const int createStatus = createHandle(&newHandle);
+      if (createStatus != 0 || !newHandle) {
+        throw std::runtime_error("cannot create matting handle: " +
+                                 std::to_string(createStatus));
+      }
+      const int initStatus = initModel(newHandle, modelType, argv[2]);
+      if (initStatus != 0) {
+        releaseHandle(newHandle);
+        throw std::runtime_error("cannot initialize matting model: " +
+                                 std::to_string(initStatus));
+      }
+      int resolvedModelType = -1;
+      const int modelTypeStatus =
+          getParam(newHandle, 6, &resolvedModelType);
+      if (modelTypeStatus != 0 || resolvedModelType != 6) {
+        releaseHandle(newHandle);
+        throw std::runtime_error("unexpected internal matting model type: " +
+                                 std::to_string(resolvedModelType));
+      }
+      for (const auto &[parameter, value] : graphParameters) {
+        const int parameterStatus = setParam(newHandle, parameter, value);
+        if (parameterStatus != 0) {
+          releaseHandle(newHandle);
+          throw std::runtime_error(
+              "cannot configure matting graph parameter " +
+              std::to_string(parameter) + ": " +
+              std::to_string(parameterStatus));
+        }
+      }
+      int resolvedAlphaWidth = 0;
+      int resolvedAlphaHeight = 0;
+      const int sizeStatus = getAlphaSize(newHandle, width, height,
+                                          &resolvedAlphaWidth,
+                                          &resolvedAlphaHeight);
+      if (sizeStatus != 0 || resolvedAlphaWidth <= 0 ||
+          resolvedAlphaHeight <= 0 || resolvedAlphaWidth > width ||
+          resolvedAlphaHeight > height) {
+        releaseHandle(newHandle);
+        throw std::runtime_error("cannot resolve alpha size: " +
+                                 std::to_string(sizeStatus));
+      }
+      return InitializedMattingHandle{
+          .handle = newHandle,
+          .alphaWidth = resolvedAlphaWidth,
+          .alphaHeight = resolvedAlphaHeight,
+          .internalModelType = resolvedModelType,
+      };
+    };
+    const auto initializedHandle = initializeHandle();
+    void *handle = initializedHandle.handle;
+    const int alphaWidth = initializedHandle.alphaWidth;
+    const int alphaHeight = initializedHandle.alphaHeight;
+    const int internalModelType = initializedHandle.internalModelType;
+    std::vector<std::uint8_t> alpha(static_cast<std::size_t>(alphaWidth) *
+                                    alphaHeight);
+    std::unique_ptr<qcut::matting::MetalMattingBlend> metalBlend;
+    if (useNativeMetal) {
+      metalBlend = std::make_unique<qcut::matting::MetalMattingBlend>(
+          qcut::matting::MetalMattingBlendConfig{
+              .library = library,
+              .width = width,
+              .height = height,
+          });
+    }
+    std::unique_ptr<qcut::matting::VisionPersonSegmentation>
+        visionSegmentation;
+    const bool visionFusionEnabled =
+        useVisionPersonFusion &&
+        std::getenv("QCUT_DISABLE_VISION_PERSON_FUSION") == nullptr;
+    if (visionFusionEnabled) {
+      try {
+        visionSegmentation =
+            std::make_unique<qcut::matting::VisionPersonSegmentation>(width,
+                                                                     height);
+      } catch (const std::exception &error) {
+        std::cerr << "Vision-person-fusion-v1 unavailable: " << error.what()
+                  << '\n';
+      }
+    }
+
+    MattingInput input{
+        .data = bgr.data(),
+        // Pixel format 2 is the runtime's BGR888 fast path.
+        .pixelFormat = 2,
+        .width = width,
+        .height = height,
+        .stride = width * 3,
+        .orientation = 0,
+        .reserved = 0,
+        .invertAlpha = false,
+    };
+    MattingOutput output{
+        .alpha = alpha.data(),
+        .width = alphaWidth,
+        .height = alphaHeight,
+    };
+    struct BufferedAlphaFrame {
+      std::size_t index;
+      std::vector<std::uint8_t> rgba;
+      std::vector<std::uint8_t> alpha;
+      std::vector<std::uint8_t> visionAlpha;
+    };
+    constexpr std::size_t temporalRadius = 5;
+    std::deque<BufferedAlphaFrame> temporalWindow;
+    std::vector<float> temporalState;
+    std::size_t frameCount = 0;
+    std::size_t nextOutputFrame = 0;
+    const auto writeAlpha = [&](const std::vector<std::uint8_t> &finalAlpha) {
+      if (streamOutput) {
+        writeAll(alphaOutputDescriptor, finalAlpha.data(), finalAlpha.size());
+        return;
+      }
+      outputFile->write(reinterpret_cast<const char *>(finalAlpha.data()),
+                        static_cast<std::streamsize>(finalAlpha.size()));
+      if (!*outputFile) {
+        throw std::runtime_error("cannot write alpha frame");
+      }
+    };
+    const auto flushTemporalWindow = [&](bool flushAll) {
+      while (!temporalWindow.empty() && nextOutputFrame < frameCount) {
+        const auto newestFrame = temporalWindow.back().index;
+        if (!flushAll && newestFrame < nextOutputFrame + temporalRadius) {
+          break;
+        }
+        const auto target = std::find_if(
+            temporalWindow.begin(), temporalWindow.end(),
+            [&](const auto &frame) { return frame.index == nextOutputFrame; });
+        if (target == temporalWindow.end()) {
+          throw std::runtime_error("temporal window lost an output frame");
+        }
+        std::vector<qcut::matting::TemporalForegroundFrameView> frameViews;
+        for (const auto &frame : temporalWindow) {
+          const auto distance = static_cast<long long>(frame.index) -
+                                static_cast<long long>(nextOutputFrame);
+          if (std::abs(distance) > static_cast<long long>(temporalRadius)) {
+            continue;
+          }
+          frameViews.push_back(qcut::matting::TemporalForegroundFrameView{
+              .rgba = &frame.rgba,
+              .alpha = &frame.alpha,
+              .frameOffset = static_cast<int>(distance),
+          });
+        }
+        const auto temporallyStabilizedAlpha =
+            temporalSmoothing <= 0.05F
+                ? qcut::matting::stabilizeTemporalForeground(frameViews, width,
+                                                               height)
+                : target->alpha;
+        const auto fusedAlpha =
+            target->visionAlpha.empty()
+                ? temporallyStabilizedAlpha
+                : qcut::matting::fusePersonAlpha(temporallyStabilizedAlpha,
+                                                 target->visionAlpha);
+        if (preBorderTemporalAlphaFile) {
+          preBorderTemporalAlphaFile->write(
+              reinterpret_cast<const char *>(fusedAlpha.data()),
+              static_cast<std::streamsize>(fusedAlpha.size()));
+          if (!*preBorderTemporalAlphaFile) {
+            throw std::runtime_error(
+                "cannot write pre-border temporal alpha diagnostic frame");
+          }
+        }
+        const auto borderProcessedAlpha =
+            qcut::matting::applyJianyingPortraitBorderLut(
+                fusedAlpha);
+        const auto refinedAlpha = qcut::matting::refineAlpha(
+            borderProcessedAlpha, temporalState, width, height, threshold,
+            temporalSmoothing, edgeShift, feather);
+        const auto finalAlpha =
+            metalBlend
+                ? metalBlend->blendAlpha(
+                      qcut::matting::MetalMattingBlendFrame{
+                          .rgba = target->rgba,
+                          .alpha = refinedAlpha,
+                          .alphaWidth = width,
+                          .alphaHeight = height,
+                      })
+                : refinedAlpha;
+        writeAlpha(finalAlpha);
+        nextOutputFrame += 1;
+        while (!temporalWindow.empty() &&
+               temporalWindow.front().index + temporalRadius <
+                   nextOutputFrame) {
+          temporalWindow.pop_front();
+        }
+      }
+    };
+    while (true) {
+      std::size_t bytesRead = 0;
+      if (streamInput) {
+        bytesRead = readAll(STDIN_FILENO, rgba.data(), rgba.size());
+      } else {
+        rgbaInput->read(reinterpret_cast<char *>(rgba.data()),
+                        static_cast<std::streamsize>(rgba.size()));
+        bytesRead = static_cast<std::size_t>(rgbaInput->gcount());
+      }
+      if (bytesRead == 0) {
+        break;
+      }
+      if (bytesRead != rgba.size()) {
+        releaseHandle(handle);
+        throw std::runtime_error("input ended with an incomplete RGBA frame");
+      }
+      for (std::size_t source = 0, target = 0; source < rgba.size();
+           source += 4, target += 3) {
+        bgr[target] = rgba[source + 2];
+        bgr[target + 1] = rgba[source + 1];
+        bgr[target + 2] = rgba[source];
+      }
+      const int processStatus = processFrame(handle, &input, &output);
+      if (processStatus != 0) {
+        releaseHandle(handle);
+        throw std::runtime_error("cannot process matting frame: " +
+                                 std::to_string(processStatus));
+      }
+      if (output.width != alphaWidth || output.height != alphaHeight) {
+        releaseHandle(handle);
+        throw std::runtime_error(
+            "matting output dimensions changed unexpectedly");
+      }
+      if (rawAlphaFile) {
+        rawAlphaFile->write(reinterpret_cast<const char *>(alpha.data()),
+                            static_cast<std::streamsize>(alpha.size()));
+        if (!*rawAlphaFile) {
+          releaseHandle(handle);
+          throw std::runtime_error("cannot write raw alpha diagnostic frame");
+        }
+      }
+      const auto fullSizeAlpha = qcut::matting::resizeAlphaBilinear(
+          alpha, alphaWidth, alphaHeight, width, height);
+      const auto visionAlpha = visionSegmentation
+                                   ? visionSegmentation->segment(rgba)
+                                   : std::vector<std::uint8_t>{};
+      if (preTemporalAlphaFile) {
+        preTemporalAlphaFile->write(
+            reinterpret_cast<const char *>(fullSizeAlpha.data()),
+            static_cast<std::streamsize>(fullSizeAlpha.size()));
+        if (!*preTemporalAlphaFile) {
+          releaseHandle(handle);
+          throw std::runtime_error(
+              "cannot write pre-temporal alpha diagnostic frame");
+        }
+      }
+      temporalWindow.push_back(BufferedAlphaFrame{
+          .index = frameCount,
+          .rgba = rgba,
+          .alpha = fullSizeAlpha,
+          .visionAlpha = visionAlpha,
+      });
+      frameCount += 1;
+      flushTemporalWindow(false);
+      std::cerr << "progress frame=" << frameCount
+                << " total=" << expectedFrameCount << '\n';
+    }
+    if (frameCount == 0 ||
+        (expectedFrameCount > 0 && frameCount != expectedFrameCount)) {
+      releaseHandle(handle);
+      throw std::runtime_error("input does not contain complete RGBA frames");
+    }
+    flushTemporalWindow(true);
+    if (nextOutputFrame != frameCount) {
+      releaseHandle(handle);
+      throw std::runtime_error("temporal window did not emit every frame");
+    }
+    releaseHandle(handle);
+    if (alphaOutputDescriptor >= 0) {
+      ::close(alphaOutputDescriptor);
+    }
+    std::cerr << "ok width=" << width << " height=" << height
+              << " alphaWidth=" << alphaWidth << " alphaHeight=" << alphaHeight
+              << " frames=" << frameCount << " modelType=" << modelType
+              << " internalModelType=" << internalModelType
+              << " blend="
+              << (useNativeMetal ? "TEMattingBlendEffectV2-native-metal"
+                                 : "TEMattingBlendEffectV2-compatible")
+              << " visionFusion="
+              << (visionSegmentation ? "Vision-person-fusion-v1" : "disabled")
+              << '\n';
+    dlclose(library);
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}

--- a/qcut/electron/jianying-person-cutout/native/metal-matting-blend.cpp
+++ b/qcut/electron/jianying-person-cutout/native/metal-matting-blend.cpp
@@ -1,0 +1,462 @@
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+#include "metal-matting-blend.hpp"
+
+#include <OpenGL/OpenGL.h>
+
+#include <dlfcn.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace qcut::matting {
+namespace {
+
+constexpr int kRgba8PixelFormat = 0x2b;
+constexpr int kLinearFilter = 1;
+constexpr int kClampWrap = 1;
+
+struct DeviceTexture {
+  void *texture = nullptr;
+  std::uint64_t metadata = 0;
+
+  DeviceTexture() = default;
+  DeviceTexture(const DeviceTexture &other)
+      : texture(other.texture), metadata(other.metadata) {}
+  DeviceTexture &operator=(const DeviceTexture &other) {
+    texture = other.texture;
+    metadata = other.metadata;
+    return *this;
+  }
+  ~DeviceTexture() {}
+};
+
+static_assert(sizeof(DeviceTexture) == 0x10);
+static_assert(!std::is_trivially_copy_constructible_v<DeviceTexture>);
+
+struct MattingImage {
+  std::uint32_t format = 0;
+  std::uint32_t reserved = 0;
+  const void *data = nullptr;
+  std::uint32_t width = 0;
+  std::uint32_t height = 0;
+};
+
+static_assert(sizeof(MattingImage) == 0x18);
+
+struct FrameSize {
+  int width;
+  int height;
+};
+
+using BindRlContext = void (*)(void *, bool);
+using BlendDeviceTextureWithData = int (*) (
+    void *, const MattingImage *, const MattingImage *, int, int,
+    const MattingImage *, const float *, const std::uint8_t *);
+using ConstructBlendEffect = void *(*)(void *);
+using CreateRlContext = void (*)(std::shared_ptr<void> *, int);
+using CreateSharedRlDevice = std::shared_ptr<void> (*)(void *, void *, void *);
+using CreateTexture2D = DeviceTexture (*)(
+    void *, int, int, const void *const *, int, int, int, int, int, int *,
+    const char *, bool, bool);
+using DestroyBlendEffect = void (*)(void *);
+using DestroyTexture = void (*)(void *, DeviceTexture);
+using GetGlobalAbConfig = void *(*)();
+using GetGpDevice = void *(*)(void *);
+using GetRenderDevice = void *(*)(void *);
+using GetRlDeviceManager = void *(*)();
+using InitBlendEffect = int (*)(void *, const FrameSize &);
+using InitRlContext = void (*)(void *);
+using ReadImage = void (*)(void *, DeviceTexture, int, int, void *, int, int,
+                           int, int);
+using RemoveRlDevice = void (*)(void *, void *);
+using SetAbBool = void (*)(void *, int, bool);
+using SetBlendMode = int (*)(void *, int);
+using SetCallerManagedLegacyFallback = int (*)(void *, bool);
+using SetStrokeParam = void (*)(void *, std::int64_t, std::int64_t,
+                                std::int64_t, const std::string &);
+using UnbindRlContext = void (*)(void *);
+using UpdateTexture = void (*)(void *, DeviceTexture, const void *);
+
+template <typename Function>
+Function requireSymbol(void *library, const char *name) {
+  auto *symbol = dlsym(library, name);
+  if (!symbol) {
+    throw std::runtime_error(std::string("missing native blend symbol: ") +
+                             name);
+  }
+  return reinterpret_cast<Function>(symbol);
+}
+
+void setBooleanConfig(void *library, const char *name, int expectedKey) {
+  auto *configId = static_cast<int *>(dlsym(library, name));
+  if (!configId) {
+    const std::string underscoredName = std::string("_") + name;
+    configId = static_cast<int *>(dlsym(library, underscoredName.c_str()));
+  }
+  if (!configId || *configId != expectedKey) {
+    throw std::runtime_error(std::string("unsupported native blend config: ") +
+                             name);
+  }
+  const auto getGlobalConfig = requireSymbol<GetGlobalAbConfig>(
+      library, "_ZN10CCABConfig17getGlobalABConfigEv");
+  const auto setBool = requireSymbol<SetAbBool>(
+      library, "_ZN10CCABConfig7setBoolE11CCABKeyBoolb");
+  setBool(getGlobalConfig(), *configId, true);
+}
+
+class GlContext {
+public:
+  GlContext() {
+    const CGLPixelFormatAttribute attributes[] = {
+        kCGLPFAOpenGLProfile,
+        static_cast<CGLPixelFormatAttribute>(kCGLOGLPVersion_Legacy),
+        kCGLPFAAccelerated,
+        kCGLPFAAllowOfflineRenderers,
+        kCGLPFAColorSize,
+        static_cast<CGLPixelFormatAttribute>(32),
+        kCGLPFAAlphaSize,
+        static_cast<CGLPixelFormatAttribute>(8),
+        static_cast<CGLPixelFormatAttribute>(0),
+    };
+    GLint count = 0;
+    if (CGLChoosePixelFormat(attributes, &pixelFormat_, &count) != kCGLNoError ||
+        !pixelFormat_) {
+      throw std::runtime_error("cannot choose native blend pixel format");
+    }
+    if (CGLCreateContext(pixelFormat_, nullptr, &context_) != kCGLNoError ||
+        !context_ || CGLSetCurrentContext(context_) != kCGLNoError) {
+      throw std::runtime_error("cannot create native blend GL context");
+    }
+  }
+
+  ~GlContext() {
+    CGLSetCurrentContext(nullptr);
+    if (context_) {
+      CGLDestroyContext(context_);
+    }
+    if (pixelFormat_) {
+      CGLDestroyPixelFormat(pixelFormat_);
+    }
+  }
+
+  GlContext(const GlContext &) = delete;
+  GlContext &operator=(const GlContext &) = delete;
+
+private:
+  CGLPixelFormatObj pixelFormat_ = nullptr;
+  CGLContextObj context_ = nullptr;
+};
+
+class RlHostContext {
+public:
+  explicit RlHostContext(void *library)
+      : unbind_(requireSymbol<UnbindRlContext>(
+            library, "_ZN17TERLRenderContext6unbindEv")) {
+    const auto construct = requireSymbol<void *(*)(void *, int)>(
+        library, "_ZN17TERLRenderContextC1Ei");
+    // This private factory offset is gated by the dylib SHA-256 in runtime.ts.
+    const auto create = reinterpret_cast<CreateRlContext>(
+        reinterpret_cast<std::uintptr_t>(construct) + 0x2178U);
+    create(&context_, 30);
+    if (!context_) {
+      throw std::runtime_error("cannot create native blend render context");
+    }
+    const auto init = requireSymbol<InitRlContext>(
+        library, "_ZN17TERLRenderContext5_initEv");
+    const auto bind = requireSymbol<BindRlContext>(
+        library, "_ZN17TERLRenderContext4bindEb");
+    init(context_.get());
+    const auto getManager = requireSymbol<GetRlDeviceManager>(
+        library, "_ZN17TERLDeviceManager11getInstanceEv");
+    const auto removeDevice = requireSymbol<RemoveRlDevice>(
+        library,
+        "_ZN17TERLDeviceManager27removeRLDeviceFromGLContextEP17TESharedGLContext");
+    const auto createDevice = requireSymbol<CreateSharedRlDevice>(
+        library,
+        "_ZN17TERLDeviceManager27createRLDeviceFromGLContextEP17TESharedGLContextS1_");
+    void *manager = getManager();
+    removeDevice(manager, context_.get());
+    const std::shared_ptr<void> metalDevice =
+        createDevice(manager, context_.get(), nullptr);
+    if (!metalDevice) {
+      throw std::runtime_error("cannot create native blend Metal device");
+    }
+    *reinterpret_cast<void **>(static_cast<std::uint8_t *>(context_.get()) +
+                               0x260) = metalDevice.get();
+    bind(context_.get(), true);
+    isBound_ = true;
+
+    const auto getRenderDevice = requireSymbol<GetRenderDevice>(
+        library, "_ZN17TESharedGLContext15getRenderDeviceEv");
+    const auto getGpDevice = requireSymbol<GetGpDevice>(
+        library, "_ZN13AmazingEngine14RendererDevice11getGPDeviceEv");
+    renderDevice_ = getRenderDevice(context_.get());
+    void *rlDevice = *reinterpret_cast<void **>(
+        static_cast<std::uint8_t *>(context_.get()) + 0x260);
+    void *ownerRenderDevice =
+        rlDevice ? *reinterpret_cast<void **>(
+                       static_cast<std::uint8_t *>(rlDevice) + 0x8)
+                 : nullptr;
+    gpDevice_ = renderDevice_ ? getGpDevice(renderDevice_) : nullptr;
+    if (!renderDevice_ || !gpDevice_ || renderDevice_ != ownerRenderDevice ||
+        gpDevice_ != getGpDevice(ownerRenderDevice)) {
+      throw std::runtime_error("native blend Metal device ownership mismatch");
+    }
+  }
+
+  ~RlHostContext() {
+    if (isBound_) {
+      unbind_(context_.get());
+    }
+  }
+
+  RlHostContext(const RlHostContext &) = delete;
+  RlHostContext &operator=(const RlHostContext &) = delete;
+
+  void *renderDevice() const { return renderDevice_; }
+  const std::shared_ptr<void> &sharedContext() const { return context_; }
+
+private:
+  std::shared_ptr<void> context_;
+  void *gpDevice_ = nullptr;
+  void *renderDevice_ = nullptr;
+  UnbindRlContext unbind_;
+  bool isBound_ = false;
+};
+
+class BlendEffectRuntime {
+public:
+  BlendEffectRuntime(void *library, const std::shared_ptr<void> &sharedContext,
+                     int width, int height)
+      : destroy_(requireSymbol<DestroyBlendEffect>(
+            library, "_ZN22TEMattingBlendEffectV2D1Ev")) {
+    const auto construct = requireSymbol<ConstructBlendEffect>(
+        library, "_ZN22TEMattingBlendEffectV2C1Ev");
+    const auto init = requireSymbol<InitBlendEffect>(
+        library, "_ZN22TEMattingBlendEffectV24initERK7TESizei");
+    construct(storage_.data());
+    isConstructed_ = true;
+    auto &targetContext = *reinterpret_cast<std::shared_ptr<void> *>(
+        storage_.data() + 0x50);
+    targetContext = sharedContext;
+    const FrameSize frameSize = {.width = width, .height = height};
+    const int status = init(storage_.data(), frameSize);
+    handle_ = *reinterpret_cast<void **>(storage_.data() + 0x70);
+    if (status != 1 || storage_[0x48] != 1 || !handle_) {
+      throw std::runtime_error("native TEMattingBlendEffectV2 init failed");
+    }
+    const auto setStrokeParam = requireSymbol<SetStrokeParam>(
+        library,
+        "_ZN22TEMattingBlendEffectV214setStrokeParamExxxRKNSt3__1"
+        "12basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE");
+    setStrokeParam(
+        storage_.data(), 0, 1'000'000, 0,
+        R"({"morphologyParams":true,"erode_dilate_kernel_size":0,"blur_kernel_size":0,"enable_reverse":false,"blendPath":"device","featurePath":""})");
+
+    const auto setMode = requireSymbol<SetBlendMode>(
+        library, "bef_portrait_matting_v2_set_blend_mode");
+    const auto setFallback = requireSymbol<SetCallerManagedLegacyFallback>(
+        library,
+        "bef_portrait_matting_v2_set_caller_managed_legacy_fallback");
+    if (setMode(handle_, 0) != 0 || setFallback(handle_, true) != 0) {
+      throw std::runtime_error("cannot configure native matting blend");
+    }
+  }
+
+  ~BlendEffectRuntime() {
+    if (isConstructed_) {
+      destroy_(storage_.data());
+    }
+  }
+
+  BlendEffectRuntime(const BlendEffectRuntime &) = delete;
+  BlendEffectRuntime &operator=(const BlendEffectRuntime &) = delete;
+
+  void *handle() const { return handle_; }
+
+private:
+  alignas(16) std::array<std::uint8_t, 256> storage_{};
+  DestroyBlendEffect destroy_;
+  void *handle_ = nullptr;
+  bool isConstructed_ = false;
+};
+
+class OwnedTexture {
+public:
+  OwnedTexture(void *renderDevice, DestroyTexture destroyTexture,
+               DeviceTexture texture)
+      : renderDevice_(renderDevice), destroyTexture_(destroyTexture),
+        texture_(texture) {
+    if (!texture_.texture) {
+      throw std::runtime_error("cannot create native blend texture");
+    }
+  }
+
+  ~OwnedTexture() { destroyTexture_(renderDevice_, texture_); }
+
+  OwnedTexture(const OwnedTexture &) = delete;
+  OwnedTexture &operator=(const OwnedTexture &) = delete;
+
+  const DeviceTexture &value() const { return texture_; }
+
+private:
+  void *renderDevice_;
+  DestroyTexture destroyTexture_;
+  DeviceTexture texture_;
+};
+
+} // namespace
+
+class MetalMattingBlend::Impl {
+public:
+  explicit Impl(const MetalMattingBlendConfig &config)
+      : width_(config.width), height_(config.height), glContext_(),
+        rlContext_(config.library),
+        blendEffect_(config.library, rlContext_.sharedContext(), config.width,
+                     config.height),
+        createTexture_(requireSymbol<CreateTexture2D>(
+            config.library,
+            "_ZN13AmazingEngine14RendererDevice15createTexture2DEiiPKPKvNS_"
+            "14AMGPixelFormatENS_13AMGFilterModeES6_NS_11AMGWrapModeES7_PiPKcbb")),
+        destroyTexture_(requireSymbol<DestroyTexture>(
+            config.library,
+            "_ZN13AmazingEngine14RendererDevice14destroyTextureE13DeviceTexture")),
+        updateTexture_(requireSymbol<UpdateTexture>(
+            config.library,
+            "_ZN13AmazingEngine14RendererDevice13updateTextureE13DeviceTexturePKv")),
+        readImage_(requireSymbol<ReadImage>(
+            config.library,
+            "_ZN13AmazingEngine14RendererDevice9readImageE13DeviceTextureiiPvNS_"
+            "8FlipModeENS_10RotateModeENS_13AMGFilterModeENS_14AMGPixelFormatE")),
+        blend_(requireSymbol<BlendDeviceTextureWithData>(
+            config.library,
+            "bef_portrait_matting_v2_blend_device_texture_with_data")) {
+    if (!config.library || width_ <= 0 || height_ <= 0) {
+      throw std::runtime_error("invalid native blend configuration");
+    }
+    void *renderDevice = rlContext_.renderDevice();
+    inputTexture_ = createReusableTexture(renderDevice, "qcut matting input");
+    alphaTexture_ = createReusableTexture(renderDevice, "qcut matting alpha");
+    outputTexture_ = std::make_unique<OwnedTexture>(
+        renderDevice, destroyTexture_,
+        createTexture_(renderDevice, width_, height_, nullptr,
+                       kRgba8PixelFormat, kLinearFilter, kLinearFilter,
+                       kClampWrap, kClampWrap, nullptr,
+                       "qcut matting output", false, false));
+  }
+
+  std::vector<std::uint8_t>
+  blendAlpha(const MetalMattingBlendFrame &frame) const {
+    const std::size_t pixelCount =
+        static_cast<std::size_t>(width_) * height_;
+    if (frame.rgba.size() != pixelCount * 4U || frame.alphaWidth != width_ ||
+        frame.alphaHeight != height_ || frame.alpha.size() != pixelCount) {
+      throw std::runtime_error("native blend frame dimensions do not match");
+    }
+    std::vector<std::uint8_t> alphaRgba(pixelCount * 4U);
+    for (std::size_t index = 0; index < pixelCount; ++index) {
+      const std::uint8_t value = frame.alpha[index];
+      const std::size_t offset = index * 4U;
+      alphaRgba[offset] = value;
+      alphaRgba[offset + 1U] = value;
+      alphaRgba[offset + 2U] = value;
+      alphaRgba[offset + 3U] = value;
+    }
+    void *renderDevice = rlContext_.renderDevice();
+    updateTexture_(renderDevice, inputTexture_->value(), frame.rgba.data());
+    updateTexture_(renderDevice, alphaTexture_->value(), alphaRgba.data());
+
+    const MattingImage inputImage = {
+        .data = &inputTexture_->value(),
+        .width = static_cast<std::uint32_t>(width_),
+        .height = static_cast<std::uint32_t>(height_),
+    };
+    const MattingImage outputImage = {
+        .data = &outputTexture_->value(),
+        .width = static_cast<std::uint32_t>(width_),
+        .height = static_cast<std::uint32_t>(height_),
+    };
+    const MattingImage alphaImage = {
+        .data = &alphaTexture_->value(),
+        .width = static_cast<std::uint32_t>(width_),
+        .height = static_cast<std::uint32_t>(height_),
+    };
+    const std::array<float, 4> fullFrame = {0.0F, 0.0F, 1.0F, 1.0F};
+    const std::array<std::uint8_t, 4> transparent = {0, 0, 0, 0};
+    const int blendStatus = blend_(
+        blendEffect_.handle(), &inputImage, &outputImage, width_, height_,
+        &alphaImage, fullFrame.data(), transparent.data());
+    if (blendStatus != 0) {
+      throw std::runtime_error("native matting blend failed: " +
+                               std::to_string(blendStatus));
+    }
+
+    std::vector<std::uint8_t> blendedRgba(frame.rgba.size());
+    readImage_(renderDevice, outputTexture_->value(), width_, height_,
+               blendedRgba.data(), 0, 0, kLinearFilter, kRgba8PixelFormat);
+    std::vector<std::uint8_t> blendedAlpha(pixelCount);
+    for (std::size_t index = 0; index < pixelCount; ++index) {
+      const std::size_t rgbaOffset = index * 4U;
+      const auto expected = static_cast<std::uint8_t>(
+          (static_cast<unsigned int>(frame.rgba[rgbaOffset + 3U]) *
+               frame.alpha[index] +
+           127U) /
+          255U);
+      blendedAlpha[index] = blendedRgba[rgbaOffset + 3U];
+      if (blendedAlpha[index] != expected) {
+        throw std::runtime_error("native blend alpha verification failed");
+      }
+    }
+    return blendedAlpha;
+  }
+
+private:
+  std::unique_ptr<OwnedTexture> createReusableTexture(void *renderDevice,
+                                                       const char *label) {
+    return std::make_unique<OwnedTexture>(
+        renderDevice, destroyTexture_,
+        createTexture_(renderDevice, width_, height_, nullptr,
+                       kRgba8PixelFormat, kLinearFilter, kLinearFilter,
+                       kClampWrap, kClampWrap, nullptr, label, false, false));
+  }
+
+  int width_;
+  int height_;
+  GlContext glContext_;
+  RlHostContext rlContext_;
+  BlendEffectRuntime blendEffect_;
+  CreateTexture2D createTexture_;
+  DestroyTexture destroyTexture_;
+  UpdateTexture updateTexture_;
+  ReadImage readImage_;
+  BlendDeviceTextureWithData blend_;
+  std::unique_ptr<OwnedTexture> inputTexture_;
+  std::unique_ptr<OwnedTexture> alphaTexture_;
+  std::unique_ptr<OwnedTexture> outputTexture_;
+};
+
+MetalMattingBlend::MetalMattingBlend(const MetalMattingBlendConfig &config)
+    : impl_(nullptr) {
+  setBooleanConfig(config.library, "ConfigID_EnableAGFXMetal", 372);
+  setBooleanConfig(config.library, "ConfigID_VeabtestEnableMetalV2", 377);
+  setBooleanConfig(config.library, "ConfigID_EnablePortraitMattingBlendV2",
+                   568);
+  impl_ = std::make_unique<Impl>(config);
+}
+
+MetalMattingBlend::~MetalMattingBlend() = default;
+
+std::vector<std::uint8_t>
+MetalMattingBlend::blendAlpha(const MetalMattingBlendFrame &frame) const {
+  return impl_->blendAlpha(frame);
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/metal-matting-blend.cpp
+++ b/qcut/electron/jianying-person-cutout/native/metal-matting-blend.cpp
@@ -10,6 +10,8 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -132,13 +134,15 @@ public:
       throw std::runtime_error("cannot choose native blend pixel format");
     }
     if (CGLCreateContext(pixelFormat_, nullptr, &context_) != kCGLNoError ||
-        !context_ || CGLSetCurrentContext(context_) != kCGLNoError) {
+        !context_ || !makeCurrent()) {
       throw std::runtime_error("cannot create native blend GL context");
     }
   }
 
   ~GlContext() {
-    CGLSetCurrentContext(nullptr);
+    if (CGLGetCurrentContext() == context_) {
+      CGLSetCurrentContext(nullptr);
+    }
     if (context_) {
       CGLDestroyContext(context_);
     }
@@ -149,6 +153,12 @@ public:
 
   GlContext(const GlContext &) = delete;
   GlContext &operator=(const GlContext &) = delete;
+
+  bool makeCurrent() const noexcept {
+    return context_ != nullptr &&
+           CGLSetCurrentContext(context_) == kCGLNoError &&
+           CGLGetCurrentContext() == context_;
+  }
 
 private:
   CGLPixelFormatObj pixelFormat_ = nullptr;
@@ -313,7 +323,81 @@ private:
   DeviceTexture texture_;
 };
 
+std::size_t checkedPixelCount(int width, int height, const char *label) {
+  if (width <= 0 || height <= 0) {
+    throw std::runtime_error(std::string(label) + " dimensions are invalid");
+  }
+  const auto pixelCount =
+      static_cast<std::size_t>(width) * static_cast<std::size_t>(height);
+  if (pixelCount > std::numeric_limits<std::size_t>::max() / 4U) {
+    throw std::runtime_error(std::string(label) + " dimensions overflow");
+  }
+  return pixelCount;
+}
+
 } // namespace
+
+namespace detail {
+
+void validateMetalMattingBlendFrame(const MetalMattingBlendFrame &frame,
+                                    int width, int height) {
+  const std::size_t sourcePixelCount =
+      checkedPixelCount(width, height, "native blend source");
+  const std::size_t alphaPixelCount = checkedPixelCount(
+      frame.alphaWidth, frame.alphaHeight, "native blend Alpha");
+  if (frame.rgba.size() != sourcePixelCount * 4U ||
+      frame.alpha.size() != alphaPixelCount) {
+    throw std::runtime_error("native blend frame dimensions do not match");
+  }
+}
+
+std::vector<std::uint8_t> extractMetalMattingBlendAlpha(
+    const MetalMattingBlendFrame &frame,
+    const std::vector<std::uint8_t> &blendedRgba, int width, int height) {
+  validateMetalMattingBlendFrame(frame, width, height);
+  const std::size_t pixelCount = checkedPixelCount(
+      width, height, "native blend output");
+  if (blendedRgba.size() != pixelCount * 4U) {
+    throw std::runtime_error("native blend output dimensions do not match");
+  }
+  const bool alphaMatchesSource =
+      frame.alphaWidth == width && frame.alphaHeight == height;
+  std::vector<std::uint8_t> blendedAlpha(pixelCount);
+  for (std::size_t index = 0; index < pixelCount; ++index) {
+    const std::size_t rgbaOffset = index * 4U;
+    const std::uint8_t sourceAlpha = frame.rgba[rgbaOffset + 3U];
+    const std::uint8_t outputAlpha = blendedRgba[rgbaOffset + 3U];
+    blendedAlpha[index] = outputAlpha;
+    if (alphaMatchesSource) {
+      const auto expected = static_cast<std::uint8_t>(
+          (static_cast<unsigned int>(sourceAlpha) * frame.alpha[index] +
+           127U) /
+          255U);
+      if (outputAlpha != expected) {
+        throw std::runtime_error("native blend alpha verification failed");
+      }
+      continue;
+    }
+    if (outputAlpha > sourceAlpha) {
+      throw std::runtime_error("native blend source alpha bound failed");
+    }
+  }
+  return blendedAlpha;
+}
+
+void clampMetalMattingBlendAlphaToSource(
+    const std::vector<std::uint8_t> &rgba,
+    std::vector<std::uint8_t> &alpha) {
+  if (alpha.size() > std::numeric_limits<std::size_t>::max() / 4U ||
+      rgba.size() != alpha.size() * 4U) {
+    throw std::runtime_error("native blend source alpha dimensions do not match");
+  }
+  for (std::size_t index = 0; index < alpha.size(); ++index) {
+    alpha[index] = std::min(alpha[index], rgba[index * 4U + 3U]);
+  }
+}
+
+} // namespace detail
 
 class MetalMattingBlend::Impl {
 public:
@@ -343,8 +427,8 @@ public:
       throw std::runtime_error("invalid native blend configuration");
     }
     void *renderDevice = rlContext_.renderDevice();
-    inputTexture_ = createReusableTexture(renderDevice, "qcut matting input");
-    alphaTexture_ = createReusableTexture(renderDevice, "qcut matting alpha");
+    inputTexture_ = createTexture(renderDevice, width_, height_,
+                                  "qcut matting input");
     outputTexture_ = std::make_unique<OwnedTexture>(
         renderDevice, destroyTexture_,
         createTexture_(renderDevice, width_, height_, nullptr,
@@ -353,16 +437,30 @@ public:
                        "qcut matting output", false, false));
   }
 
-  std::vector<std::uint8_t>
-  blendAlpha(const MetalMattingBlendFrame &frame) const {
-    const std::size_t pixelCount =
-        static_cast<std::size_t>(width_) * height_;
-    if (frame.rgba.size() != pixelCount * 4U || frame.alphaWidth != width_ ||
-        frame.alphaHeight != height_ || frame.alpha.size() != pixelCount) {
-      throw std::runtime_error("native blend frame dimensions do not match");
+  ~Impl() noexcept {
+    if (!glContext_.makeCurrent()) {
+      std::terminate();
     }
-    std::vector<std::uint8_t> alphaRgba(pixelCount * 4U);
-    for (std::size_t index = 0; index < pixelCount; ++index) {
+  }
+
+  std::vector<std::uint8_t>
+  blendAlpha(const MetalMattingBlendFrame &frame) {
+    detail::validateMetalMattingBlendFrame(frame, width_, height_);
+    if (!glContext_.makeCurrent()) {
+      throw std::runtime_error("cannot restore native blend GL context");
+    }
+    const std::size_t alphaPixelCount =
+        static_cast<std::size_t>(frame.alphaWidth) * frame.alphaHeight;
+    if (!alphaTexture_ || alphaWidth_ != frame.alphaWidth ||
+        alphaHeight_ != frame.alphaHeight) {
+      alphaTexture_ = createTexture(rlContext_.renderDevice(),
+                                    frame.alphaWidth, frame.alphaHeight,
+                                    "qcut matting alpha");
+      alphaWidth_ = frame.alphaWidth;
+      alphaHeight_ = frame.alphaHeight;
+    }
+    std::vector<std::uint8_t> alphaRgba(alphaPixelCount * 4U);
+    for (std::size_t index = 0; index < alphaPixelCount; ++index) {
       const std::uint8_t value = frame.alpha[index];
       const std::size_t offset = index * 4U;
       alphaRgba[offset] = value;
@@ -386,8 +484,8 @@ public:
     };
     const MattingImage alphaImage = {
         .data = &alphaTexture_->value(),
-        .width = static_cast<std::uint32_t>(width_),
-        .height = static_cast<std::uint32_t>(height_),
+        .width = static_cast<std::uint32_t>(frame.alphaWidth),
+        .height = static_cast<std::uint32_t>(frame.alphaHeight),
     };
     const std::array<float, 4> fullFrame = {0.0F, 0.0F, 1.0F, 1.0F};
     const std::array<std::uint8_t, 4> transparent = {0, 0, 0, 0};
@@ -402,28 +500,17 @@ public:
     std::vector<std::uint8_t> blendedRgba(frame.rgba.size());
     readImage_(renderDevice, outputTexture_->value(), width_, height_,
                blendedRgba.data(), 0, 0, kLinearFilter, kRgba8PixelFormat);
-    std::vector<std::uint8_t> blendedAlpha(pixelCount);
-    for (std::size_t index = 0; index < pixelCount; ++index) {
-      const std::size_t rgbaOffset = index * 4U;
-      const auto expected = static_cast<std::uint8_t>(
-          (static_cast<unsigned int>(frame.rgba[rgbaOffset + 3U]) *
-               frame.alpha[index] +
-           127U) /
-          255U);
-      blendedAlpha[index] = blendedRgba[rgbaOffset + 3U];
-      if (blendedAlpha[index] != expected) {
-        throw std::runtime_error("native blend alpha verification failed");
-      }
-    }
-    return blendedAlpha;
+    return detail::extractMetalMattingBlendAlpha(frame, blendedRgba, width_,
+                                                  height_);
   }
 
 private:
-  std::unique_ptr<OwnedTexture> createReusableTexture(void *renderDevice,
-                                                       const char *label) {
+  std::unique_ptr<OwnedTexture> createTexture(void *renderDevice, int width,
+                                              int height,
+                                              const char *label) {
     return std::make_unique<OwnedTexture>(
         renderDevice, destroyTexture_,
-        createTexture_(renderDevice, width_, height_, nullptr,
+        createTexture_(renderDevice, width, height, nullptr,
                        kRgba8PixelFormat, kLinearFilter, kLinearFilter,
                        kClampWrap, kClampWrap, nullptr, label, false, false));
   }
@@ -441,6 +528,8 @@ private:
   std::unique_ptr<OwnedTexture> inputTexture_;
   std::unique_ptr<OwnedTexture> alphaTexture_;
   std::unique_ptr<OwnedTexture> outputTexture_;
+  int alphaWidth_ = 0;
+  int alphaHeight_ = 0;
 };
 
 MetalMattingBlend::MetalMattingBlend(const MetalMattingBlendConfig &config)
@@ -455,7 +544,7 @@ MetalMattingBlend::MetalMattingBlend(const MetalMattingBlendConfig &config)
 MetalMattingBlend::~MetalMattingBlend() = default;
 
 std::vector<std::uint8_t>
-MetalMattingBlend::blendAlpha(const MetalMattingBlendFrame &frame) const {
+MetalMattingBlend::blendAlpha(const MetalMattingBlendFrame &frame) {
   return impl_->blendAlpha(frame);
 }
 

--- a/qcut/electron/jianying-person-cutout/native/metal-matting-blend.cpp
+++ b/qcut/electron/jianying-person-cutout/native/metal-matting-blend.cpp
@@ -135,6 +135,15 @@ public:
     }
     if (CGLCreateContext(pixelFormat_, nullptr, &context_) != kCGLNoError ||
         !context_ || !makeCurrent()) {
+      if (context_) {
+        if (CGLGetCurrentContext() == context_) {
+          CGLSetCurrentContext(nullptr);
+        }
+        CGLDestroyContext(context_);
+        context_ = nullptr;
+      }
+      CGLDestroyPixelFormat(pixelFormat_);
+      pixelFormat_ = nullptr;
       throw std::runtime_error("cannot create native blend GL context");
     }
   }
@@ -423,9 +432,6 @@ public:
         blend_(requireSymbol<BlendDeviceTextureWithData>(
             config.library,
             "bef_portrait_matting_v2_blend_device_texture_with_data")) {
-    if (!config.library || width_ <= 0 || height_ <= 0) {
-      throw std::runtime_error("invalid native blend configuration");
-    }
     void *renderDevice = rlContext_.renderDevice();
     inputTexture_ = createTexture(renderDevice, width_, height_,
                                   "qcut matting input");
@@ -534,6 +540,9 @@ private:
 
 MetalMattingBlend::MetalMattingBlend(const MetalMattingBlendConfig &config)
     : impl_(nullptr) {
+  if (!config.library || config.width <= 0 || config.height <= 0) {
+    throw std::runtime_error("invalid native blend configuration");
+  }
   setBooleanConfig(config.library, "ConfigID_EnableAGFXMetal", 372);
   setBooleanConfig(config.library, "ConfigID_VeabtestEnableMetalV2", 377);
   setBooleanConfig(config.library, "ConfigID_EnablePortraitMattingBlendV2",

--- a/qcut/electron/jianying-person-cutout/native/metal-matting-blend.hpp
+++ b/qcut/electron/jianying-person-cutout/native/metal-matting-blend.hpp
@@ -19,6 +19,21 @@ struct MetalMattingBlendFrame {
   int alphaHeight;
 };
 
+namespace detail {
+
+void validateMetalMattingBlendFrame(const MetalMattingBlendFrame &frame,
+                                    int width, int height);
+
+std::vector<std::uint8_t> extractMetalMattingBlendAlpha(
+    const MetalMattingBlendFrame &frame,
+    const std::vector<std::uint8_t> &blendedRgba, int width, int height);
+
+void clampMetalMattingBlendAlphaToSource(
+    const std::vector<std::uint8_t> &rgba,
+    std::vector<std::uint8_t> &alpha);
+
+} // namespace detail
+
 class MetalMattingBlend {
 public:
   explicit MetalMattingBlend(const MetalMattingBlendConfig &config);
@@ -28,7 +43,7 @@ public:
   MetalMattingBlend &operator=(const MetalMattingBlend &) = delete;
 
   std::vector<std::uint8_t>
-  blendAlpha(const MetalMattingBlendFrame &frame) const;
+  blendAlpha(const MetalMattingBlendFrame &frame);
 
 private:
   class Impl;

--- a/qcut/electron/jianying-person-cutout/native/metal-matting-blend.hpp
+++ b/qcut/electron/jianying-person-cutout/native/metal-matting-blend.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace qcut::matting {
+
+struct MetalMattingBlendConfig {
+  void *library;
+  int width;
+  int height;
+};
+
+struct MetalMattingBlendFrame {
+  const std::vector<std::uint8_t> &rgba;
+  const std::vector<std::uint8_t> &alpha;
+  int alphaWidth;
+  int alphaHeight;
+};
+
+class MetalMattingBlend {
+public:
+  explicit MetalMattingBlend(const MetalMattingBlendConfig &config);
+  ~MetalMattingBlend();
+
+  MetalMattingBlend(const MetalMattingBlend &) = delete;
+  MetalMattingBlend &operator=(const MetalMattingBlend &) = delete;
+
+  std::vector<std::uint8_t>
+  blendAlpha(const MetalMattingBlendFrame &frame) const;
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/metal-matting-blend.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/metal-matting-blend.test.cpp
@@ -1,0 +1,103 @@
+#include "metal-matting-blend.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+template <typename Operation> void expectRuntimeError(Operation operation) {
+  bool threw = false;
+  try {
+    operation();
+  } catch (const std::runtime_error &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+std::vector<std::uint8_t> makeRgba(std::size_t pixelCount) {
+  std::vector<std::uint8_t> rgba(pixelCount * 4U, 127);
+  for (std::size_t index = 0; index < pixelCount; ++index) {
+    rgba[index * 4U + 3U] = static_cast<std::uint8_t>((index * 37U) % 256U);
+  }
+  return rgba;
+}
+
+} // namespace
+
+int main() {
+  using qcut::matting::MetalMattingBlendFrame;
+  using qcut::matting::detail::clampMetalMattingBlendAlphaToSource;
+  using qcut::matting::detail::extractMetalMattingBlendAlpha;
+  using qcut::matting::detail::validateMetalMattingBlendFrame;
+
+  auto source = makeRgba(16);
+  const std::vector<std::uint8_t> lowResolutionAlpha = {0, 64, 128, 255};
+  const MetalMattingBlendFrame lowResolutionFrame = {
+      .rgba = source,
+      .alpha = lowResolutionAlpha,
+      .alphaWidth = 2,
+      .alphaHeight = 2,
+  };
+  validateMetalMattingBlendFrame(lowResolutionFrame, 4, 4);
+
+  auto blended = source;
+  for (std::size_t index = 0; index < 16; ++index) {
+    blended[index * 4U + 3U] = source[index * 4U + 3U] / 2U;
+  }
+  const auto extracted =
+      extractMetalMattingBlendAlpha(lowResolutionFrame, blended, 4, 4);
+  assert(extracted.size() == 16);
+  assert(extracted.front() == 0);
+
+  blended[4U + 3U] = static_cast<std::uint8_t>(source[4U + 3U] + 1U);
+  expectRuntimeError([&] {
+    extractMetalMattingBlendAlpha(lowResolutionFrame, blended, 4, 4);
+  });
+
+  const std::vector<std::uint8_t> malformedAlpha = {0, 1, 2};
+  const MetalMattingBlendFrame malformedFrame = {
+      .rgba = source,
+      .alpha = malformedAlpha,
+      .alphaWidth = 2,
+      .alphaHeight = 2,
+  };
+  expectRuntimeError(
+      [&] { validateMetalMattingBlendFrame(malformedFrame, 4, 4); });
+  expectRuntimeError(
+      [&] { validateMetalMattingBlendFrame(lowResolutionFrame, 0, 4); });
+
+  std::vector<std::uint8_t> sameSizeSource = {
+      10, 20, 30, 255,
+      40, 50, 60, 100,
+  };
+  const std::vector<std::uint8_t> sameSizeAlpha = {128, 255};
+  const MetalMattingBlendFrame sameSizeFrame = {
+      .rgba = sameSizeSource,
+      .alpha = sameSizeAlpha,
+      .alphaWidth = 2,
+      .alphaHeight = 1,
+  };
+  std::vector<std::uint8_t> sameSizeBlended = sameSizeSource;
+  sameSizeBlended[3] = 128;
+  sameSizeBlended[7] = 100;
+  const std::vector<std::uint8_t> expectedSameSizeAlpha = {128, 100};
+  assert(extractMetalMattingBlendAlpha(sameSizeFrame, sameSizeBlended, 2, 1) ==
+         expectedSameSizeAlpha);
+  sameSizeBlended[7] = 99;
+  expectRuntimeError([&] {
+    extractMetalMattingBlendAlpha(sameSizeFrame, sameSizeBlended, 2, 1);
+  });
+
+  std::vector<std::uint8_t> refinedAlpha(16, 255);
+  clampMetalMattingBlendAlphaToSource(source, refinedAlpha);
+  for (std::size_t index = 0; index < refinedAlpha.size(); ++index) {
+    assert(refinedAlpha[index] == source[index * 4U + 3U]);
+  }
+  std::vector<std::uint8_t> invalidRefinedAlpha(15, 255);
+  expectRuntimeError(
+      [&] { clampMetalMattingBlendAlphaToSource(source, invalidRefinedAlpha); });
+  return 0;
+}

--- a/qcut/electron/jianying-person-cutout/native/saliency-script-bridge.cpp
+++ b/qcut/electron/jianying-person-cutout/native/saliency-script-bridge.cpp
@@ -1,0 +1,601 @@
+// QCut-owned interoperability bridge; proprietary libraries and assets are supplied at runtime.
+#include "alpha-refinement.hpp"
+#include "alpha-resize.hpp"
+#include "effect-texture-context.hpp"
+#include "video-object-alpha-quality.hpp"
+
+#include <mach/mach.h>
+
+#include <dlfcn.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using EffectHandle = std::uint64_t;
+using Result = std::int32_t;
+using EffectCreate = Result (*)(EffectHandle *);
+using EffectDestroy = void (*)(EffectHandle);
+using EffectSetRenderApi = Result (*)(EffectHandle, std::int32_t);
+using EffectUsePipeline = Result (*)(EffectHandle, bool);
+using EffectInit =
+    Result (*)(EffectHandle, std::int32_t, std::int32_t, const char *,
+               const char *);
+using EffectSetWidthHeight =
+    Result (*)(EffectHandle, std::int32_t, std::int32_t);
+using EffectSetOrientation = Result (*)(EffectHandle, std::int32_t);
+using EffectSet = Result (*)(EffectHandle, const char *);
+using EffectAlgorithmTexture =
+    Result (*)(EffectHandle, std::uint32_t, double);
+using EffectProcessTexture =
+    Result (*)(EffectHandle, std::uint32_t, std::uint32_t, double);
+using EffectGetBachResult = Result (*)(EffectHandle, void **, std::int32_t);
+
+struct Vector4f {
+  float x;
+  float y;
+  float z;
+  float w;
+};
+
+using BachObjectToVector4f = Vector4f (*)(const void *);
+using BachObjectToMap = void *(*)(const void *);
+using FindScriptValue = void *(*)(void *, const std::string *, const void *,
+                                  const std::string **, bool *);
+using BachTextureDimension = std::int32_t (*)(void *);
+
+struct ReturnedPrimitiveVector {
+  void *value = nullptr;
+  // The vendor method returns this wrapper through arm64's indirect-result ABI.
+  ~ReturnedPrimitiveVector() {}
+};
+
+using BachTextureData = ReturnedPrimitiveVector (*)(void *);
+using ReleaseReference = void (*)(const void *);
+
+enum class SegmentationRoute { SaliencyScript, VideoObject };
+
+template <typename Function>
+Function requireSymbol(void *library, const char *name) {
+  dlerror();
+  void *symbol = dlsym(library, name);
+  if (const char *error = dlerror(); error != nullptr) {
+    throw std::runtime_error(std::string("missing symbol ") + name + ": " +
+                             error);
+  }
+  return reinterpret_cast<Function>(symbol);
+}
+
+int parsePositiveInteger(const char *text, const char *label) {
+  const int value = std::stoi(text);
+  if (value <= 0 || value > 8192) {
+    throw std::runtime_error(std::string(label) + " is out of range");
+  }
+  return value;
+}
+
+void writeAll(int fileDescriptor, const std::uint8_t *data, std::size_t size) {
+  std::size_t written = 0;
+  while (written < size) {
+    const auto result = ::write(fileDescriptor, data + written, size - written);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    if (result <= 0) {
+      throw std::runtime_error("cannot write saliency alpha frame");
+    }
+    written += static_cast<std::size_t>(result);
+  }
+}
+
+std::size_t readAll(int fileDescriptor, std::uint8_t *data, std::size_t size) {
+  std::size_t bytesRead = 0;
+  while (bytesRead < size) {
+    const auto result = ::read(fileDescriptor, data + bytesRead, size - bytesRead);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    if (result < 0) {
+      throw std::runtime_error("cannot read saliency RGBA input");
+    }
+    if (result == 0) {
+      break;
+    }
+    bytesRead += static_cast<std::size_t>(result);
+  }
+  return bytesRead;
+}
+
+bool readProcessMemory(const void *address, void *output, std::size_t size) {
+  vm_size_t bytesRead = 0;
+  const kern_return_t result = vm_read_overwrite(
+      mach_task_self(), reinterpret_cast<vm_address_t>(address),
+      static_cast<vm_size_t>(size), reinterpret_cast<vm_address_t>(output),
+      &bytesRead);
+  return result == KERN_SUCCESS && bytesRead == size;
+}
+
+void flipRows(const std::vector<std::uint8_t> &source,
+              std::vector<std::uint8_t> &target, int width, int height) {
+  const std::size_t rowBytes = static_cast<std::size_t>(width) * 4;
+  for (int y = 0; y < height; ++y) {
+    const auto sourceOffset = static_cast<std::size_t>(y) * rowBytes;
+    const auto targetOffset = static_cast<std::size_t>(height - y - 1) * rowBytes;
+    std::copy_n(source.data() + sourceOffset, rowBytes,
+                target.data() + targetOffset);
+  }
+}
+
+void *findScriptValue(const void *scriptInfo, const char *key,
+                      const void *libraryBase) {
+  // VideoFusion 11.3.0 offsets recovered from
+  // TEBachMattingAlgorithm::getMaskAndBoundingBox.
+  constexpr std::uintptr_t findValueOffset = 0x0b86aa4;
+  constexpr std::uintptr_t comparatorOffset = 0x2d03ee0;
+  const auto base = reinterpret_cast<std::uintptr_t>(libraryBase);
+  const auto findValue =
+      reinterpret_cast<FindScriptValue>(base + findValueOffset);
+  const auto *comparator = reinterpret_cast<const void *>(base + comparatorOffset);
+  const std::string requestedKey(key);
+  const std::string *matchedKey = &requestedKey;
+  bool didInsert = false;
+  auto *map = const_cast<std::uint8_t *>(
+                  static_cast<const std::uint8_t *>(scriptInfo)) +
+              0x10;
+  return findValue(map, &requestedKey, comparator, &matchedKey, &didInsert);
+}
+
+std::vector<std::uint8_t>
+extractScriptMask(EffectHandle handle, EffectGetBachResult getResult,
+                  BachObjectToVector4f toVector4f,
+                  const void *libraryBase, int width, int height) {
+  constexpr std::int32_t scriptAlgorithmType = 141;
+  void *resultObject = nullptr;
+  if (getResult(handle, &resultObject, scriptAlgorithmType) != 0 ||
+      resultObject == nullptr) {
+    throw std::runtime_error("saliency graph did not expose ScriptInfo");
+  }
+
+  void *infoVector = nullptr;
+  void *scriptInfo = nullptr;
+  const auto *resultBytes = static_cast<const std::uint8_t *>(resultObject);
+  if (!readProcessMemory(resultBytes + 0x18, &infoVector, sizeof(infoVector)) ||
+      infoVector == nullptr ||
+      !readProcessMemory(infoVector, &scriptInfo, sizeof(scriptInfo)) ||
+      scriptInfo == nullptr) {
+    throw std::runtime_error("saliency ScriptInfo layout is incompatible");
+  }
+
+  const void *maskEntry = findScriptValue(scriptInfo, "mask", libraryBase);
+  const void *boundsEntry = findScriptValue(scriptInfo, "ltwh", libraryBase);
+  if (maskEntry == nullptr || boundsEntry == nullptr) {
+    throw std::runtime_error("saliency ScriptInfo has no mask or ltwh entry");
+  }
+
+  const Vector4f bounds = toVector4f(
+      static_cast<const std::uint8_t *>(boundsEntry) + 0x28);
+  const int maskLeft = static_cast<int>(std::lround(bounds.x));
+  const int maskTop = static_cast<int>(std::lround(bounds.y));
+  const int maskWidth = static_cast<int>(std::lround(bounds.z));
+  const int maskHeight = static_cast<int>(std::lround(bounds.w));
+  if (maskWidth <= 0 || maskHeight <= 0 || maskLeft < 0 || maskTop < 0 ||
+      maskLeft + maskWidth > width || maskTop + maskHeight > height) {
+    throw std::runtime_error("saliency mask bounds are outside the source frame");
+  }
+
+  const void *textureInfo = nullptr;
+  if (!readProcessMemory(
+          static_cast<const std::uint8_t *>(maskEntry) + 0x88, &textureInfo,
+          sizeof(textureInfo)) ||
+      textureInfo == nullptr) {
+    throw std::runtime_error("saliency mask has no CPU image payload");
+  }
+  const std::uint8_t *begin = nullptr;
+  const std::uint8_t *end = nullptr;
+  const auto *textureBytes = static_cast<const std::uint8_t *>(textureInfo);
+  if (!readProcessMemory(textureBytes + 0x10, &begin, sizeof(begin)) ||
+      !readProcessMemory(textureBytes + 0x18, &end, sizeof(end)) ||
+      begin == nullptr || end < begin ||
+      static_cast<std::size_t>(end - begin) !=
+          static_cast<std::size_t>(maskWidth) * maskHeight) {
+    throw std::runtime_error("saliency mask payload is incomplete");
+  }
+
+  std::vector<std::uint8_t> alpha(static_cast<std::size_t>(width) * height);
+  for (int y = 0; y < maskHeight; ++y) {
+    const auto sourceOffset = static_cast<std::size_t>(y) * maskWidth;
+    const auto targetOffset =
+        static_cast<std::size_t>(maskTop + y) * width + maskLeft;
+    std::copy_n(begin + sourceOffset, maskWidth, alpha.data() + targetOffset);
+  }
+  return alpha;
+}
+
+class RetainedReference {
+public:
+  RetainedReference(void *value, ReleaseReference release)
+      : value_(value), release_(release) {}
+
+  RetainedReference(const RetainedReference &) = delete;
+  RetainedReference &operator=(const RetainedReference &) = delete;
+
+  ~RetainedReference() {
+    if (value_ != nullptr) {
+      release_(value_);
+    }
+  }
+
+private:
+  void *value_;
+  ReleaseReference release_;
+};
+
+std::vector<std::uint8_t> extractVideoObjectMask(
+    EffectHandle handle, EffectGetBachResult getResult,
+    BachObjectToMap toMap, BachTextureData getTextureData,
+    BachTextureDimension getWidth, BachTextureDimension getHeight,
+    ReleaseReference releaseReference, int width, int height) {
+  constexpr std::int32_t generalSegAlgorithmType = 198;
+  constexpr std::size_t bachMapFirstNodeOffset = 0x20;
+  constexpr std::size_t unorderedMapValueOffset = 0x28;
+  constexpr std::size_t bachObjectTypeOffset = 0x80;
+  constexpr std::uint32_t bachMapType = 0x1d;
+  constexpr std::size_t primitiveVectorBeginOffset = 0x10;
+  constexpr std::size_t primitiveVectorEndOffset = 0x18;
+  constexpr char resultKey[] = "saliency_mask";
+
+  void *resultObject = nullptr;
+  if (getResult(handle, &resultObject, generalSegAlgorithmType) != 0 ||
+      resultObject == nullptr) {
+    throw std::runtime_error("video-object graph did not expose BachBuffer");
+  }
+  void *resultVector = nullptr;
+  void *outerMap = nullptr;
+  const auto *resultBytes = static_cast<const std::uint8_t *>(resultObject);
+  if (!readProcessMemory(resultBytes + 0x18, &resultVector,
+                         sizeof(resultVector)) ||
+      resultVector == nullptr ||
+      !readProcessMemory(resultVector, &outerMap, sizeof(outerMap)) ||
+      outerMap == nullptr) {
+    throw std::runtime_error("video-object BachBuffer layout is incompatible");
+  }
+  void *firstNode = nullptr;
+  if (!readProcessMemory(
+          static_cast<const std::uint8_t *>(outerMap) +
+              bachMapFirstNodeOffset,
+          &firstNode, sizeof(firstNode)) ||
+      firstNode == nullptr) {
+    throw std::runtime_error("video-object result map is empty");
+  }
+  char key[sizeof(resultKey) - 1]{};
+  if (!readProcessMemory(static_cast<const std::uint8_t *>(firstNode) + 0x10,
+                         key, sizeof(key)) ||
+      !std::equal(std::begin(key), std::end(key), std::begin(resultKey))) {
+    throw std::runtime_error("video-object result has no saliency_mask");
+  }
+  const auto *value = static_cast<const std::uint8_t *>(firstNode) +
+                      unorderedMapValueOffset;
+  std::uint32_t valueType = 0;
+  if (!readProcessMemory(value + bachObjectTypeOffset, &valueType,
+                         sizeof(valueType)) ||
+      valueType != bachMapType) {
+    throw std::runtime_error("video-object saliency_mask type is incompatible");
+  }
+  void *textureInfo = toMap(value);
+  if (textureInfo == nullptr) {
+    throw std::runtime_error("video-object saliency_mask texture is missing");
+  }
+  const int maskWidth = getWidth(textureInfo);
+  const int maskHeight = getHeight(textureInfo);
+  if (maskWidth <= 0 || maskHeight <= 0 || maskWidth > 4096 ||
+      maskHeight > 4096) {
+    throw std::runtime_error("video-object saliency_mask dimensions are invalid");
+  }
+  ReturnedPrimitiveVector returnedData = getTextureData(textureInfo);
+  if (returnedData.value == nullptr) {
+    throw std::runtime_error("video-object saliency_mask data is missing");
+  }
+  RetainedReference retainedData(returnedData.value, releaseReference);
+  const std::uint8_t *begin = nullptr;
+  const std::uint8_t *end = nullptr;
+  const auto *dataBytes =
+      static_cast<const std::uint8_t *>(returnedData.value);
+  if (!readProcessMemory(dataBytes + primitiveVectorBeginOffset, &begin,
+                         sizeof(begin)) ||
+      !readProcessMemory(dataBytes + primitiveVectorEndOffset, &end,
+                         sizeof(end)) ||
+      begin == nullptr || end < begin ||
+      static_cast<std::size_t>(end - begin) !=
+          static_cast<std::size_t>(maskWidth) * maskHeight) {
+    throw std::runtime_error("video-object saliency_mask payload is incomplete");
+  }
+  const std::vector<std::uint8_t> alpha(begin, end);
+  return qcut::matting::resizeAlphaBilinear(alpha, maskWidth, maskHeight,
+                                             width, height);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  const bool hasRoute = argc == 14 && std::string(argv[12]) == "--route";
+  if (argc != 12 && !hasRoute) {
+    std::cerr << "usage: segmentation-bridge <libcccreator> <models-dir> "
+                 "<effect-dir> <input.rgba|-> <width> <height> "
+                 "<output.gray|-> <threshold> <temporal-smoothing> "
+                 "<edge-shift> <feather> [--route video-object]\n";
+    return 2;
+  }
+
+  try {
+    const SegmentationRoute route =
+        hasRoute && std::string(argv[13]) == "video-object"
+            ? SegmentationRoute::VideoObject
+            : SegmentationRoute::SaliencyScript;
+    if (hasRoute && route != SegmentationRoute::VideoObject) {
+      throw std::runtime_error("unsupported segmentation route");
+    }
+    const int width = parsePositiveInteger(argv[5], "width");
+    const int height = parsePositiveInteger(argv[6], "height");
+    const float threshold = std::clamp(std::stof(argv[8]), 0.0F, 1.0F);
+    const float temporalSmoothing =
+        std::clamp(std::stof(argv[9]), 0.0F, 0.95F);
+    const float edgeShift = std::clamp(std::stof(argv[10]), -12.0F, 12.0F);
+    const float feather = std::clamp(std::stof(argv[11]), 0.0F, 16.0F);
+    const std::size_t frameBytes =
+        static_cast<std::size_t>(width) * height * 4;
+    const bool streamInput = std::string(argv[4]) == "-";
+    const bool streamOutput = std::string(argv[7]) == "-";
+
+    std::unique_ptr<std::ifstream> inputFile;
+    std::istream *rgbaInput = &std::cin;
+    std::size_t expectedFrameCount = 0;
+    if (!streamInput) {
+      inputFile = std::make_unique<std::ifstream>(
+          argv[4], std::ios::binary | std::ios::ate);
+      if (!*inputFile) {
+        throw std::runtime_error("cannot open saliency RGBA input");
+      }
+      const auto inputBytes = inputFile->tellg();
+      if (inputBytes <= 0 ||
+          static_cast<std::size_t>(inputBytes) % frameBytes != 0) {
+        throw std::runtime_error("input does not contain complete RGBA frames");
+      }
+      expectedFrameCount = static_cast<std::size_t>(inputBytes) / frameBytes;
+      inputFile->seekg(0);
+      rgbaInput = inputFile.get();
+    }
+
+    std::unique_ptr<std::ofstream> outputFile;
+    int alphaOutputDescriptor = -1;
+    if (streamOutput) {
+      alphaOutputDescriptor = ::dup(STDOUT_FILENO);
+      if (alphaOutputDescriptor < 0 ||
+          ::dup2(STDERR_FILENO, STDOUT_FILENO) < 0) {
+        throw std::runtime_error("cannot isolate saliency alpha output stream");
+      }
+    } else {
+      outputFile = std::make_unique<std::ofstream>(argv[7], std::ios::binary);
+      if (!*outputFile) {
+        throw std::runtime_error("cannot open saliency alpha output");
+      }
+    }
+
+    std::vector<std::uint8_t> source(frameBytes);
+    std::vector<std::uint8_t> flipped(frameBytes);
+
+    void *library = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+    if (library == nullptr) {
+      throw std::runtime_error(std::string("cannot load saliency runtime: ") +
+                               dlerror());
+    }
+    Dl_info libraryInfo{};
+    if (dladdr(dlsym(library, "bef_effect_create_handle"), &libraryInfo) == 0 ||
+        libraryInfo.dli_fbase == nullptr) {
+      throw std::runtime_error("cannot resolve saliency runtime base address");
+    }
+    auto textureContext =
+        std::make_unique<qcut::matting::EffectTextureContext>();
+    textureContext->setUnpackAlignment(1);
+    std::vector<std::uint8_t> outputSeed(frameBytes);
+    for (std::size_t offset = 0; offset < outputSeed.size(); offset += 4) {
+      outputSeed[offset] = 255;
+      outputSeed[offset + 2] = 255;
+      outputSeed[offset + 3] = 255;
+    }
+    const std::uint32_t inputTexture =
+        textureContext->createTexture(width, height, outputSeed);
+    const std::uint32_t outputTexture =
+        textureContext->createTexture(width, height, outputSeed);
+
+    const auto effectCreate =
+        requireSymbol<EffectCreate>(library, "bef_effect_create_handle");
+    const auto effectDestroy =
+        requireSymbol<EffectDestroy>(library, "bef_effect_destroy");
+    const auto effectSetRenderApi = requireSymbol<EffectSetRenderApi>(
+        library, "bef_effect_set_render_api");
+    const auto effectUsePipeline = requireSymbol<EffectUsePipeline>(
+        library, "bef_effect_use_pipeline_processor");
+    const auto effectInit =
+        requireSymbol<EffectInit>(library, "bef_effect_init");
+    const auto effectSetWidthHeight = requireSymbol<EffectSetWidthHeight>(
+        library, "bef_effect_set_width_height");
+    const auto effectSetOrientation = requireSymbol<EffectSetOrientation>(
+        library, "bef_effect_set_orientation");
+    const auto effectSet =
+        requireSymbol<EffectSet>(library, "bef_effect_set_effect");
+    const auto effectAlgorithmTexture = requireSymbol<EffectAlgorithmTexture>(
+        library, "bef_effect_algorithm_texture");
+    const auto effectProcessTexture = requireSymbol<EffectProcessTexture>(
+        library, "bef_effect_process_texture");
+    const auto effectGetBachResult = requireSymbol<EffectGetBachResult>(
+        library, "bef_effect_get_bach_result");
+    const auto bachObjectToVector4f = requireSymbol<BachObjectToVector4f>(
+        library, "_ZNK4Bach10BachObjectcvN13AmazingEngine8Vector4fEEv");
+    const auto bachObjectToMap = requireSymbol<BachObjectToMap>(
+        library, "_ZNK4Bach10BachObjectcvPNS_7BachMapEEv");
+    const auto bachTextureData = requireSymbol<BachTextureData>(
+        library, "_ZN4Bach15BachTextureInfo4dataEv");
+    const auto bachTextureWidth = requireSymbol<BachTextureDimension>(
+        library, "_ZN4Bach15BachTextureInfo5widthEv");
+    const auto bachTextureHeight = requireSymbol<BachTextureDimension>(
+        library, "_ZN4Bach15BachTextureInfo6heightEv");
+    const auto releaseReference = requireSymbol<ReleaseReference>(
+        library, "_ZNK13AmazingEngine7RefBase7releaseEv");
+
+    EffectHandle handle = 0;
+    Result status = effectCreate(&handle);
+    if (status != 0 || handle == 0) {
+      throw std::runtime_error("cannot create saliency effect handle: " +
+                               std::to_string(status));
+    }
+    const Result renderApiStatus = effectSetRenderApi(handle, 1);
+    const Result pipelineStatus =
+        effectUsePipeline(handle, route == SegmentationRoute::VideoObject);
+    const Result initStatus = effectInit(handle, width, height, argv[2], "");
+    if (renderApiStatus != 0 || pipelineStatus != 0 || initStatus != 0 ||
+        effectSetWidthHeight(handle, width, height) != 0 ||
+        effectSetOrientation(handle, 0) != 0 || effectSet(handle, argv[3]) != 0) {
+      effectDestroy(handle);
+      throw std::runtime_error("cannot initialize the saliency effect graph");
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+    std::size_t frameCount = 0;
+    std::vector<float> temporalState;
+    while (true) {
+      std::size_t bytesRead = 0;
+      if (streamInput) {
+        bytesRead = readAll(STDIN_FILENO, source.data(), source.size());
+      } else {
+        rgbaInput->read(reinterpret_cast<char *>(source.data()),
+                        static_cast<std::streamsize>(source.size()));
+        bytesRead = static_cast<std::size_t>(rgbaInput->gcount());
+      }
+      if (bytesRead == 0) {
+        break;
+      }
+      if (bytesRead != source.size()) {
+        effectDestroy(handle);
+        throw std::runtime_error("input ended with an incomplete RGBA frame");
+      }
+      flipRows(source, flipped, width, height);
+      textureContext->updateTexture(inputTexture, width, height, flipped);
+
+      Result algorithmStatus = -1;
+      Result processStatus = -1;
+      std::optional<std::vector<std::uint8_t>> rawAlpha;
+      std::string extractionError;
+      const int maximumAttempts =
+          frameCount == 0
+              ? (route == SegmentationRoute::VideoObject ? 60 : 20)
+              : (route == SegmentationRoute::VideoObject ? 2 : 1);
+      for (int attempt = 0; attempt < maximumAttempts; ++attempt) {
+        const double timestamp = static_cast<double>(frameCount) / 30.0;
+        algorithmStatus =
+            effectAlgorithmTexture(handle, inputTexture, timestamp);
+        processStatus = effectProcessTexture(handle, inputTexture,
+                                             outputTexture, timestamp);
+        if (algorithmStatus == 0 && processStatus == 0) {
+          try {
+            rawAlpha = route == SegmentationRoute::VideoObject
+                           ? extractVideoObjectMask(
+                                 handle, effectGetBachResult, bachObjectToMap,
+                                 bachTextureData, bachTextureWidth,
+                                 bachTextureHeight, releaseReference, width,
+                                 height)
+                           : extractScriptMask(
+                                 handle, effectGetBachResult,
+                                 bachObjectToVector4f, libraryInfo.dli_fbase,
+                                 width, height);
+            if (attempt + 1 >= maximumAttempts || frameCount == 0) {
+              break;
+            }
+          } catch (const std::exception &error) {
+            rawAlpha.reset();
+            extractionError = error.what();
+          }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      }
+      if (algorithmStatus != 0 || processStatus != 0 || !rawAlpha) {
+        effectDestroy(handle);
+        throw std::runtime_error(
+            "segmentation graph processing failed: algorithm=" +
+            std::to_string(algorithmStatus) +
+            " process=" + std::to_string(processStatus) +
+            (extractionError.empty() ? "" : " result=" + extractionError));
+      }
+      if (route == SegmentationRoute::VideoObject) {
+        qcut::matting::requireCalibratedVideoObjectAlpha(*rawAlpha);
+      }
+      const auto alpha = qcut::matting::refineAlpha(
+          *rawAlpha, temporalState, width, height, threshold,
+          temporalSmoothing, edgeShift, feather);
+      if (streamOutput) {
+        writeAll(alphaOutputDescriptor, alpha.data(), alpha.size());
+      } else {
+        outputFile->write(reinterpret_cast<const char *>(alpha.data()),
+                          static_cast<std::streamsize>(alpha.size()));
+        if (!*outputFile) {
+          effectDestroy(handle);
+          throw std::runtime_error("cannot write saliency alpha frame");
+        }
+      }
+      frameCount += 1;
+      std::cerr << "progress frame=" << frameCount
+                << " total=" << expectedFrameCount << '\n';
+    }
+
+    if (frameCount == 0 ||
+        (expectedFrameCount > 0 && expectedFrameCount != frameCount)) {
+      throw std::runtime_error("segmentation input did not contain complete frames");
+    }
+    if (route == SegmentationRoute::VideoObject) {
+      if (outputFile) {
+        outputFile->flush();
+        if (!*outputFile) {
+          throw std::runtime_error("cannot flush video-object alpha output");
+        }
+      }
+      if (alphaOutputDescriptor >= 0) {
+        ::close(alphaOutputDescriptor);
+      }
+      std::cerr << "ok width=" << width << " height=" << height
+                << " frames=" << frameCount
+                << " route=video-object-general-seg-v1\n"
+                << std::flush;
+      // The verified type-198 pipeline crashes in vendor teardown outside its
+      // host. This helper owns no persistent state, so process isolation is the
+      // reliable release boundary after the complete mask has been flushed.
+      ::_exit(0);
+    }
+
+    effectDestroy(handle);
+    textureContext->deleteTextures({inputTexture, outputTexture});
+    if (alphaOutputDescriptor >= 0) {
+      ::close(alphaOutputDescriptor);
+    }
+    dlclose(library);
+    std::cerr << "ok width=" << width << " height=" << height
+              << " frames=" << frameCount
+              << " route=saliency-script-v1.2\n";
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}

--- a/qcut/electron/jianying-person-cutout/native/saliency-script-bridge.cpp
+++ b/qcut/electron/jianying-person-cutout/native/saliency-script-bridge.cpp
@@ -1,6 +1,7 @@
 // QCut-owned interoperability bridge; proprietary libraries and assets are supplied at runtime.
 #include "alpha-refinement.hpp"
 #include "alpha-resize.hpp"
+#include "effect-input-probe.hpp"
 #include "effect-texture-context.hpp"
 #include "video-object-alpha-quality.hpp"
 
@@ -41,6 +42,16 @@ using EffectSetOrientation = Result (*)(EffectHandle, std::int32_t);
 using EffectSet = Result (*)(EffectHandle, const char *);
 using EffectAlgorithmTexture =
     Result (*)(EffectHandle, std::uint32_t, double);
+using EffectAlgorithmBuffer = Result (*)(EffectHandle, std::int32_t,
+                                         std::int32_t, const std::uint8_t *,
+                                         std::int32_t, double);
+struct EffectRequirement {
+  std::uint64_t low;
+  std::uint64_t high;
+};
+using EffectGetNewRequirement = EffectRequirement (*)(EffectHandle);
+using EffectRefreshNewAlgorithm = Result (*)(EffectHandle, std::uint64_t,
+                                             std::uint64_t, std::int32_t);
 using EffectProcessTexture =
     Result (*)(EffectHandle, std::uint32_t, std::uint32_t, double);
 using EffectGetBachResult = Result (*)(EffectHandle, void **, std::int32_t);
@@ -407,8 +418,24 @@ int main(int argc, char **argv) {
         libraryInfo.dli_fbase == nullptr) {
       throw std::runtime_error("cannot resolve saliency runtime base address");
     }
+    const bool usesEngineContext =
+        route == SegmentationRoute::VideoObject &&
+        qcut::matting::engineImageProcessingContextProbeEnabled() &&
+        qcut::matting::bindEngineImageProcessingContext();
+    const bool usesBufferInput =
+        route == SegmentationRoute::VideoObject &&
+        qcut::matting::bufferInputProbeEnabled();
+    const auto contextMode =
+        usesEngineContext
+            ? qcut::matting::EffectTextureContextMode::AdoptCurrent
+            : qcut::matting::EffectTextureContextMode::CreateStandalone;
     auto textureContext =
-        std::make_unique<qcut::matting::EffectTextureContext>();
+        std::make_unique<qcut::matting::EffectTextureContext>(contextMode);
+    std::cerr << "texture_context="
+              << (usesEngineContext ? "engine-shared" : "standalone")
+              << " input_transport="
+              << (usesBufferInput ? "cpu-buffer-canary" : "gl-texture")
+              << '\n';
     textureContext->setUnpackAlignment(1);
     std::vector<std::uint8_t> outputSeed(frameBytes);
     for (std::size_t offset = 0; offset < outputSeed.size(); offset += 4) {
@@ -439,6 +466,21 @@ int main(int argc, char **argv) {
         requireSymbol<EffectSet>(library, "bef_effect_set_effect");
     const auto effectAlgorithmTexture = requireSymbol<EffectAlgorithmTexture>(
         library, "bef_effect_algorithm_texture");
+    const auto effectAlgorithmBuffer =
+        usesBufferInput
+            ? requireSymbol<EffectAlgorithmBuffer>(
+                  library, "bef_effect_algorithm_buffer")
+            : nullptr;
+    const auto effectGetNewRequirement =
+        usesBufferInput
+            ? requireSymbol<EffectGetNewRequirement>(
+                  library, "bef_effect_get_new_requirment")
+            : nullptr;
+    const auto effectRefreshNewAlgorithm =
+        usesBufferInput
+            ? requireSymbol<EffectRefreshNewAlgorithm>(
+                  library, "bef_effect_refresh_new_algorithm")
+            : nullptr;
     const auto effectProcessTexture = requireSymbol<EffectProcessTexture>(
         library, "bef_effect_process_texture");
     const auto effectGetBachResult = requireSymbol<EffectGetBachResult>(
@@ -456,26 +498,73 @@ int main(int argc, char **argv) {
     const auto releaseReference = requireSymbol<ReleaseReference>(
         library, "_ZNK13AmazingEngine7RefBase7releaseEv");
 
-    EffectHandle handle = 0;
-    Result status = effectCreate(&handle);
-    if (status != 0 || handle == 0) {
+    EffectHandle standaloneHandle = 0;
+    const auto destroyStandaloneHandle = [&]() {
+      if (standaloneHandle != 0) {
+        effectDestroy(standaloneHandle);
+        standaloneHandle = 0;
+      }
+    };
+    Result status = effectCreate(&standaloneHandle);
+    if (status != 0 || standaloneHandle == 0) {
       throw std::runtime_error("cannot create saliency effect handle: " +
                                std::to_string(status));
     }
-    const Result renderApiStatus = effectSetRenderApi(handle, 1);
-    const Result pipelineStatus =
-        effectUsePipeline(handle, route == SegmentationRoute::VideoObject);
-    const Result initStatus = effectInit(handle, width, height, argv[2], "");
+    const Result renderApiStatus = effectSetRenderApi(standaloneHandle, 1);
+    const Result pipelineStatus = effectUsePipeline(
+        standaloneHandle, route == SegmentationRoute::VideoObject);
+    const Result initStatus =
+        effectInit(standaloneHandle, width, height, argv[2], "");
     if (renderApiStatus != 0 || pipelineStatus != 0 || initStatus != 0 ||
-        effectSetWidthHeight(handle, width, height) != 0 ||
-        effectSetOrientation(handle, 0) != 0 || effectSet(handle, argv[3]) != 0) {
-      effectDestroy(handle);
+        effectSetWidthHeight(standaloneHandle, width, height) != 0 ||
+        effectSetOrientation(standaloneHandle, 0) != 0 ||
+        effectSet(standaloneHandle, argv[3]) != 0) {
+      destroyStandaloneHandle();
       throw std::runtime_error("cannot initialize the saliency effect graph");
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    if (usesBufferInput) {
+      if (effectAlgorithmTexture(standaloneHandle, inputTexture, 0.0) != 0) {
+        destroyStandaloneHandle();
+        throw std::runtime_error("cannot activate the buffer-input effect graph");
+      }
+      EffectRequirement requirement{};
+      for (int attempt = 0; attempt < 60 && requirement.low == 0; ++attempt) {
+        requirement = effectGetNewRequirement(standaloneHandle);
+        if (requirement.low == 0) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+      }
+      std::cerr << "buffer_requirement_low=" << requirement.low
+                << " high=" << requirement.high << '\n';
+      if (requirement.low == 0 ||
+          effectRefreshNewAlgorithm(standaloneHandle, requirement.low,
+                                    requirement.high, 1) != 0) {
+        destroyStandaloneHandle();
+        throw std::runtime_error("cannot refresh the buffer-input requirement");
+      }
+      if (effectUsePipeline(standaloneHandle, false) != 0) {
+        destroyStandaloneHandle();
+        throw std::runtime_error("cannot select synchronous buffer input");
+      }
+    } else {
+      std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
 
     std::size_t frameCount = 0;
     std::vector<float> temporalState;
+    qcut::matting::VideoObjectAlphaQualityGate videoObjectAlphaQuality;
+    auto lastProgressReportAt = std::chrono::steady_clock::now();
+    const auto reportProgress = [&](bool force) {
+      const auto now = std::chrono::steady_clock::now();
+      const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+          now - lastProgressReportAt);
+      if (!force && elapsed.count() < 250) {
+        return;
+      }
+      std::cerr << "progress frame=" << frameCount
+                << " total=" << expectedFrameCount << '\n';
+      lastProgressReportAt = now;
+    };
     while (true) {
       std::size_t bytesRead = 0;
       if (streamInput) {
@@ -489,7 +578,7 @@ int main(int argc, char **argv) {
         break;
       }
       if (bytesRead != source.size()) {
-        effectDestroy(handle);
+        destroyStandaloneHandle();
         throw std::runtime_error("input ended with an incomplete RGBA frame");
       }
       flipRows(source, flipped, width, height);
@@ -505,20 +594,28 @@ int main(int argc, char **argv) {
               : (route == SegmentationRoute::VideoObject ? 2 : 1);
       for (int attempt = 0; attempt < maximumAttempts; ++attempt) {
         const double timestamp = static_cast<double>(frameCount) / 30.0;
-        algorithmStatus =
-            effectAlgorithmTexture(handle, inputTexture, timestamp);
-        processStatus = effectProcessTexture(handle, inputTexture,
-                                             outputTexture, timestamp);
+        if (effectAlgorithmBuffer != nullptr) {
+          constexpr std::int32_t rgbaBufferFormat = 0;
+          algorithmStatus = effectAlgorithmBuffer(
+              standaloneHandle, width, height, source.data(), rgbaBufferFormat,
+              timestamp);
+          processStatus = 0;
+        } else {
+          algorithmStatus = effectAlgorithmTexture(standaloneHandle,
+                                                   inputTexture, timestamp);
+          processStatus = effectProcessTexture(
+              standaloneHandle, inputTexture, outputTexture, timestamp);
+        }
         if (algorithmStatus == 0 && processStatus == 0) {
           try {
             rawAlpha = route == SegmentationRoute::VideoObject
                            ? extractVideoObjectMask(
-                                 handle, effectGetBachResult, bachObjectToMap,
-                                 bachTextureData, bachTextureWidth,
-                                 bachTextureHeight, releaseReference, width,
-                                 height)
+                                 standaloneHandle, effectGetBachResult,
+                                 bachObjectToMap, bachTextureData,
+                                 bachTextureWidth, bachTextureHeight,
+                                 releaseReference, width, height)
                            : extractScriptMask(
-                                 handle, effectGetBachResult,
+                                 standaloneHandle, effectGetBachResult,
                                  bachObjectToVector4f, libraryInfo.dli_fbase,
                                  width, height);
             if (attempt + 1 >= maximumAttempts || frameCount == 0) {
@@ -532,7 +629,7 @@ int main(int argc, char **argv) {
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
       }
       if (algorithmStatus != 0 || processStatus != 0 || !rawAlpha) {
-        effectDestroy(handle);
+        destroyStandaloneHandle();
         throw std::runtime_error(
             "segmentation graph processing failed: algorithm=" +
             std::to_string(algorithmStatus) +
@@ -540,7 +637,7 @@ int main(int argc, char **argv) {
             (extractionError.empty() ? "" : " result=" + extractionError));
       }
       if (route == SegmentationRoute::VideoObject) {
-        qcut::matting::requireCalibratedVideoObjectAlpha(*rawAlpha);
+        videoObjectAlphaQuality.observe(*rawAlpha);
       }
       const auto alpha = qcut::matting::refineAlpha(
           *rawAlpha, temporalState, width, height, threshold,
@@ -551,20 +648,21 @@ int main(int argc, char **argv) {
         outputFile->write(reinterpret_cast<const char *>(alpha.data()),
                           static_cast<std::streamsize>(alpha.size()));
         if (!*outputFile) {
-          effectDestroy(handle);
+          destroyStandaloneHandle();
           throw std::runtime_error("cannot write saliency alpha frame");
         }
       }
       frameCount += 1;
-      std::cerr << "progress frame=" << frameCount
-                << " total=" << expectedFrameCount << '\n';
+      reportProgress(false);
     }
 
     if (frameCount == 0 ||
         (expectedFrameCount > 0 && expectedFrameCount != frameCount)) {
       throw std::runtime_error("segmentation input did not contain complete frames");
     }
+    reportProgress(true);
     if (route == SegmentationRoute::VideoObject) {
+      videoObjectAlphaQuality.finalize();
       if (outputFile) {
         outputFile->flush();
         if (!*outputFile) {
@@ -576,7 +674,9 @@ int main(int argc, char **argv) {
       }
       std::cerr << "ok width=" << width << " height=" << height
                 << " frames=" << frameCount
-                << " route=video-object-general-seg-v1\n"
+                << " route=video-object-general-seg-v1"
+                << " alpha_quality="
+                << qcut::matting::videoObjectAlphaQualityCapability() << '\n'
                 << std::flush;
       // The verified type-198 pipeline crashes in vendor teardown outside its
       // host. This helper owns no persistent state, so process isolation is the
@@ -584,7 +684,7 @@ int main(int argc, char **argv) {
       ::_exit(0);
     }
 
-    effectDestroy(handle);
+    destroyStandaloneHandle();
     textureContext->deleteTextures({inputTexture, outputTexture});
     if (alphaOutputDescriptor >= 0) {
       ::close(alphaOutputDescriptor);

--- a/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.cpp
+++ b/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.cpp
@@ -1,0 +1,21 @@
+#include "video-object-alpha-quality.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace qcut::matting {
+
+void requireCalibratedVideoObjectAlpha(
+    const std::vector<std::uint8_t> &alpha) {
+  if (alpha.empty()) {
+    throw std::runtime_error("video-object graph returned an empty alpha mask");
+  }
+  const auto maximum = std::max_element(alpha.begin(), alpha.end());
+  if (*maximum <= 2) {
+    throw std::runtime_error(
+        "video-object graph requires Jianying's host Metal context; "
+        "fall back to portrait GRU");
+  }
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.cpp
+++ b/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.cpp
@@ -2,20 +2,37 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <string>
 
 namespace qcut::matting {
 
-void requireCalibratedVideoObjectAlpha(
+const char *videoObjectAlphaQualityCapability() {
+  return "video-object-alpha-quality-v1";
+}
+
+void VideoObjectAlphaQualityGate::observe(
     const std::vector<std::uint8_t> &alpha) {
   if (alpha.empty()) {
     throw std::runtime_error("video-object graph returned an empty alpha mask");
   }
   const auto maximum = std::max_element(alpha.begin(), alpha.end());
-  if (*maximum <= 2) {
-    throw std::runtime_error(
-        "video-object graph requires Jianying's host Metal context; "
-        "fall back to portrait GRU");
+  if (*maximum > 2) {
+    hasObservedUsableAlpha_ = true;
+    return;
   }
+  if (*maximum > 0) {
+    hasObservedQuantizedNoise_ = true;
+  }
+}
+
+void VideoObjectAlphaQualityGate::finalize() const {
+  if (hasObservedUsableAlpha_ || !hasObservedQuantizedNoise_) {
+    return;
+  }
+  throw std::runtime_error(
+      std::string(videoObjectAlphaQualityCapability()) +
+      ": video-object graph returned only the hostless 0/1/2 Alpha signature "
+      "for the complete stream; fall back to portrait GRU");
 }
 
 } // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.hpp
+++ b/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace qcut::matting {
+
+void requireCalibratedVideoObjectAlpha(
+    const std::vector<std::uint8_t> &alpha);
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.hpp
+++ b/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.hpp
@@ -5,7 +5,16 @@
 
 namespace qcut::matting {
 
-void requireCalibratedVideoObjectAlpha(
-    const std::vector<std::uint8_t> &alpha);
+const char *videoObjectAlphaQualityCapability();
+
+class VideoObjectAlphaQualityGate {
+public:
+  void observe(const std::vector<std::uint8_t> &alpha);
+  void finalize() const;
+
+private:
+  bool hasObservedUsableAlpha_ = false;
+  bool hasObservedQuantizedNoise_ = false;
+};
 
 } // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.test.cpp
@@ -1,0 +1,26 @@
+#include "video-object-alpha-quality.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+bool rejects(const std::vector<std::uint8_t> &alpha) {
+  try {
+    qcut::matting::requireCalibratedVideoObjectAlpha(alpha);
+    return false;
+  } catch (const std::runtime_error &) {
+    return true;
+  }
+}
+
+} // namespace
+
+int main() {
+  assert(rejects({}));
+  assert(rejects({0, 1, 2, 2, 1, 0}));
+  assert(!rejects({0, 3, 255, 127}));
+  return 0;
+}

--- a/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/video-object-alpha-quality.test.cpp
@@ -3,24 +3,67 @@
 #include <cassert>
 #include <cstdint>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace {
 
-bool rejects(const std::vector<std::uint8_t> &alpha) {
+std::string observeError(
+    qcut::matting::VideoObjectAlphaQualityGate &qualityGate,
+    const std::vector<std::uint8_t> &alpha) {
   try {
-    qcut::matting::requireCalibratedVideoObjectAlpha(alpha);
-    return false;
-  } catch (const std::runtime_error &) {
-    return true;
+    qualityGate.observe(alpha);
+  } catch (const std::runtime_error &error) {
+    return error.what();
   }
+  return {};
+}
+
+std::string finalizeError(
+    const qcut::matting::VideoObjectAlphaQualityGate &qualityGate) {
+  try {
+    qualityGate.finalize();
+  } catch (const std::runtime_error &error) {
+    return error.what();
+  }
+  return {};
 }
 
 } // namespace
 
 int main() {
-  assert(rejects({}));
-  assert(rejects({0, 1, 2, 2, 1, 0}));
-  assert(!rejects({0, 3, 255, 127}));
+  qcut::matting::VideoObjectAlphaQualityGate hostlessGate;
+  assert(observeError(hostlessGate, {0, 1, 2, 2, 1, 0}).empty());
+  assert(observeError(hostlessGate, {0, 0, 1, 2}).empty());
+  assert(observeError(hostlessGate, {2, 1, 0, 2}).empty());
+  const auto confirmedHostlessError = finalizeError(hostlessGate);
+  assert(confirmedHostlessError.find(
+             qcut::matting::videoObjectAlphaQualityCapability()) !=
+         std::string::npos);
+
+  qcut::matting::VideoObjectAlphaQualityGate prefixEmptyThenUsableGate;
+  for (int frame = 0; frame < 120; ++frame) {
+    assert(observeError(prefixEmptyThenUsableGate, {0, 0, 0, 0}).empty());
+  }
+  assert(observeError(prefixEmptyThenUsableGate, {0, 3, 255, 127}).empty());
+  assert(finalizeError(prefixEmptyThenUsableGate).empty());
+
+  qcut::matting::VideoObjectAlphaQualityGate allZeroGate;
+  for (int frame = 0; frame < 120; ++frame) {
+    assert(observeError(allZeroGate, {0, 0, 0, 0}).empty());
+  }
+  assert(finalizeError(allZeroGate).empty());
+
+  qcut::matting::VideoObjectAlphaQualityGate noiseThenUsableGate;
+  assert(observeError(noiseThenUsableGate, {0, 1, 2}).empty());
+  assert(observeError(noiseThenUsableGate, {0, 4, 0}).empty());
+  assert(observeError(noiseThenUsableGate, {0, 1, 2}).empty());
+  assert(finalizeError(noiseThenUsableGate).empty());
+
+  qcut::matting::VideoObjectAlphaQualityGate emptyGate;
+  const auto emptyError = observeError(emptyGate, {});
+  assert(!emptyError.empty());
+  assert(emptyError.find(qcut::matting::videoObjectAlphaQualityCapability()) ==
+         std::string::npos);
   return 0;
 }

--- a/qcut/electron/jianying-person-cutout/native/video-object-bach-bridge.mm
+++ b/qcut/electron/jianying-person-cutout/native/video-object-bach-bridge.mm
@@ -1,0 +1,812 @@
+#define GL_SILENCE_DEPRECATION
+
+#include "alpha-refinement.hpp"
+#include "metal-matting-blend.hpp"
+
+#import <AppKit/AppKit.h>
+#import <OpenGL/OpenGL.h>
+
+#include <CommonCrypto/CommonDigest.h>
+#include <CoreVideo/CoreVideo.h>
+#include <dlfcn.h>
+#include <mach-o/loader.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#if defined(QCUT_BACH_RESEARCH_CAPTURE)
+extern "C" void installByteCoreMLNn3Capture();
+#endif
+
+namespace {
+
+constexpr std::size_t kFrameObjectSize = 0x2c8;
+constexpr std::size_t kMattingObjectSize = 0x388;
+constexpr std::size_t kMaskStorageSize = 0x80;
+constexpr int kObjectMattingType = 1;
+constexpr int kVideoSaliencyModelType = 3;
+constexpr int kBgraPixelFormat = 13;
+constexpr int kModelDimension = 256;
+constexpr std::string_view kProviderId =
+    "video-object-jianying-bach-v2-exact-d634-v1";
+constexpr std::string_view kBlendId =
+    "TEMattingBlendEffectV2-vendor-exact";
+constexpr std::string_view kExactRefinementId =
+    "vendor-v2-exact-no-qcut-refinement-v1";
+constexpr std::string_view kAdvancedRefinementId =
+    "qcut-alpha-refinement-after-vendor-v2-v1";
+constexpr std::string_view kExpectedRuntimeUuid =
+    "D6342ECD-5432-33F0-A2AD-0C28F5699994";
+constexpr std::string_view kExpectedLibrarySha256 =
+    "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9";
+constexpr std::string_view kExpectedGraphSha256 =
+    "797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b";
+constexpr std::string_view kExpectedModelSha256 =
+    "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef";
+constexpr std::string_view kRuntimeFrameworkClosureId =
+    "jianying-runtime-framework-closure-d634-v1-"
+    "e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e";
+
+struct PinnedRuntimeFramework {
+  std::string_view fileName;
+  std::string_view sha256;
+};
+
+constexpr std::array<PinnedRuntimeFramework, 22> kRuntimeFrameworks{{
+    {"libAGFX.dylib",
+     "1b9493940eebda3b79d72b7308adf8abfbff56c9cfce9d7d73b31cd080453eee"},
+    {"libByteVC1_dec.dylib",
+     "1934d8af041763669bf671ae4bc36920b50a671112eee97e238d59e2c6f4f80a"},
+    {"libEGL.dylib",
+     "9b47714f4e4db6a99567a361df7d68fe3f1ba1ce0f2277a7c2d13f8df144cedc"},
+    {"libGLESv2.dylib",
+     "6553b3bf3900e51c31d81d1734b689410aec7eedd48e199b8909e6824763842f"},
+    {"libIESAppLogger.dylib",
+     "90e6e7b203d42c3315c704e4912288e9a6e9fab7db310e404a48657b1c662687"},
+    {"libLumiGeneRuntime.dylib",
+     "2ef804016a7e3c359c9cbb430a33d15eee37b6a9c274e27d00246dfdadb907ab"},
+    {"libavcodec.dylib",
+     "83dcaf3834b561ef9cb7dfe23979053932ae075e33bae60c1c1ffccdb2f3c831"},
+    {"libavdevice.dylib",
+     "e50acfe1423795507e0e8a8beec6a22504e4b3484961d617700cc1389f33e0c9"},
+    {"libavfilter.dylib",
+     "04bca9d6227f80b916fa149f2f786e6ccfaa264e58d3903d3eccc347eb6e6ea0"},
+    {"libavformat.dylib",
+     "e3e123b6f6efdfebbd20fbd554006a6da8348671150eaa8ff27999edad00dc04"},
+    {"libavutil.dylib",
+     "647f031c96f4e75506c8a663970e06594f15ac76196b1d0d82e1f2c1273b8fd1"},
+    {"libbytenn.dylib",
+     "febfce4549cd6337c232c22ed00463a54cda7b255c4961426a33bfc78542b863"},
+    {"libdav1d.dylib",
+     "08f14e26884aa68653471bf737d1e619def2376d256c57265dc443bdf8fc3751"},
+    {"libfastcv.dylib",
+     "679fc0665d9e24a6130f1bf53cc04d7a54edde4fcba6d9607e4559b627ae066f"},
+    {"libffmpeg.dylib",
+     "f9d7e2346b80bb14265ee274bb69cadaa5e7d8b86ab14339290f9fa6cb2231e5"},
+    {"liblens.dylib",
+     "fdf576dd066a11db7b54d815621893ed62a8ed223e22834d5753738dc66df161"},
+    {"libmp3lame.0.dylib",
+     "7e94d5e4ac4f9bba67399b3f161fb4f6297ed9a56e7772ca805ebbd2e8905294"},
+    {"libsamicore.dylib",
+     "79494a89151fbf4b11ac8093e993a58ca075b2f379d17b4ccba309ec1aca6214"},
+    {"libsscronet.dylib",
+     "0f9f0b5adfd2128dc12b1885c60b5f4a0099fb0cddf0fbc5f8eef108a0f2428c"},
+    {"libswresample.dylib",
+     "b87bdbb71fb77ebe00a25709fc47ffaf2edbd9850aff698ba8e6e0fa2e4db53d"},
+    {"libswscale.dylib",
+     "114efa544ceced50e59d24956ae4bb8d0b42679389f0e251b6da43fde1b918bd"},
+    {"libvecryptor.dylib",
+     "8cc1f5cf094ee0dd8673a3c626f51892d6bd37ea15a178e3c80246c939a3a81e"},
+}};
+
+struct ITEVideoFrame;
+struct BachAlgorithmSystem;
+
+struct TagSteImgPos {
+  std::array<std::byte, 0x18> bytes{};
+};
+
+struct VEMattingTypeParam {
+  int mattingType = 0;
+  int padding04 = 0;
+  std::string field08;
+  std::string graphPath;
+  std::string field38;
+  std::string field50;
+  int modelType = 0;
+  int field6c = 0;
+  bool field70 = false;
+  std::array<std::byte, 7> padding71{};
+  std::string field78;
+  std::uint64_t field90 = 0;
+  std::uint32_t field98 = 0;
+  std::uint32_t padding9c = 0;
+};
+
+static_assert(sizeof(std::string) == 0x18);
+static_assert(sizeof(TagSteImgPos) == 0x18);
+static_assert(sizeof(VEMattingTypeParam) == 0xa0);
+static_assert(offsetof(VEMattingTypeParam, graphPath) == 0x20);
+static_assert(offsetof(VEMattingTypeParam, modelType) == 0x68);
+
+using ResourceFinder =
+    std::function<char *(void *, const char *, const char *)>;
+using GetEffectConfig = void *(*)();
+using SetExternalFinder = void (*)(void *, const ResourceFinder &);
+using FrameConstructor = void (*)(void *, int, const TagSteImgPos &, int);
+using FrameDestructor = void (*)(void *);
+using StorePixelBuffer = void (*)(void *, void *);
+using MattingConstructor = void (*)(void *);
+using MattingDestructor = void (*)(void *);
+using InitBach = int (*)(void *, const VEMattingTypeParam &,
+                         const VEMattingTypeParam &, int);
+using AIMattingInternal =
+    int (*)(void *, const std::shared_ptr<ITEVideoFrame> &,
+            const VEMattingTypeParam &,
+            const std::shared_ptr<BachAlgorithmSystem> &, bool);
+using GetMaskAndBoundingBox =
+    int (*)(void *, int, int, void *,
+            const std::shared_ptr<BachAlgorithmSystem> &);
+
+std::filesystem::path targetModelPath;
+
+template <typename Symbol>
+Symbol requireSymbol(void *library, const char *name) {
+  dlerror();
+  void *address = dlsym(library, name);
+  const char *error = dlerror();
+  if (error != nullptr || address == nullptr) {
+    throw std::runtime_error("missing audited symbol " + std::string(name) +
+                             ": " +
+                             (error == nullptr ? "null" : error));
+  }
+  return reinterpret_cast<Symbol>(address);
+}
+
+class LibraryHandle {
+public:
+  explicit LibraryHandle(const std::filesystem::path &path) {
+    handle_ = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    if (handle_ == nullptr) {
+      throw std::runtime_error("cannot load audited Jianying runtime: " +
+                               std::string(dlerror()));
+    }
+  }
+
+  ~LibraryHandle() {
+    if (handle_ != nullptr) {
+      dlclose(handle_);
+    }
+  }
+
+  LibraryHandle(const LibraryHandle &) = delete;
+  LibraryHandle &operator=(const LibraryHandle &) = delete;
+
+  void *get() const { return handle_; }
+
+private:
+  void *handle_ = nullptr;
+};
+
+class EngineGlContext {
+public:
+  EngineGlContext() {
+    [NSApplication sharedApplication];
+    const NSOpenGLPixelFormatAttribute attributes[] = {
+        NSOpenGLPFAOpenGLProfile,
+        NSOpenGLProfileVersion3_2Core,
+        NSOpenGLPFAAccelerated,
+        NSOpenGLPFAAllowOfflineRenderers,
+        NSOpenGLPFAColorSize,
+        32,
+        NSOpenGLPFAAlphaSize,
+        8,
+        0,
+    };
+    pixelFormat_ =
+        [[NSOpenGLPixelFormat alloc] initWithAttributes:attributes];
+    if (pixelFormat_ == nil) {
+      throw std::runtime_error("cannot create the audited OpenGL context");
+    }
+    context_ = [[NSOpenGLContext alloc] initWithFormat:pixelFormat_
+                                          shareContext:nil];
+    if (context_ == nil) {
+      throw std::runtime_error("cannot create the audited OpenGL context");
+    }
+    makeCurrent();
+  }
+
+  ~EngineGlContext() {
+    if ([NSOpenGLContext currentContext] == context_) {
+      [NSOpenGLContext clearCurrentContext];
+    }
+  }
+
+  EngineGlContext(const EngineGlContext &) = delete;
+  EngineGlContext &operator=(const EngineGlContext &) = delete;
+
+  bool makeCurrentNoexcept() const noexcept {
+    [context_ makeCurrentContext];
+    return [NSOpenGLContext currentContext] == context_ &&
+           CGLGetCurrentContext() != nullptr;
+  }
+
+  void makeCurrent() const {
+    if (!makeCurrentNoexcept()) {
+      throw std::runtime_error("audited OpenGL context is not current");
+    }
+  }
+
+private:
+  __strong NSOpenGLPixelFormat *pixelFormat_ = nil;
+  __strong NSOpenGLContext *context_ = nil;
+};
+
+class EngineContextRestore {
+public:
+  explicit EngineContextRestore(const EngineGlContext &context)
+      : context_(context) {}
+
+  ~EngineContextRestore() noexcept {
+    if (!context_.makeCurrentNoexcept()) {
+      std::terminate();
+    }
+  }
+
+  EngineContextRestore(const EngineContextRestore &) = delete;
+  EngineContextRestore &operator=(const EngineContextRestore &) = delete;
+
+private:
+  const EngineGlContext &context_;
+};
+
+class PixelBuffer {
+public:
+  PixelBuffer(const std::vector<std::uint8_t> &rgba, int width, int height) {
+    const CVReturn createResult = CVPixelBufferCreate(
+        kCFAllocatorDefault, static_cast<std::size_t>(width),
+        static_cast<std::size_t>(height), kCVPixelFormatType_32BGRA, nullptr,
+        &buffer_);
+    if (createResult != kCVReturnSuccess || buffer_ == nullptr) {
+      throw std::runtime_error("cannot allocate BGRA CVPixelBuffer: " +
+                               std::to_string(createResult));
+    }
+    const CVReturn lockResult = CVPixelBufferLockBaseAddress(buffer_, 0);
+    if (lockResult != kCVReturnSuccess) {
+      CVPixelBufferRelease(buffer_);
+      buffer_ = nullptr;
+      throw std::runtime_error("cannot lock BGRA CVPixelBuffer: " +
+                               std::to_string(lockResult));
+    }
+    auto *base =
+        static_cast<std::uint8_t *>(CVPixelBufferGetBaseAddress(buffer_));
+    const std::size_t rowBytes = CVPixelBufferGetBytesPerRow(buffer_);
+    for (int y = 0; y < height; ++y) {
+      auto *destination = base + static_cast<std::size_t>(y) * rowBytes;
+      const auto *source =
+          rgba.data() + static_cast<std::size_t>(y) * width * 4;
+      for (int x = 0; x < width; ++x) {
+        destination[x * 4] = source[x * 4 + 2];
+        destination[x * 4 + 1] = source[x * 4 + 1];
+        destination[x * 4 + 2] = source[x * 4];
+        destination[x * 4 + 3] = source[x * 4 + 3];
+      }
+    }
+    CVPixelBufferUnlockBaseAddress(buffer_, 0);
+  }
+
+  ~PixelBuffer() {
+    if (buffer_ != nullptr) {
+      CVPixelBufferRelease(buffer_);
+    }
+  }
+
+  PixelBuffer(const PixelBuffer &) = delete;
+  PixelBuffer &operator=(const PixelBuffer &) = delete;
+
+  CVPixelBufferRef get() const { return buffer_; }
+
+private:
+  CVPixelBufferRef buffer_ = nullptr;
+};
+
+std::string sha256File(const std::filesystem::path &path) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input) {
+    throw std::runtime_error("cannot open pinned runtime asset: " +
+                             path.string());
+  }
+  CC_SHA256_CTX context{};
+  CC_SHA256_Init(&context);
+  std::array<char, 1024 * 1024> buffer{};
+  while (input) {
+    input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    const auto count = input.gcount();
+    if (count > 0) {
+      CC_SHA256_Update(&context, buffer.data(),
+                       static_cast<CC_LONG>(count));
+    }
+  }
+  if (!input.eof()) {
+    throw std::runtime_error("cannot read pinned runtime asset: " +
+                             path.string());
+  }
+  std::array<unsigned char, CC_SHA256_DIGEST_LENGTH> digest{};
+  CC_SHA256_Final(digest.data(), &context);
+  std::ostringstream result;
+  result << std::hex << std::setfill('0');
+  for (const unsigned char byte : digest) {
+    result << std::setw(2) << static_cast<unsigned int>(byte);
+  }
+  return result.str();
+}
+
+void requireSha256(const std::filesystem::path &path,
+                   std::string_view expected, std::string_view label) {
+  const std::string actual = sha256File(path);
+  if (actual != expected) {
+    throw std::runtime_error(std::string(label) +
+                             " SHA-256 does not match the audited asset");
+  }
+}
+
+void requireRuntimeFrameworkClosure(
+    const std::filesystem::path &libraryPath) {
+  const auto frameworkDirectory = libraryPath.parent_path();
+  for (const auto &framework : kRuntimeFrameworks) {
+    requireSha256(frameworkDirectory / framework.fileName, framework.sha256,
+                  framework.fileName);
+  }
+}
+
+std::string loadedImageUuid(void *symbol) {
+  Dl_info info{};
+  if (dladdr(symbol, &info) == 0 || info.dli_fbase == nullptr) {
+    throw std::runtime_error("cannot inspect loaded runtime UUID");
+  }
+  const auto *header = static_cast<const mach_header_64 *>(info.dli_fbase);
+  if (header->magic != MH_MAGIC_64) {
+    throw std::runtime_error("loaded runtime is not native ARM64 Mach-O");
+  }
+  const auto *command = reinterpret_cast<const load_command *>(header + 1);
+  for (std::uint32_t index = 0; index < header->ncmds; ++index) {
+    if (command->cmd == LC_UUID && command->cmdsize >= sizeof(uuid_command)) {
+      const auto *uuid = reinterpret_cast<const uuid_command *>(command)->uuid;
+      std::ostringstream output;
+      output << std::uppercase << std::hex << std::setfill('0');
+      for (int byte = 0; byte < 16; ++byte) {
+        if (byte == 4 || byte == 6 || byte == 8 || byte == 10) {
+          output << '-';
+        }
+        output << std::setw(2) << static_cast<unsigned int>(uuid[byte]);
+      }
+      return output.str();
+    }
+    command = reinterpret_cast<const load_command *>(
+        reinterpret_cast<const std::byte *>(command) + command->cmdsize);
+  }
+  throw std::runtime_error("loaded runtime has no UUID");
+}
+
+char *copyUrl(const std::filesystem::path &path) {
+  const std::string value = "file://" + path.string();
+  auto *copy = static_cast<char *>(std::malloc(value.size() + 1));
+  if (copy == nullptr) {
+    return nullptr;
+  }
+  std::memcpy(copy, value.c_str(), value.size() + 1);
+  return copy;
+}
+
+char *resolveModel(void *, const char *directory, const char *name) noexcept {
+  try {
+    const std::string request =
+        std::string(directory == nullptr ? "" : directory) + "/" +
+        std::string(name == nullptr ? "" : name);
+    if (request.find("video_saliency_seg_bce") == std::string::npos) {
+      return nullptr;
+    }
+    return copyUrl(targetModelPath);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+int parsePositiveInteger(const char *value, const char *label) {
+  char *end = nullptr;
+  errno = 0;
+  const long parsed = std::strtol(value, &end, 10);
+  if (errno != 0 || end == value || *end != '\0' || parsed <= 0 ||
+      parsed > 16384) {
+    throw std::runtime_error(std::string(label) + " is out of range");
+  }
+  return static_cast<int>(parsed);
+}
+
+float parseBoundedFloat(const char *value, float minimum, float maximum,
+                        const char *label) {
+  char *end = nullptr;
+  errno = 0;
+  const float parsed = std::strtof(value, &end);
+  if (errno != 0 || end == value || *end != '\0' || !std::isfinite(parsed) ||
+      parsed < minimum || parsed > maximum) {
+    throw std::runtime_error(std::string(label) + " is out of range");
+  }
+  return parsed;
+}
+
+std::size_t readAll(int descriptor, std::uint8_t *data, std::size_t size) {
+  std::size_t bytesRead = 0;
+  while (bytesRead < size) {
+    const auto result = ::read(descriptor, data + bytesRead, size - bytesRead);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    if (result < 0) {
+      throw std::runtime_error("cannot read video-object RGBA input");
+    }
+    if (result == 0) {
+      break;
+    }
+    bytesRead += static_cast<std::size_t>(result);
+  }
+  return bytesRead;
+}
+
+void writeAll(int descriptor, const std::uint8_t *data, std::size_t size) {
+  std::size_t bytesWritten = 0;
+  while (bytesWritten < size) {
+    const auto result =
+        ::write(descriptor, data + bytesWritten, size - bytesWritten);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    if (result <= 0) {
+      throw std::runtime_error("cannot write video-object Alpha output");
+    }
+    bytesWritten += static_cast<std::size_t>(result);
+  }
+}
+
+class BachMattingSession {
+public:
+  BachMattingSession(void *library, const std::filesystem::path &graphPath)
+      : frameConstructor_(requireSymbol<FrameConstructor>(
+            library,
+            "_ZN20TECVPixelBufferFrameC1E9ETEPixFmtRK12tagSTEImgPos15ETERota"
+            "tionType")),
+        frameDestructor_(requireSymbol<FrameDestructor>(
+            library, "_ZN20TECVPixelBufferFrameD1Ev")),
+        storePixelBuffer_(requireSymbol<StorePixelBuffer>(
+            library, "_ZN20TECVPixelBufferFrame18storeCVPixelBufferEPv")),
+        mattingConstructor_(requireSymbol<MattingConstructor>(
+            library, "_ZN22TEBachMattingAlgorithmC1Ev")),
+        mattingDestructor_(requireSymbol<MattingDestructor>(
+            library, "_ZN22TEBachMattingAlgorithmD1Ev")),
+        initBach_(requireSymbol<InitBach>(
+            library,
+            "_ZN22TEBachMattingAlgorithm8initBachERK18VEMattingTypeParamS2_i")),
+        aiMattingInternal_(requireSymbol<AIMattingInternal>(
+            library,
+            "_ZN22TEBachMattingAlgorithm17AIMattingInternalERKNSt3__110shared_"
+            "ptrI13ITEVideoFrameEERK18VEMattingTypeParamRKNS1_IN4Bach19BachAlg"
+            "orithmSystemEEEb")),
+        getMaskAndBoundingBox_(requireSymbol<GetMaskAndBoundingBox>(
+            library,
+            "_ZN22TEBachMattingAlgorithm21getMaskAndBoundingBoxE13VEMattingTy"
+            "pe18VEMattingModelTypeR17TEMattingMaskInfoRKNSt3__110shared_ptrIN"
+            "4Bach19BachAlgorithmSystemEEE")) {
+    current_.mattingType = kObjectMattingType;
+    current_.graphPath = graphPath.string();
+    current_.modelType = kVideoSaliencyModelType;
+    mattingMemory_ = ::operator new(kMattingObjectSize);
+    try {
+      mattingConstructor_(mattingMemory_);
+      mattingConstructed_ = true;
+      const int result = initBach_(mattingMemory_, current_, base_, 0);
+      if (result != 0) {
+        throw std::runtime_error("TEBachMattingAlgorithm::initBach failed: " +
+                                 std::to_string(result));
+      }
+    } catch (...) {
+      if (mattingConstructed_) {
+        mattingDestructor_(mattingMemory_);
+      }
+      ::operator delete(mattingMemory_);
+      mattingMemory_ = nullptr;
+      mattingConstructed_ = false;
+      throw;
+    }
+  }
+
+  ~BachMattingSession() {
+    if (mattingConstructed_) {
+      mattingDestructor_(mattingMemory_);
+    }
+    ::operator delete(mattingMemory_);
+  }
+
+  BachMattingSession(const BachMattingSession &) = delete;
+  BachMattingSession &operator=(const BachMattingSession &) = delete;
+
+  std::vector<std::uint8_t>
+  processRawMask(const std::vector<std::uint8_t> &rgba, int width,
+                 int height) {
+    PixelBuffer pixelBuffer(rgba, width, height);
+    void *frameMemory = ::operator new(kFrameObjectSize);
+    const TagSteImgPos position{};
+    try {
+      frameConstructor_(frameMemory, kBgraPixelFormat, position, 0);
+    } catch (...) {
+      ::operator delete(frameMemory);
+      throw;
+    }
+    std::shared_ptr<ITEVideoFrame> frame(
+        reinterpret_cast<ITEVideoFrame *>(frameMemory),
+        [destructor = frameDestructor_](ITEVideoFrame *pointer) {
+          destructor(pointer);
+          ::operator delete(pointer);
+        });
+    storePixelBuffer_(frameMemory, pixelBuffer.get());
+
+    const std::shared_ptr<BachAlgorithmSystem> externalSystem;
+    const int executeResult = aiMattingInternal_(
+        mattingMemory_, frame, current_, externalSystem, true);
+    if (executeResult != 0) {
+      throw std::runtime_error("Bach video-object inference failed: " +
+                               std::to_string(executeResult));
+    }
+
+    alignas(16) std::array<std::byte, kMaskStorageSize> maskStorage{};
+    *reinterpret_cast<float *>(maskStorage.data()) = -1.0F;
+    const int maskResult = getMaskAndBoundingBox_(
+        mattingMemory_, kObjectMattingType, kVideoSaliencyModelType,
+        maskStorage.data(), externalSystem);
+    if (maskResult != 0) {
+      throw std::runtime_error("cannot read Bach saliency_mask: " +
+                               std::to_string(maskResult));
+    }
+
+    auto *alpha =
+        *reinterpret_cast<std::uint8_t **>(maskStorage.data() + 0x10);
+    const std::unique_ptr<std::uint8_t[]> ownedAlpha(alpha);
+    const int alphaWidth =
+        *reinterpret_cast<const int *>(maskStorage.data() + 0x18);
+    const int alphaHeight =
+        *reinterpret_cast<const int *>(maskStorage.data() + 0x1c);
+    if (ownedAlpha == nullptr || alphaWidth != kModelDimension ||
+        alphaHeight != kModelDimension) {
+      throw std::runtime_error(
+          "Bach saliency_mask violates the audited 256x256 contract");
+    }
+    const std::size_t alphaSize =
+        static_cast<std::size_t>(alphaWidth) * alphaHeight;
+    return std::vector<std::uint8_t>(ownedAlpha.get(),
+                                     ownedAlpha.get() + alphaSize);
+  }
+
+private:
+  FrameConstructor frameConstructor_;
+  FrameDestructor frameDestructor_;
+  StorePixelBuffer storePixelBuffer_;
+  MattingConstructor mattingConstructor_;
+  MattingDestructor mattingDestructor_;
+  InitBach initBach_;
+  AIMattingInternal aiMattingInternal_;
+  GetMaskAndBoundingBox getMaskAndBoundingBox_;
+  VEMattingTypeParam current_;
+  VEMattingTypeParam base_;
+  void *mattingMemory_ = nullptr;
+  bool mattingConstructed_ = false;
+};
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 8 && argc != 12) {
+    std::cerr << "usage: jianying-video-object-bach-bridge <libcccreator> "
+                 "<graph-dir> <model-file> <input.rgba|-> <width> <height> "
+                 "<output.gray|-> [<threshold> <temporal-smoothing> "
+                 "<edge-shift> <feather>]\n";
+    return 2;
+  }
+  try {
+    const std::filesystem::path libraryPath = argv[1];
+    const std::filesystem::path graphPath = argv[2];
+    targetModelPath = argv[3];
+    const std::filesystem::path inputPath = argv[4];
+    const int width = parsePositiveInteger(argv[5], "width");
+    const int height = parsePositiveInteger(argv[6], "height");
+    const std::filesystem::path outputPath = argv[7];
+    const float threshold =
+        argc == 12 ? parseBoundedFloat(argv[8], 0.0F, 1.0F, "threshold")
+                   : 0.5F;
+    const float temporalSmoothing =
+        argc == 12
+            ? parseBoundedFloat(argv[9], 0.0F, 0.95F, "temporal smoothing")
+            : 0.0F;
+    const float edgeShift =
+        argc == 12
+            ? parseBoundedFloat(argv[10], -12.0F, 12.0F, "edge shift")
+            : 0.0F;
+    const float feather =
+        argc == 12 ? parseBoundedFloat(argv[11], 0.0F, 16.0F, "feather")
+                   : 0.0F;
+    const bool useRefinement = threshold != 0.5F || temporalSmoothing != 0.0F ||
+                               edgeShift != 0.0F || feather != 0.0F;
+    const std::size_t frameBytes =
+        static_cast<std::size_t>(width) * height * 4;
+    const bool streamInput = inputPath == "-";
+    const bool streamOutput = outputPath == "-";
+
+    requireSha256(libraryPath, kExpectedLibrarySha256, "libcccreator");
+    requireRuntimeFrameworkClosure(libraryPath);
+    requireSha256(graphPath / "algorithmConfig.json", kExpectedGraphSha256,
+                  "video-object graph");
+    requireSha256(targetModelPath, kExpectedModelSha256,
+                  "video-object packed model");
+
+    std::unique_ptr<std::ifstream> inputFile;
+    std::istream *input = &std::cin;
+    std::size_t expectedFrameCount = 0;
+    if (!streamInput) {
+      inputFile = std::make_unique<std::ifstream>(
+          inputPath, std::ios::binary | std::ios::ate);
+      if (!*inputFile) {
+        throw std::runtime_error("cannot open video-object RGBA input");
+      }
+      const auto inputBytes = inputFile->tellg();
+      if (inputBytes <= 0 ||
+          static_cast<std::size_t>(inputBytes) % frameBytes != 0) {
+        throw std::runtime_error("video-object input has incomplete frames");
+      }
+      expectedFrameCount =
+          static_cast<std::size_t>(inputBytes) / frameBytes;
+      inputFile->seekg(0);
+      input = inputFile.get();
+    }
+
+    std::unique_ptr<std::ofstream> outputFile;
+    int outputDescriptor = -1;
+    if (streamOutput) {
+      outputDescriptor = ::dup(STDOUT_FILENO);
+      if (outputDescriptor < 0 || ::dup2(STDERR_FILENO, STDOUT_FILENO) < 0) {
+        throw std::runtime_error("cannot isolate video-object Alpha stream");
+      }
+    } else {
+      outputFile =
+          std::make_unique<std::ofstream>(outputPath, std::ios::binary);
+      if (!*outputFile) {
+        throw std::runtime_error("cannot open video-object Alpha output");
+      }
+    }
+
+    LibraryHandle library(libraryPath);
+    const auto getEffectConfig = requireSymbol<GetEffectConfig>(
+        library.get(), "_ZN14TEEffectConfig11getInstanceEv");
+    if (loadedImageUuid(reinterpret_cast<void *>(getEffectConfig)) !=
+        kExpectedRuntimeUuid) {
+      throw std::runtime_error("runtime UUID does not match the audited image");
+    }
+#if defined(QCUT_BACH_RESEARCH_CAPTURE)
+    installByteCoreMLNn3Capture();
+#endif
+    const auto setExternalFinder = requireSymbol<SetExternalFinder>(
+        library.get(),
+        "_ZN14TEEffectConfig17setExternalFinderERKNSt3__18functionIFPcPvPKcS5_"
+        "EEE");
+    const ResourceFinder finder(resolveModel);
+    setExternalFinder(getEffectConfig(), finder);
+
+    EngineGlContext engineGlContext;
+    BachMattingSession session(library.get(), graphPath);
+    // Teardown is V2 -> restore Engine context -> Bach session.
+    EngineContextRestore engineContextRestore(engineGlContext);
+    auto vendorBlend = std::make_unique<qcut::matting::MetalMattingBlend>(
+        qcut::matting::MetalMattingBlendConfig{
+            .library = library.get(),
+            .width = width,
+            .height = height,
+        });
+    std::vector<std::uint8_t> rgba(frameBytes);
+    std::vector<float> refinementState;
+    std::size_t frameCount = 0;
+    while (true) {
+      std::size_t bytesRead = 0;
+      if (streamInput) {
+        bytesRead = readAll(STDIN_FILENO, rgba.data(), rgba.size());
+      } else {
+        input->read(reinterpret_cast<char *>(rgba.data()),
+                    static_cast<std::streamsize>(rgba.size()));
+        bytesRead = static_cast<std::size_t>(input->gcount());
+      }
+      if (bytesRead == 0) {
+        break;
+      }
+      if (bytesRead != frameBytes) {
+        throw std::runtime_error("video-object input ended mid-frame");
+      }
+      std::vector<std::uint8_t> vendorAlpha;
+      @autoreleasepool {
+        engineGlContext.makeCurrent();
+        const auto rawMask = session.processRawMask(rgba, width, height);
+        vendorAlpha = vendorBlend->blendAlpha(
+            qcut::matting::MetalMattingBlendFrame{
+                .rgba = rgba,
+                .alpha = rawMask,
+                .alphaWidth = kModelDimension,
+                .alphaHeight = kModelDimension,
+            });
+      }
+      auto alpha =
+          useRefinement
+              ? qcut::matting::refineAlpha(
+                    vendorAlpha, refinementState, width, height, threshold,
+                    temporalSmoothing, edgeShift, feather)
+              : vendorAlpha;
+      if (useRefinement) {
+        qcut::matting::detail::clampMetalMattingBlendAlphaToSource(rgba,
+                                                                   alpha);
+      }
+      if (alpha.size() != static_cast<std::size_t>(width) * height) {
+        throw std::runtime_error("video-object Alpha frame size is invalid");
+      }
+      if (streamOutput) {
+        writeAll(outputDescriptor, alpha.data(), alpha.size());
+      } else {
+        outputFile->write(reinterpret_cast<const char *>(alpha.data()),
+                          static_cast<std::streamsize>(alpha.size()));
+        if (!*outputFile) {
+          throw std::runtime_error("cannot write video-object Alpha frame");
+        }
+      }
+      ++frameCount;
+      std::cerr << "progress frame=" << frameCount
+                << " total=" << expectedFrameCount << '\n';
+    }
+    if (frameCount == 0 ||
+        (expectedFrameCount > 0 && frameCount != expectedFrameCount)) {
+      throw std::runtime_error("video-object input frame count is invalid");
+    }
+    if (outputFile) {
+      outputFile->flush();
+      if (!*outputFile) {
+        throw std::runtime_error("cannot flush video-object Alpha output");
+      }
+    }
+    if (outputDescriptor >= 0) {
+      ::close(outputDescriptor);
+    }
+    std::cerr << "ok width=" << width << " height=" << height
+              << " frames=" << frameCount << " route=" << kProviderId
+              << " blend=" << kBlendId
+              << " closure=" << kRuntimeFrameworkClosureId
+              << " refinement="
+              << (useRefinement ? kAdvancedRefinementId : kExactRefinementId)
+              << '\n';
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << "error route=" << kProviderId << " message=" << error.what()
+              << '\n';
+    return 1;
+  }
+}

--- a/qcut/electron/jianying-person-cutout/native/video-object-coreml-bridge.mm
+++ b/qcut/electron/jianying-person-cutout/native/video-object-coreml-bridge.mm
@@ -1,0 +1,302 @@
+#include "alpha-refinement.hpp"
+#include "video-object-coreml-preprocess.hpp"
+
+#import <CoreML/CoreML.h>
+#import <Foundation/Foundation.h>
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kModelDimension = 256;
+
+int parsePositiveInteger(const char *text, const char *label) {
+  const int value = std::stoi(text);
+  if (value <= 0 || value > 8192) {
+    throw std::runtime_error(std::string(label) + " is out of range");
+  }
+  return value;
+}
+
+std::size_t readAll(int fileDescriptor, std::uint8_t *data, std::size_t size) {
+  std::size_t bytesRead = 0;
+  while (bytesRead < size) {
+    const auto result = ::read(fileDescriptor, data + bytesRead, size - bytesRead);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    if (result < 0) {
+      throw std::runtime_error("cannot read video-object RGBA input");
+    }
+    if (result == 0) {
+      break;
+    }
+    bytesRead += static_cast<std::size_t>(result);
+  }
+  return bytesRead;
+}
+
+void writeAll(int fileDescriptor, const std::uint8_t *data, std::size_t size) {
+  std::size_t written = 0;
+  while (written < size) {
+    const auto result = ::write(fileDescriptor, data + written, size - written);
+    if (result < 0 && errno == EINTR) {
+      continue;
+    }
+    if (result <= 0) {
+      throw std::runtime_error("cannot write video-object Alpha output");
+    }
+    written += static_cast<std::size_t>(result);
+  }
+}
+
+std::set<std::size_t> resetFrames() {
+  std::set<std::size_t> frames;
+  const char *configured = std::getenv("QCUT_VIDEO_OBJECT_RESET_FRAMES");
+  if (configured == nullptr || configured[0] == '\0') {
+    return frames;
+  }
+  std::string values(configured);
+  std::size_t offset = 0;
+  while (offset < values.size()) {
+    const std::size_t separator = values.find(',', offset);
+    const std::string value = values.substr(offset, separator - offset);
+    const long long frame = std::stoll(value);
+    if (frame < 0) {
+      throw std::runtime_error("video-object reset frame cannot be negative");
+    }
+    frames.insert(static_cast<std::size_t>(frame));
+    if (separator == std::string::npos) {
+      break;
+    }
+    offset = separator + 1;
+  }
+  return frames;
+}
+
+class CoreMLVideoObjectModel {
+public:
+  explicit CoreMLVideoObjectModel(const char *modelPath) {
+    @autoreleasepool {
+      NSError *error = nil;
+      MLModelConfiguration *configuration = [MLModelConfiguration new];
+      configuration.computeUnits = MLComputeUnitsAll;
+      NSURL *modelUrl = [NSURL fileURLWithPath:@(modelPath)];
+      model_ = [MLModel modelWithContentsOfURL:modelUrl
+                                 configuration:configuration
+                                         error:&error];
+      if (model_ == nil) {
+        throw std::runtime_error(
+            "cannot load video-object CoreML model: " +
+            std::string(error.localizedDescription.UTF8String ?: "unknown"));
+      }
+      current_ = createArray(@[@1, @3, @256, @256]);
+      previousImage_ = createArray(@[@1, @3, @256, @256]);
+      previousMask_ = createArray(@[@1, @1, @256, @256]);
+    }
+  }
+
+  std::vector<std::uint8_t>
+  process(const std::vector<std::uint8_t> &rgba, int width, int height) {
+    @autoreleasepool {
+      const auto current =
+          qcut::matting::prepareVideoObjectCoreMLInput(rgba, width, height);
+      copyToArray(current.data(), current.size(), current_);
+      copyToArray(temporalState_.previousImage(), current.size(),
+                  previousImage_);
+      copyToArray(temporalState_.previousMask(),
+                  qcut::matting::VideoObjectCoreMLTemporalState::
+                      kMaskElementCount,
+                  previousMask_);
+
+      NSError *error = nil;
+      MLDictionaryFeatureProvider *input =
+          [[MLDictionaryFeatureProvider alloc]
+              initWithDictionary:@{
+                @"data" : [MLFeatureValue featureValueWithMultiArray:current_],
+                @"prev_img" :
+                    [MLFeatureValue featureValueWithMultiArray:previousImage_],
+                @"prev_mask" :
+                    [MLFeatureValue featureValueWithMultiArray:previousMask_]
+              }
+                          error:&error];
+      if (input == nil) {
+        throwCoreMLError("cannot create video-object CoreML input", error);
+      }
+      id<MLFeatureProvider> prediction = [model_ predictionFromFeatures:input
+                                                                  error:&error];
+      if (prediction == nil) {
+        throwCoreMLError("video-object CoreML inference failed", error);
+      }
+      MLMultiArray *output = [prediction featureValueForName:@"nn_3"].multiArrayValue;
+      if (output == nil || output.dataType != MLMultiArrayDataTypeFloat32 ||
+          output.count != kModelDimension * kModelDimension) {
+        throw std::runtime_error("video-object CoreML output shape is invalid");
+      }
+      const auto *mask = static_cast<const float *>(output.dataPointer);
+      temporalState_.advance(current.data(), mask);
+      return qcut::matting::finalizeVideoObjectCoreMLOutput(mask, width,
+                                                            height);
+    }
+  }
+
+  void reset() { temporalState_.reset(); }
+
+private:
+  static MLMultiArray *createArray(NSArray<NSNumber *> *shape) {
+    NSError *error = nil;
+    MLMultiArray *array = [[MLMultiArray alloc] initWithShape:shape
+                                                   dataType:MLMultiArrayDataTypeFloat32
+                                                      error:&error];
+    if (array == nil) {
+      throwCoreMLError("cannot allocate video-object CoreML tensor", error);
+    }
+    return array;
+  }
+
+  static void copyToArray(const float *source, std::size_t count,
+                          MLMultiArray *target) {
+    if (target.count != static_cast<NSInteger>(count)) {
+      throw std::runtime_error("video-object CoreML tensor size is invalid");
+    }
+    std::copy_n(source, count, static_cast<float *>(target.dataPointer));
+  }
+
+  [[noreturn]] static void throwCoreMLError(const char *message,
+                                            NSError *error) {
+    throw std::runtime_error(
+        std::string(message) + ": " +
+        std::string(error.localizedDescription.UTF8String ?: "unknown"));
+  }
+
+  MLModel *model_ = nil;
+  MLMultiArray *current_ = nil;
+  MLMultiArray *previousImage_ = nil;
+  MLMultiArray *previousMask_ = nil;
+  qcut::matting::VideoObjectCoreMLTemporalState temporalState_;
+};
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 10) {
+    std::cerr << "usage: video-object-coreml-bridge <model.mlmodelc> "
+                 "<input.rgba|-> <width> <height> <output.gray|-> "
+                 "<threshold> <temporal-smoothing> <edge-shift> <feather>\n";
+    return 2;
+  }
+  try {
+    const int width = parsePositiveInteger(argv[3], "width");
+    const int height = parsePositiveInteger(argv[4], "height");
+    const float threshold = std::clamp(std::stof(argv[6]), 0.0F, 1.0F);
+    const float temporalSmoothing =
+        std::clamp(std::stof(argv[7]), 0.0F, 0.95F);
+    const float edgeShift = std::clamp(std::stof(argv[8]), -12.0F, 12.0F);
+    const float feather = std::clamp(std::stof(argv[9]), 0.0F, 16.0F);
+    const std::size_t frameBytes =
+        static_cast<std::size_t>(width) * height * 4;
+    const bool streamInput = std::string(argv[2]) == "-";
+    const bool streamOutput = std::string(argv[5]) == "-";
+
+    std::unique_ptr<std::ifstream> inputFile;
+    std::istream *input = &std::cin;
+    std::size_t expectedFrameCount = 0;
+    if (!streamInput) {
+      inputFile = std::make_unique<std::ifstream>(argv[2],
+                                                  std::ios::binary | std::ios::ate);
+      if (!*inputFile) {
+        throw std::runtime_error("cannot open video-object RGBA input");
+      }
+      const auto inputBytes = inputFile->tellg();
+      if (inputBytes <= 0 ||
+          static_cast<std::size_t>(inputBytes) % frameBytes != 0) {
+        throw std::runtime_error("video-object input has incomplete frames");
+      }
+      expectedFrameCount = static_cast<std::size_t>(inputBytes) / frameBytes;
+      inputFile->seekg(0);
+      input = inputFile.get();
+    }
+
+    std::unique_ptr<std::ofstream> outputFile;
+    int outputDescriptor = -1;
+    if (streamOutput) {
+      outputDescriptor = ::dup(STDOUT_FILENO);
+      if (outputDescriptor < 0 || ::dup2(STDERR_FILENO, STDOUT_FILENO) < 0) {
+        throw std::runtime_error("cannot isolate video-object Alpha output");
+      }
+    } else {
+      outputFile = std::make_unique<std::ofstream>(argv[5], std::ios::binary);
+      if (!*outputFile) {
+        throw std::runtime_error("cannot open video-object Alpha output");
+      }
+    }
+
+    const auto stateResetFrames = resetFrames();
+    CoreMLVideoObjectModel model(argv[1]);
+    std::vector<std::uint8_t> source(frameBytes);
+    std::vector<float> refinementState;
+    std::size_t frameCount = 0;
+    while (true) {
+      std::size_t bytesRead = 0;
+      if (streamInput) {
+        bytesRead = readAll(STDIN_FILENO, source.data(), source.size());
+      } else {
+        input->read(reinterpret_cast<char *>(source.data()), source.size());
+        bytesRead = static_cast<std::size_t>(input->gcount());
+      }
+      if (bytesRead == 0) {
+        break;
+      }
+      if (bytesRead != frameBytes) {
+        throw std::runtime_error("video-object input ended mid-frame");
+      }
+      if (stateResetFrames.contains(frameCount)) {
+        model.reset();
+        refinementState.clear();
+        std::cerr << "state_reset frame=" << frameCount << '\n';
+      }
+      const auto rawAlpha = model.process(source, width, height);
+      const auto alpha = qcut::matting::refineAlpha(
+          rawAlpha, refinementState, width, height, threshold,
+          temporalSmoothing, edgeShift, feather);
+      if (streamOutput) {
+        writeAll(outputDescriptor, alpha.data(), alpha.size());
+      } else {
+        outputFile->write(reinterpret_cast<const char *>(alpha.data()),
+                          alpha.size());
+        if (!*outputFile) {
+          throw std::runtime_error("cannot write video-object Alpha frame");
+        }
+      }
+      ++frameCount;
+      std::cerr << "progress frame=" << frameCount
+                << " total=" << expectedFrameCount << '\n';
+    }
+    if (frameCount == 0 ||
+        (expectedFrameCount > 0 && frameCount != expectedFrameCount)) {
+      throw std::runtime_error("video-object input did not contain complete frames");
+    }
+    if (outputDescriptor >= 0) {
+      ::close(outputDescriptor);
+    }
+    std::cerr << "ok width=" << width << " height=" << height
+              << " frames=" << frameCount
+              << " route=video-object-same-model-coreml-v1\n";
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}

--- a/qcut/electron/jianying-person-cutout/native/video-object-coreml-bridge.mm
+++ b/qcut/electron/jianying-person-cutout/native/video-object-coreml-bridge.mm
@@ -288,6 +288,12 @@ int main(int argc, char **argv) {
         (expectedFrameCount > 0 && frameCount != expectedFrameCount)) {
       throw std::runtime_error("video-object input did not contain complete frames");
     }
+    if (outputFile) {
+      outputFile->flush();
+      if (!*outputFile) {
+        throw std::runtime_error("cannot flush video-object Alpha output");
+      }
+    }
     if (outputDescriptor >= 0) {
       ::close(outputDescriptor);
     }

--- a/qcut/electron/jianying-person-cutout/native/video-object-coreml-preprocess.cpp
+++ b/qcut/electron/jianying-person-cutout/native/video-object-coreml-preprocess.cpp
@@ -1,0 +1,121 @@
+#include "video-object-coreml-preprocess.hpp"
+
+#include "alpha-resize.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+
+namespace qcut::matting {
+namespace {
+
+constexpr int kModelDimension = 256;
+
+} // namespace
+
+std::vector<std::uint8_t> resizeVideoObjectRgbaBilinear(
+    const std::vector<std::uint8_t> &source, int sourceWidth, int sourceHeight,
+    int targetWidth, int targetHeight) {
+  if (sourceWidth <= 0 || sourceHeight <= 0 || targetWidth <= 0 ||
+      targetHeight <= 0 ||
+      source.size() !=
+          static_cast<std::size_t>(sourceWidth) * sourceHeight * 4) {
+    throw std::runtime_error("video-object RGBA input size is invalid");
+  }
+  std::vector<std::uint8_t> target(
+      static_cast<std::size_t>(targetWidth) * targetHeight * 4);
+  const float scaleX = static_cast<float>(sourceWidth) / targetWidth;
+  const float scaleY = static_cast<float>(sourceHeight) / targetHeight;
+  for (int y = 0; y < targetHeight; ++y) {
+    const float sourceY = std::clamp((y + 0.5F) * scaleY - 0.5F, 0.0F,
+                                     static_cast<float>(sourceHeight - 1));
+    const int y0 = static_cast<int>(std::floor(sourceY));
+    const int y1 = std::min(y0 + 1, sourceHeight - 1);
+    const float fractionY = sourceY - y0;
+    for (int x = 0; x < targetWidth; ++x) {
+      const float sourceX = std::clamp((x + 0.5F) * scaleX - 0.5F, 0.0F,
+                                       static_cast<float>(sourceWidth - 1));
+      const int x0 = static_cast<int>(std::floor(sourceX));
+      const int x1 = std::min(x0 + 1, sourceWidth - 1);
+      const float fractionX = sourceX - x0;
+      for (int channel = 0; channel < 4; ++channel) {
+        const auto sample = [&](int sampleX, int sampleY) {
+          return static_cast<float>(
+              source[(static_cast<std::size_t>(sampleY) * sourceWidth +
+                      sampleX) *
+                         4 +
+                     channel]);
+        };
+        const float top = std::lerp(sample(x0, y0), sample(x1, y0), fractionX);
+        const float bottom =
+            std::lerp(sample(x0, y1), sample(x1, y1), fractionX);
+        target[(static_cast<std::size_t>(y) * targetWidth + x) * 4 + channel] =
+            static_cast<std::uint8_t>(
+                std::clamp(std::lround(std::lerp(top, bottom, fractionY)), 0L,
+                           255L));
+      }
+    }
+  }
+  return target;
+}
+
+std::vector<float>
+prepareVideoObjectCoreMLInput(const std::vector<std::uint8_t> &rgba, int width,
+                              int height) {
+  const auto modelInput = resizeVideoObjectRgbaBilinear(
+      rgba, width, height, kModelDimension, kModelDimension);
+  constexpr std::size_t plane = kModelDimension * kModelDimension;
+  std::vector<float> bgr(plane * 3);
+  for (std::size_t pixel = 0; pixel < plane; ++pixel) {
+    bgr[pixel] = modelInput[pixel * 4 + 2] / 255.0F;
+    bgr[plane + pixel] = modelInput[pixel * 4 + 1] / 255.0F;
+    bgr[plane * 2 + pixel] = modelInput[pixel * 4] / 255.0F;
+  }
+  return bgr;
+}
+
+std::vector<std::uint8_t>
+finalizeVideoObjectCoreMLOutput(const float *mask, int width, int height) {
+  if (mask == nullptr) {
+    throw std::runtime_error("video-object CoreML output is missing");
+  }
+  std::vector<std::uint8_t> modelMask(kModelDimension * kModelDimension);
+  for (std::size_t index = 0; index < modelMask.size(); ++index) {
+    if (!std::isfinite(mask[index])) {
+      throw std::runtime_error("video-object CoreML output is not finite");
+    }
+    const float value = std::clamp(mask[index], 0.0F, 1.0F);
+    modelMask[index] =
+        static_cast<std::uint8_t>(std::lround(value * 255.0F));
+  }
+  return resizeAlphaBilinear(modelMask, kModelDimension, kModelDimension, width,
+                             height);
+}
+
+VideoObjectCoreMLTemporalState::VideoObjectCoreMLTemporalState()
+    : previousImage_(kImageElementCount), previousMask_(kMaskElementCount) {}
+
+const float *VideoObjectCoreMLTemporalState::previousImage() const {
+  return previousImage_.data();
+}
+
+const float *VideoObjectCoreMLTemporalState::previousMask() const {
+  return previousMask_.data();
+}
+
+void VideoObjectCoreMLTemporalState::advance(const float *image,
+                                             const float *mask) {
+  if (image == nullptr || mask == nullptr) {
+    throw std::runtime_error("video-object temporal input is missing");
+  }
+  std::copy_n(image, kImageElementCount, previousImage_.begin());
+  std::copy_n(mask, kMaskElementCount, previousMask_.begin());
+}
+
+void VideoObjectCoreMLTemporalState::reset() {
+  std::fill(previousImage_.begin(), previousImage_.end(), 0.0F);
+  std::fill(previousMask_.begin(), previousMask_.end(), 0.0F);
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/video-object-coreml-preprocess.hpp
+++ b/qcut/electron/jianying-person-cutout/native/video-object-coreml-preprocess.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace qcut::matting {
+
+std::vector<std::uint8_t> resizeVideoObjectRgbaBilinear(
+    const std::vector<std::uint8_t> &source, int sourceWidth, int sourceHeight,
+    int targetWidth, int targetHeight);
+
+std::vector<float>
+prepareVideoObjectCoreMLInput(const std::vector<std::uint8_t> &rgba, int width,
+                              int height);
+
+std::vector<std::uint8_t>
+finalizeVideoObjectCoreMLOutput(const float *mask, int width, int height);
+
+class VideoObjectCoreMLTemporalState {
+public:
+  static constexpr int kImageElementCount = 3 * 256 * 256;
+  static constexpr int kMaskElementCount = 256 * 256;
+
+  VideoObjectCoreMLTemporalState();
+
+  const float *previousImage() const;
+  const float *previousMask() const;
+  void advance(const float *image, const float *mask);
+  void reset();
+
+private:
+  std::vector<float> previousImage_;
+  std::vector<float> previousMask_;
+};
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/video-object-coreml-preprocess.test.cpp
+++ b/qcut/electron/jianying-person-cutout/native/video-object-coreml-preprocess.test.cpp
@@ -1,0 +1,72 @@
+#include "video-object-coreml-preprocess.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+int main() {
+  using namespace qcut::matting;
+  const std::vector<std::uint8_t> redPixel{255, 0, 0, 255};
+  const auto input = prepareVideoObjectCoreMLInput(redPixel, 1, 1);
+  constexpr std::size_t plane = 256 * 256;
+  assert(input.size() == plane * 3);
+  assert(std::all_of(input.begin(), input.begin() + plane,
+                     [](float value) { return value == 0.0F; }));
+  assert(std::all_of(input.begin() + plane, input.begin() + plane * 2,
+                     [](float value) { return value == 0.0F; }));
+  assert(std::all_of(input.begin() + plane * 2, input.end(),
+                     [](float value) { return value == 1.0F; }));
+
+  const std::vector<std::uint8_t> source{
+      0,   10,  20,  255, 30,  40,  50,  255, 60,  70,  80,  255,
+      90,  100, 110, 255, 120, 130, 140, 255, 150, 160, 170, 255,
+  };
+  const auto directResize =
+      resizeVideoObjectRgbaBilinear(source, 3, 2, 256, 256);
+  const auto directInput = prepareVideoObjectCoreMLInput(source, 3, 2);
+  for (std::size_t pixel : {0UL, 127UL, plane - 1}) {
+    assert(directInput[pixel] == directResize[pixel * 4 + 2] / 255.0F);
+    assert(directInput[plane + pixel] ==
+           directResize[pixel * 4 + 1] / 255.0F);
+    assert(directInput[plane * 2 + pixel] ==
+           directResize[pixel * 4] / 255.0F);
+  }
+
+  VideoObjectCoreMLTemporalState state;
+  std::vector<float> image(state.kImageElementCount, 0.25F);
+  std::vector<float> mask(state.kMaskElementCount, 0.75F);
+  state.advance(image.data(), mask.data());
+  assert(state.previousImage()[123] == 0.25F);
+  assert(state.previousMask()[123] == 0.75F);
+  state.reset();
+  assert(state.previousImage()[123] == 0.0F);
+  assert(state.previousMask()[123] == 0.0F);
+
+  std::vector<float> whiteMask(plane, 1.0F);
+  const auto output = finalizeVideoObjectCoreMLOutput(whiteMask.data(), 3, 5);
+  assert(output.size() == 15);
+  assert(std::all_of(output.begin(), output.end(),
+                     [](std::uint8_t value) { return value == 255; }));
+
+  std::vector<float> lowMask(plane);
+  lowMask[0] = 1.0F / 255.0F;
+  lowMask[1] = 2.0F / 255.0F;
+  const auto lowOutput =
+      finalizeVideoObjectCoreMLOutput(lowMask.data(), 256, 256);
+  assert(lowOutput[0] == 1);
+  assert(lowOutput[1] == 2);
+  assert(lowOutput[2] == 0);
+
+  lowMask[0] = std::numeric_limits<float>::quiet_NaN();
+  bool rejectedNonFinite = false;
+  try {
+    static_cast<void>(
+        finalizeVideoObjectCoreMLOutput(lowMask.data(), 256, 256));
+  } catch (const std::runtime_error &) {
+    rejectedNonFinite = true;
+  }
+  assert(rejectedNonFinite);
+}

--- a/qcut/electron/jianying-person-cutout/native/vision-person-segmentation.hpp
+++ b/qcut/electron/jianying-person-cutout/native/vision-person-segmentation.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace qcut::matting {
+
+class VisionPersonSegmentation {
+public:
+  VisionPersonSegmentation(int width, int height);
+  ~VisionPersonSegmentation();
+
+  VisionPersonSegmentation(const VisionPersonSegmentation &) = delete;
+  VisionPersonSegmentation &operator=(const VisionPersonSegmentation &) = delete;
+  VisionPersonSegmentation(VisionPersonSegmentation &&) noexcept;
+  VisionPersonSegmentation &operator=(VisionPersonSegmentation &&) noexcept;
+
+  std::vector<std::uint8_t>
+  segment(const std::vector<std::uint8_t> &rgba) const;
+
+private:
+  class Implementation;
+  std::unique_ptr<Implementation> implementation;
+};
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/vision-person-segmentation.mm
+++ b/qcut/electron/jianying-person-cutout/native/vision-person-segmentation.mm
@@ -1,0 +1,190 @@
+#include "vision-person-segmentation.hpp"
+
+#include "alpha-resize.hpp"
+
+#import <CoreVideo/CoreVideo.h>
+#import <Foundation/Foundation.h>
+#import <ImageIO/CGImageProperties.h>
+#import <Vision/Vision.h>
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace qcut::matting {
+namespace {
+
+std::runtime_error visionError(NSString *prefix, NSError *error) {
+  const char *description =
+      error ? error.localizedDescription.UTF8String : "unknown error";
+  return std::runtime_error(std::string(prefix.UTF8String) + ": " +
+                            description);
+}
+
+} // namespace
+
+class VisionPersonSegmentation::Implementation {
+public:
+  Implementation(int sourceWidth, int sourceHeight)
+      : width(sourceWidth), height(sourceHeight) {
+    if (width <= 0 || height <= 0) {
+      throw std::invalid_argument("invalid Vision segmentation dimensions");
+    }
+    if (@available(macOS 12.0, *)) {
+      request = [[VNGeneratePersonSegmentationRequest alloc] init];
+      if (!request) {
+        throw std::runtime_error(
+            "cannot create Vision person segmentation request");
+      }
+      request.qualityLevel =
+          VNGeneratePersonSegmentationRequestQualityLevelAccurate;
+      request.outputPixelFormat = kCVPixelFormatType_OneComponent8;
+    } else {
+      throw std::runtime_error(
+          "Vision person segmentation requires macOS 12 or newer");
+    }
+
+    const NSDictionary *attributes = @{
+      (NSString *)kCVPixelBufferCGImageCompatibilityKey :
+          [NSNumber numberWithBool:YES],
+      (NSString *)kCVPixelBufferCGBitmapContextCompatibilityKey :
+          [NSNumber numberWithBool:YES],
+    };
+    const auto status = CVPixelBufferCreate(
+        kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA,
+        (CFDictionaryRef)attributes, &pixelBuffer);
+    if (status != kCVReturnSuccess || !pixelBuffer) {
+      [request release];
+      request = nil;
+      throw std::runtime_error("cannot allocate Vision input pixel buffer: " +
+                               std::to_string(status));
+    }
+  }
+
+  ~Implementation() {
+    if (pixelBuffer) {
+      CVPixelBufferRelease(pixelBuffer);
+    }
+    [request release];
+  }
+
+  std::vector<std::uint8_t>
+  segment(const std::vector<std::uint8_t> &rgba) const {
+    const auto expectedBytes = static_cast<std::size_t>(width) * height * 4;
+    if (rgba.size() != expectedBytes) {
+      throw std::invalid_argument(
+          "RGBA dimensions do not match Vision segmentation");
+    }
+
+    @autoreleasepool {
+      const auto lockStatus = CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+      if (lockStatus != kCVReturnSuccess) {
+        throw std::runtime_error("cannot lock Vision input pixel buffer: " +
+                                 std::to_string(lockStatus));
+      }
+      auto *destination = static_cast<std::uint8_t *>(
+          CVPixelBufferGetBaseAddress(pixelBuffer));
+      const auto destinationStride =
+          CVPixelBufferGetBytesPerRow(pixelBuffer);
+      for (int y = 0; y < height; ++y) {
+        const auto *sourceRow =
+            rgba.data() + static_cast<std::size_t>(y) * width * 4;
+        auto *destinationRow = destination +
+                               static_cast<std::size_t>(y) *
+                                   destinationStride;
+        for (int x = 0; x < width; ++x) {
+          const auto sourceOffset = static_cast<std::size_t>(x) * 4;
+          destinationRow[sourceOffset] = sourceRow[sourceOffset + 2];
+          destinationRow[sourceOffset + 1] = sourceRow[sourceOffset + 1];
+          destinationRow[sourceOffset + 2] = sourceRow[sourceOffset];
+          destinationRow[sourceOffset + 3] = sourceRow[sourceOffset + 3];
+        }
+      }
+      CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+
+      NSError *error = nil;
+      VNImageRequestHandler *handler = [[VNImageRequestHandler alloc]
+          initWithCVPixelBuffer:pixelBuffer
+                    orientation:kCGImagePropertyOrientationUp
+                        options:@{}];
+      if (!handler) {
+        throw std::runtime_error("cannot create Vision image request handler");
+      }
+      const BOOL succeeded = [handler performRequests:@[ request ] error:&error];
+      [handler release];
+      if (!succeeded) {
+        throw visionError(@"Vision person segmentation failed", error);
+      }
+
+      VNPixelBufferObservation *observation =
+          (VNPixelBufferObservation *)request.results.firstObject;
+      if (!observation) {
+        throw std::runtime_error(
+            "Vision person segmentation returned no mask");
+      }
+      CVPixelBufferRef maskBuffer = observation.pixelBuffer;
+      if (CVPixelBufferGetPixelFormatType(maskBuffer) !=
+          kCVPixelFormatType_OneComponent8) {
+        throw std::runtime_error(
+            "Vision person segmentation returned an unexpected mask format");
+      }
+      const auto maskLockStatus =
+          CVPixelBufferLockBaseAddress(maskBuffer, kCVPixelBufferLock_ReadOnly);
+      if (maskLockStatus != kCVReturnSuccess) {
+        throw std::runtime_error("cannot lock Vision mask pixel buffer: " +
+                                 std::to_string(maskLockStatus));
+      }
+      const int maskWidth =
+          static_cast<int>(CVPixelBufferGetWidth(maskBuffer));
+      const int maskHeight =
+          static_cast<int>(CVPixelBufferGetHeight(maskBuffer));
+      if (maskWidth <= 0 || maskHeight <= 0) {
+        CVPixelBufferUnlockBaseAddress(maskBuffer,
+                                       kCVPixelBufferLock_ReadOnly);
+        throw std::runtime_error(
+            "Vision person segmentation returned an empty mask");
+      }
+      const auto maskStride = CVPixelBufferGetBytesPerRow(maskBuffer);
+      const auto *maskBase = static_cast<const std::uint8_t *>(
+          CVPixelBufferGetBaseAddress(maskBuffer));
+      std::vector<std::uint8_t> mask(
+          static_cast<std::size_t>(maskWidth) * maskHeight);
+      for (int y = 0; y < maskHeight; ++y) {
+        const auto *sourceRow =
+            maskBase + static_cast<std::size_t>(y) * maskStride;
+        std::copy(sourceRow, sourceRow + maskWidth,
+                  mask.begin() + static_cast<std::size_t>(y) * maskWidth);
+      }
+      CVPixelBufferUnlockBaseAddress(maskBuffer,
+                                     kCVPixelBufferLock_ReadOnly);
+      if (maskWidth == width && maskHeight == height) {
+        return mask;
+      }
+      return resizeAlphaBilinear(mask, maskWidth, maskHeight, width, height);
+    }
+  }
+
+private:
+  int width;
+  int height;
+  VNGeneratePersonSegmentationRequest *request = nil;
+  CVPixelBufferRef pixelBuffer = nullptr;
+};
+
+VisionPersonSegmentation::VisionPersonSegmentation(int width, int height)
+    : implementation(std::make_unique<Implementation>(width, height)) {}
+
+VisionPersonSegmentation::~VisionPersonSegmentation() = default;
+
+VisionPersonSegmentation::VisionPersonSegmentation(
+    VisionPersonSegmentation &&) noexcept = default;
+
+VisionPersonSegmentation &VisionPersonSegmentation::operator=(
+    VisionPersonSegmentation &&) noexcept = default;
+
+std::vector<std::uint8_t> VisionPersonSegmentation::segment(
+    const std::vector<std::uint8_t> &rgba) const {
+  return implementation->segment(rgba);
+}
+
+} // namespace qcut::matting

--- a/qcut/electron/jianying-person-cutout/native/vision-person-segmentation.test.mm
+++ b/qcut/electron/jianying-person-cutout/native/vision-person-segmentation.test.mm
@@ -1,0 +1,19 @@
+#include "vision-person-segmentation.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+int main() {
+  constexpr int width = 64;
+  constexpr int height = 64;
+  std::vector<std::uint8_t> rgba(
+      static_cast<std::size_t>(width) * height * 4, 0);
+  for (std::size_t offset = 3; offset < rgba.size(); offset += 4) {
+    rgba[offset] = 255;
+  }
+  qcut::matting::VisionPersonSegmentation segmentation(width, height);
+  const auto alpha = segmentation.segment(rgba);
+  assert(alpha.size() == static_cast<std::size_t>(width) * height);
+  return 0;
+}

--- a/qcut/electron/jianying-person-cutout/pipeline-descriptor.ts
+++ b/qcut/electron/jianying-person-cutout/pipeline-descriptor.ts
@@ -1,157 +1,159 @@
 export type PersonCutoutModelRoute =
-  "portrait-gru" | "video-object" | "saliency-script";
+	| "portrait-gru"
+	| "video-object"
+	| "saliency-script";
 
 export type VideoObjectExecutionBackend =
-  | "effect-host-interop-v1"
-  | "jianying-bach-v2-exact-d634-v1"
-  | "same-model-coreml-v1";
+	| "effect-host-interop-v1"
+	| "jianying-bach-v2-exact-d634-v1"
+	| "same-model-coreml-v1";
 
 export type PersonCutoutProviderId =
-  | "qcut-local-person-matting-v1"
-  | "qcut-jianying-video-object-bach-v2-exact-d634-v1"
-  | "qcut-video-object-same-model-coreml-v1"
-  | "qcut-video-object-interop-experimental-v1"
-  | "qcut-saliency-interop-experimental-v1";
+	| "qcut-local-person-matting-v1"
+	| "qcut-jianying-video-object-bach-v2-exact-d634-v1"
+	| "qcut-video-object-same-model-coreml-v1"
+	| "qcut-video-object-interop-experimental-v1"
+	| "qcut-saliency-interop-experimental-v1";
 
 export type PersonCutoutPipelineId =
-  | "qcut-gru-vision-fusion-v1"
-  | "qcut-gru-only-v1"
-  | "qcut-jianying-video-object-bach-v2-exact-d634-v1"
-  | "qcut-jianying-video-object-bach-v2-refined-d634-v1"
-  | "qcut-video-object-same-model-coreml-v1"
-  | "qcut-video-object-same-model-coreml-refined-v1"
-  | "qcut-video-object-interop-experimental-v1"
-  | "qcut-saliency-script-interop-experimental-v1";
+	| "qcut-gru-vision-fusion-v1"
+	| "qcut-gru-only-v1"
+	| "qcut-jianying-video-object-bach-v2-exact-d634-v1"
+	| "qcut-jianying-video-object-bach-v2-refined-d634-v1"
+	| "qcut-video-object-same-model-coreml-v1"
+	| "qcut-video-object-same-model-coreml-refined-v1"
+	| "qcut-video-object-interop-experimental-v1"
+	| "qcut-saliency-script-interop-experimental-v1";
 
 export type PersonCutoutRefinementProvider =
-  | "qcut-portrait-temporal-border-refinement-v1"
-  | "vendor-v2-exact-no-qcut-refinement-v1"
-  | "qcut-alpha-refinement-after-vendor-v2-v1"
-  | "qcut-same-model-graph-output-v1"
-  | "qcut-effect-graph-alpha-refinement-v1";
+	| "qcut-portrait-temporal-border-refinement-v1"
+	| "vendor-v2-exact-no-qcut-refinement-v1"
+	| "qcut-alpha-refinement-after-vendor-v2-v1"
+	| "qcut-same-model-graph-output-v1"
+	| "qcut-effect-graph-alpha-refinement-v1";
 
 interface PersonCutoutPipelineDescriptorShape {
-  experimental: boolean;
-  modelRoute: PersonCutoutModelRoute;
-  pipelineId: PersonCutoutPipelineId;
-  providerId: PersonCutoutProviderId;
-  refinementProvider: PersonCutoutRefinementProvider;
+	experimental: boolean;
+	modelRoute: PersonCutoutModelRoute;
+	pipelineId: PersonCutoutPipelineId;
+	providerId: PersonCutoutProviderId;
+	refinementProvider: PersonCutoutRefinementProvider;
 }
 
 export const GRU_VISION_PERSON_CUTOUT_PIPELINE = {
-  experimental: false,
-  modelRoute: "portrait-gru",
-  pipelineId: "qcut-gru-vision-fusion-v1",
-  providerId: "qcut-local-person-matting-v1",
-  refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+	experimental: false,
+	modelRoute: "portrait-gru",
+	pipelineId: "qcut-gru-vision-fusion-v1",
+	providerId: "qcut-local-person-matting-v1",
+	refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
 } as const satisfies PersonCutoutPipelineDescriptorShape;
 
 export const GRU_ONLY_PERSON_CUTOUT_PIPELINE = {
-  experimental: false,
-  modelRoute: "portrait-gru",
-  pipelineId: "qcut-gru-only-v1",
-  providerId: "qcut-local-person-matting-v1",
-  refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+	experimental: false,
+	modelRoute: "portrait-gru",
+	pipelineId: "qcut-gru-only-v1",
+	providerId: "qcut-local-person-matting-v1",
+	refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
 } as const satisfies PersonCutoutPipelineDescriptorShape;
 
 export const JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE = {
-  experimental: false,
-  modelRoute: "video-object",
-  pipelineId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
-  providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
-  refinementProvider: "vendor-v2-exact-no-qcut-refinement-v1",
+	experimental: false,
+	modelRoute: "video-object",
+	pipelineId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+	providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+	refinementProvider: "vendor-v2-exact-no-qcut-refinement-v1",
 } as const satisfies PersonCutoutPipelineDescriptorShape;
 
 export const JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE = {
-  experimental: true,
-  modelRoute: "video-object",
-  pipelineId: "qcut-jianying-video-object-bach-v2-refined-d634-v1",
-  providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
-  refinementProvider: "qcut-alpha-refinement-after-vendor-v2-v1",
+	experimental: true,
+	modelRoute: "video-object",
+	pipelineId: "qcut-jianying-video-object-bach-v2-refined-d634-v1",
+	providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+	refinementProvider: "qcut-alpha-refinement-after-vendor-v2-v1",
 } as const satisfies PersonCutoutPipelineDescriptorShape;
 
 export const VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE = {
-  experimental: false,
-  modelRoute: "video-object",
-  pipelineId: "qcut-video-object-same-model-coreml-v1",
-  providerId: "qcut-video-object-same-model-coreml-v1",
-  refinementProvider: "qcut-same-model-graph-output-v1",
+	experimental: false,
+	modelRoute: "video-object",
+	pipelineId: "qcut-video-object-same-model-coreml-v1",
+	providerId: "qcut-video-object-same-model-coreml-v1",
+	refinementProvider: "qcut-same-model-graph-output-v1",
 } as const satisfies PersonCutoutPipelineDescriptorShape;
 
 export const VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE = {
-  experimental: true,
-  modelRoute: "video-object",
-  pipelineId: "qcut-video-object-same-model-coreml-refined-v1",
-  providerId: "qcut-video-object-same-model-coreml-v1",
-  refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
+	experimental: true,
+	modelRoute: "video-object",
+	pipelineId: "qcut-video-object-same-model-coreml-refined-v1",
+	providerId: "qcut-video-object-same-model-coreml-v1",
+	refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
 } as const satisfies PersonCutoutPipelineDescriptorShape;
 
 export const VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE = {
-  experimental: true,
-  modelRoute: "video-object",
-  pipelineId: "qcut-video-object-interop-experimental-v1",
-  providerId: "qcut-video-object-interop-experimental-v1",
-  refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
+	experimental: true,
+	modelRoute: "video-object",
+	pipelineId: "qcut-video-object-interop-experimental-v1",
+	providerId: "qcut-video-object-interop-experimental-v1",
+	refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
 } as const satisfies PersonCutoutPipelineDescriptorShape;
 
 export const SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE = {
-  experimental: true,
-  modelRoute: "saliency-script",
-  pipelineId: "qcut-saliency-script-interop-experimental-v1",
-  providerId: "qcut-saliency-interop-experimental-v1",
-  refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
+	experimental: true,
+	modelRoute: "saliency-script",
+	pipelineId: "qcut-saliency-script-interop-experimental-v1",
+	providerId: "qcut-saliency-interop-experimental-v1",
+	refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
 } as const satisfies PersonCutoutPipelineDescriptorShape;
 
 export type PersonCutoutPipelineDescriptor =
-  | typeof GRU_VISION_PERSON_CUTOUT_PIPELINE
-  | typeof GRU_ONLY_PERSON_CUTOUT_PIPELINE
-  | typeof JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
-  | typeof JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE
-  | typeof VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
-  | typeof VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE
-  | typeof VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE
-  | typeof SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE;
+	| typeof GRU_VISION_PERSON_CUTOUT_PIPELINE
+	| typeof GRU_ONLY_PERSON_CUTOUT_PIPELINE
+	| typeof JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
+	| typeof JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE
+	| typeof VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
+	| typeof VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE
+	| typeof VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE
+	| typeof SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE;
 
 export function selectVideoObjectPersonCutoutPipeline({
-  executionBackend,
-  settings,
+	executionBackend,
+	settings,
 }: {
-  executionBackend: VideoObjectExecutionBackend;
-  settings: {
-    edgeShift: number;
-    feather: number;
-    temporalSmoothing: number;
-    threshold: number;
-  };
+	executionBackend: VideoObjectExecutionBackend;
+	settings: {
+		edgeShift: number;
+		feather: number;
+		temporalSmoothing: number;
+		threshold: number;
+	};
 }): PersonCutoutPipelineDescriptor {
-  const usesIdentityGraphOutput =
-    Math.fround(settings.threshold) === 0.5 &&
-    Math.fround(settings.temporalSmoothing) === 0 &&
-    Math.fround(settings.edgeShift) === 0 &&
-    Math.fround(settings.feather) === 0;
-  if (executionBackend === "jianying-bach-v2-exact-d634-v1") {
-    return usesIdentityGraphOutput
-      ? JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
-      : JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE;
-  }
-  if (executionBackend === "effect-host-interop-v1") {
-    return VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE;
-  }
-  return usesIdentityGraphOutput
-    ? VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
-    : VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE;
+	const usesIdentityGraphOutput =
+		Math.fround(settings.threshold) === 0.5 &&
+		Math.fround(settings.temporalSmoothing) === 0 &&
+		Math.fround(settings.edgeShift) === 0 &&
+		Math.fround(settings.feather) === 0;
+	if (executionBackend === "jianying-bach-v2-exact-d634-v1") {
+		return usesIdentityGraphOutput
+			? JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
+			: JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE;
+	}
+	if (executionBackend === "effect-host-interop-v1") {
+		return VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE;
+	}
+	return usesIdentityGraphOutput
+		? VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
+		: VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE;
 }
 
 export function defaultPersonCutoutPipelineDescriptor({
-  modelRoute,
+	modelRoute,
 }: {
-  modelRoute: PersonCutoutModelRoute;
+	modelRoute: PersonCutoutModelRoute;
 }): PersonCutoutPipelineDescriptor {
-  if (modelRoute === "video-object") {
-    return JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE;
-  }
-  if (modelRoute === "saliency-script") {
-    return SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE;
-  }
-  return GRU_VISION_PERSON_CUTOUT_PIPELINE;
+	if (modelRoute === "video-object") {
+		return JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE;
+	}
+	if (modelRoute === "saliency-script") {
+		return SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE;
+	}
+	return GRU_VISION_PERSON_CUTOUT_PIPELINE;
 }

--- a/qcut/electron/jianying-person-cutout/pipeline-descriptor.ts
+++ b/qcut/electron/jianying-person-cutout/pipeline-descriptor.ts
@@ -1,0 +1,157 @@
+export type PersonCutoutModelRoute =
+  "portrait-gru" | "video-object" | "saliency-script";
+
+export type VideoObjectExecutionBackend =
+  | "effect-host-interop-v1"
+  | "jianying-bach-v2-exact-d634-v1"
+  | "same-model-coreml-v1";
+
+export type PersonCutoutProviderId =
+  | "qcut-local-person-matting-v1"
+  | "qcut-jianying-video-object-bach-v2-exact-d634-v1"
+  | "qcut-video-object-same-model-coreml-v1"
+  | "qcut-video-object-interop-experimental-v1"
+  | "qcut-saliency-interop-experimental-v1";
+
+export type PersonCutoutPipelineId =
+  | "qcut-gru-vision-fusion-v1"
+  | "qcut-gru-only-v1"
+  | "qcut-jianying-video-object-bach-v2-exact-d634-v1"
+  | "qcut-jianying-video-object-bach-v2-refined-d634-v1"
+  | "qcut-video-object-same-model-coreml-v1"
+  | "qcut-video-object-same-model-coreml-refined-v1"
+  | "qcut-video-object-interop-experimental-v1"
+  | "qcut-saliency-script-interop-experimental-v1";
+
+export type PersonCutoutRefinementProvider =
+  | "qcut-portrait-temporal-border-refinement-v1"
+  | "vendor-v2-exact-no-qcut-refinement-v1"
+  | "qcut-alpha-refinement-after-vendor-v2-v1"
+  | "qcut-same-model-graph-output-v1"
+  | "qcut-effect-graph-alpha-refinement-v1";
+
+interface PersonCutoutPipelineDescriptorShape {
+  experimental: boolean;
+  modelRoute: PersonCutoutModelRoute;
+  pipelineId: PersonCutoutPipelineId;
+  providerId: PersonCutoutProviderId;
+  refinementProvider: PersonCutoutRefinementProvider;
+}
+
+export const GRU_VISION_PERSON_CUTOUT_PIPELINE = {
+  experimental: false,
+  modelRoute: "portrait-gru",
+  pipelineId: "qcut-gru-vision-fusion-v1",
+  providerId: "qcut-local-person-matting-v1",
+  refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+} as const satisfies PersonCutoutPipelineDescriptorShape;
+
+export const GRU_ONLY_PERSON_CUTOUT_PIPELINE = {
+  experimental: false,
+  modelRoute: "portrait-gru",
+  pipelineId: "qcut-gru-only-v1",
+  providerId: "qcut-local-person-matting-v1",
+  refinementProvider: "qcut-portrait-temporal-border-refinement-v1",
+} as const satisfies PersonCutoutPipelineDescriptorShape;
+
+export const JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE = {
+  experimental: false,
+  modelRoute: "video-object",
+  pipelineId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+  providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+  refinementProvider: "vendor-v2-exact-no-qcut-refinement-v1",
+} as const satisfies PersonCutoutPipelineDescriptorShape;
+
+export const JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE = {
+  experimental: true,
+  modelRoute: "video-object",
+  pipelineId: "qcut-jianying-video-object-bach-v2-refined-d634-v1",
+  providerId: "qcut-jianying-video-object-bach-v2-exact-d634-v1",
+  refinementProvider: "qcut-alpha-refinement-after-vendor-v2-v1",
+} as const satisfies PersonCutoutPipelineDescriptorShape;
+
+export const VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE = {
+  experimental: false,
+  modelRoute: "video-object",
+  pipelineId: "qcut-video-object-same-model-coreml-v1",
+  providerId: "qcut-video-object-same-model-coreml-v1",
+  refinementProvider: "qcut-same-model-graph-output-v1",
+} as const satisfies PersonCutoutPipelineDescriptorShape;
+
+export const VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE = {
+  experimental: true,
+  modelRoute: "video-object",
+  pipelineId: "qcut-video-object-same-model-coreml-refined-v1",
+  providerId: "qcut-video-object-same-model-coreml-v1",
+  refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
+} as const satisfies PersonCutoutPipelineDescriptorShape;
+
+export const VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE = {
+  experimental: true,
+  modelRoute: "video-object",
+  pipelineId: "qcut-video-object-interop-experimental-v1",
+  providerId: "qcut-video-object-interop-experimental-v1",
+  refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
+} as const satisfies PersonCutoutPipelineDescriptorShape;
+
+export const SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE = {
+  experimental: true,
+  modelRoute: "saliency-script",
+  pipelineId: "qcut-saliency-script-interop-experimental-v1",
+  providerId: "qcut-saliency-interop-experimental-v1",
+  refinementProvider: "qcut-effect-graph-alpha-refinement-v1",
+} as const satisfies PersonCutoutPipelineDescriptorShape;
+
+export type PersonCutoutPipelineDescriptor =
+  | typeof GRU_VISION_PERSON_CUTOUT_PIPELINE
+  | typeof GRU_ONLY_PERSON_CUTOUT_PIPELINE
+  | typeof JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
+  | typeof JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE
+  | typeof VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
+  | typeof VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE
+  | typeof VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE
+  | typeof SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE;
+
+export function selectVideoObjectPersonCutoutPipeline({
+  executionBackend,
+  settings,
+}: {
+  executionBackend: VideoObjectExecutionBackend;
+  settings: {
+    edgeShift: number;
+    feather: number;
+    temporalSmoothing: number;
+    threshold: number;
+  };
+}): PersonCutoutPipelineDescriptor {
+  const usesIdentityGraphOutput =
+    Math.fround(settings.threshold) === 0.5 &&
+    Math.fround(settings.temporalSmoothing) === 0 &&
+    Math.fround(settings.edgeShift) === 0 &&
+    Math.fround(settings.feather) === 0;
+  if (executionBackend === "jianying-bach-v2-exact-d634-v1") {
+    return usesIdentityGraphOutput
+      ? JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
+      : JIANYING_BACH_VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE;
+  }
+  if (executionBackend === "effect-host-interop-v1") {
+    return VIDEO_OBJECT_HOST_INTEROP_PERSON_CUTOUT_PIPELINE;
+  }
+  return usesIdentityGraphOutput
+    ? VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE
+    : VIDEO_OBJECT_REFINED_PERSON_CUTOUT_PIPELINE;
+}
+
+export function defaultPersonCutoutPipelineDescriptor({
+  modelRoute,
+}: {
+  modelRoute: PersonCutoutModelRoute;
+}): PersonCutoutPipelineDescriptor {
+  if (modelRoute === "video-object") {
+    return JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE;
+  }
+  if (modelRoute === "saliency-script") {
+    return SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE;
+  }
+  return GRU_VISION_PERSON_CUTOUT_PIPELINE;
+}

--- a/qcut/electron/jianying-person-cutout/process-inactivity-watchdog.ts
+++ b/qcut/electron/jianying-person-cutout/process-inactivity-watchdog.ts
@@ -1,0 +1,30 @@
+export interface ProcessInactivityWatchdog {
+	clear: () => void;
+	reset: () => void;
+}
+
+export function createProcessInactivityWatchdog({
+	onTimeout,
+	timeoutMs,
+}: {
+	onTimeout: () => void;
+	timeoutMs: number;
+}): ProcessInactivityWatchdog {
+	if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+		throw new Error("进程无响应超时时间无效");
+	}
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	const clear = () => {
+		if (!timer) return;
+		clearTimeout(timer);
+		timer = null;
+	};
+	const reset = () => {
+		clear();
+		timer = setTimeout(() => {
+			timer = null;
+			onTimeout();
+		}, timeoutMs);
+	};
+	return { clear, reset };
+}

--- a/qcut/electron/jianying-person-cutout/process-pipeline.ts
+++ b/qcut/electron/jianying-person-cutout/process-pipeline.ts
@@ -5,157 +5,157 @@ import { createProcessInactivityWatchdog } from "./process-inactivity-watchdog.j
 const PROCESS_ERROR_TAIL_BYTES = 64 * 1024;
 
 export interface ManagedPersonCutoutProcess {
-  child: ChildProcess;
-  label: string;
+	child: ChildProcess;
+	label: string;
 }
 
 export function createPersonCutoutRgbaDecoderArguments({
-  sourcePath,
+	sourcePath,
 }: {
-  sourcePath: string;
+	sourcePath: string;
 }) {
-  return [
-    "-v",
-    "error",
-    "-i",
-    sourcePath,
-    "-map",
-    "0:v:0",
-    "-pix_fmt",
-    "rgba",
-    "-f",
-    "rawvideo",
-    "pipe:1",
-  ];
+	return [
+		"-v",
+		"error",
+		"-i",
+		sourcePath,
+		"-map",
+		"0:v:0",
+		"-pix_fmt",
+		"rgba",
+		"-f",
+		"rawvideo",
+		"pipe:1",
+	];
 }
 
 function appendProcessOutputTail({
-  current,
-  next,
+	current,
+	next,
 }: {
-  current: string;
-  next: string;
+	current: string;
+	next: string;
 }) {
-  return `${current}${next}`.slice(-PROCESS_ERROR_TAIL_BYTES);
+	return `${current}${next}`.slice(-PROCESS_ERROR_TAIL_BYTES);
 }
 
 export function connectPersonCutoutProcessPipe({
-  consumer,
-  producer,
+	consumer,
+	producer,
 }: {
-  consumer: ChildProcess;
-  producer: ChildProcess;
+	consumer: ChildProcess;
+	producer: ChildProcess;
 }) {
-  if (!producer.stdout || !consumer.stdin) {
-    producer.kill("SIGTERM");
-    consumer.kill("SIGTERM");
-    throw new Error("无法建立人物蒙版预计算管线");
-  }
-  producer.stdout.pipe(consumer.stdin);
-  for (const stream of [producer.stdout, consumer.stdin]) {
-    stream.on("error", (error: NodeJS.ErrnoException) => {
-      if (error.code !== "EPIPE") consumer.kill("SIGTERM");
-    });
-  }
+	if (!producer.stdout || !consumer.stdin) {
+		producer.kill("SIGTERM");
+		consumer.kill("SIGTERM");
+		throw new Error("无法建立人物蒙版预计算管线");
+	}
+	producer.stdout.pipe(consumer.stdin);
+	for (const stream of [producer.stdout, consumer.stdin]) {
+		stream.on("error", (error: NodeJS.ErrnoException) => {
+			if (error.code !== "EPIPE") consumer.kill("SIGTERM");
+		});
+	}
 }
 
 export function waitForPersonCutoutProcesses({
-  inactivityTimeoutMs,
-  onStderr,
-  processes,
-  signal,
+	inactivityTimeoutMs,
+	onStderr,
+	processes,
+	signal,
 }: {
-  inactivityTimeoutMs?: number;
-  onStderr?: (event: { child: ChildProcess; chunk: Buffer }) => void;
-  processes: ManagedPersonCutoutProcess[];
-  signal?: AbortSignal;
+	inactivityTimeoutMs?: number;
+	onStderr?: (event: { child: ChildProcess; chunk: Buffer }) => void;
+	processes: ManagedPersonCutoutProcess[];
+	signal?: AbortSignal;
 }) {
-  return new Promise<void>((resolve, reject) => {
-    const outputTails = new Map<ChildProcess, string>(
-      processes.map(({ child }) => [child, ""]),
-    );
-    let completed = 0;
-    let settled = false;
-    let inactivityWatchdog: ReturnType<
-      typeof createProcessInactivityWatchdog
-    > | null = null;
-    const terminate = () => {
-      for (const { child } of processes) {
-        if (child.exitCode === null && child.signalCode === null) {
-          child.kill("SIGTERM");
-        }
-      }
-      const forceKill = setTimeout(() => {
-        for (const { child } of processes) {
-          if (child.exitCode === null && child.signalCode === null) {
-            child.kill("SIGKILL");
-          }
-        }
-      }, 1000);
-      forceKill.unref();
-    };
-    const cleanup = () => {
-      inactivityWatchdog?.clear();
-      signal?.removeEventListener("abort", abort);
-    };
-    const fail = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      terminate();
-      reject(signal?.aborted ? createPersonCutoutAbortError() : error);
-    };
-    const abort = () => fail(createPersonCutoutAbortError());
-    signal?.addEventListener("abort", abort, { once: true });
-    if (inactivityTimeoutMs) {
-      inactivityWatchdog = createProcessInactivityWatchdog({
-        onTimeout: () =>
-          fail(
-            new Error(
-              `${processes.map(({ label }) => label).join("、")}长时间无响应，已停止并切换稳定模式`,
-            ),
-          ),
-        timeoutMs: inactivityTimeoutMs,
-      });
-      inactivityWatchdog.reset();
-    }
+	return new Promise<void>((resolve, reject) => {
+		const outputTails = new Map<ChildProcess, string>(
+			processes.map(({ child }) => [child, ""])
+		);
+		let completed = 0;
+		let settled = false;
+		let inactivityWatchdog: ReturnType<
+			typeof createProcessInactivityWatchdog
+		> | null = null;
+		const terminate = () => {
+			for (const { child } of processes) {
+				if (child.exitCode === null && child.signalCode === null) {
+					child.kill("SIGTERM");
+				}
+			}
+			const forceKill = setTimeout(() => {
+				for (const { child } of processes) {
+					if (child.exitCode === null && child.signalCode === null) {
+						child.kill("SIGKILL");
+					}
+				}
+			}, 1000);
+			forceKill.unref();
+		};
+		const cleanup = () => {
+			inactivityWatchdog?.clear();
+			signal?.removeEventListener("abort", abort);
+		};
+		const fail = (error: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			terminate();
+			reject(signal?.aborted ? createPersonCutoutAbortError() : error);
+		};
+		const abort = () => fail(createPersonCutoutAbortError());
+		signal?.addEventListener("abort", abort, { once: true });
+		if (inactivityTimeoutMs) {
+			inactivityWatchdog = createProcessInactivityWatchdog({
+				onTimeout: () =>
+					fail(
+						new Error(
+							`${processes.map(({ label }) => label).join("、")}长时间无响应，已停止并切换稳定模式`
+						)
+					),
+				timeoutMs: inactivityTimeoutMs,
+			});
+			inactivityWatchdog.reset();
+		}
 
-    for (const { child, label } of processes) {
-      child.stderr?.on("data", (chunk: Buffer) => {
-        if (settled) return;
-        inactivityWatchdog?.reset();
-        outputTails.set(
-          child,
-          appendProcessOutputTail({
-            current: outputTails.get(child) ?? "",
-            next: chunk.toString("utf8"),
-          }),
-        );
-        onStderr?.({ child, chunk });
-      });
-      child.once("error", (error) => fail(error));
-      child.once("close", (code, closeSignal) => {
-        if (settled) return;
-        if (code !== 0) {
-          const details = processes
-            .map(
-              (candidate) =>
-                `${candidate.label}: ${outputTails.get(candidate.child) ?? ""}`,
-            )
-            .join("\n");
-          fail(
-            new Error(
-              `${label}失败（退出 ${code ?? closeSignal ?? "unknown"}）：\n${details}`,
-            ),
-          );
-          return;
-        }
-        completed += 1;
-        if (completed !== processes.length) return;
-        settled = true;
-        cleanup();
-        resolve();
-      });
-    }
-  });
+		for (const { child, label } of processes) {
+			child.stderr?.on("data", (chunk: Buffer) => {
+				if (settled) return;
+				inactivityWatchdog?.reset();
+				outputTails.set(
+					child,
+					appendProcessOutputTail({
+						current: outputTails.get(child) ?? "",
+						next: chunk.toString("utf8"),
+					})
+				);
+				onStderr?.({ child, chunk });
+			});
+			child.once("error", (error) => fail(error));
+			child.once("close", (code, closeSignal) => {
+				if (settled) return;
+				if (code !== 0) {
+					const details = processes
+						.map(
+							(candidate) =>
+								`${candidate.label}: ${outputTails.get(candidate.child) ?? ""}`
+						)
+						.join("\n");
+					fail(
+						new Error(
+							`${label}失败（退出 ${code ?? closeSignal ?? "unknown"}）：\n${details}`
+						)
+					);
+					return;
+				}
+				completed += 1;
+				if (completed !== processes.length) return;
+				settled = true;
+				cleanup();
+				resolve();
+			});
+		}
+	});
 }

--- a/qcut/electron/jianying-person-cutout/process-pipeline.ts
+++ b/qcut/electron/jianying-person-cutout/process-pipeline.ts
@@ -1,0 +1,161 @@
+import type { ChildProcess } from "node:child_process";
+import { createPersonCutoutAbortError } from "./abort.js";
+import { createProcessInactivityWatchdog } from "./process-inactivity-watchdog.js";
+
+const PROCESS_ERROR_TAIL_BYTES = 64 * 1024;
+
+export interface ManagedPersonCutoutProcess {
+  child: ChildProcess;
+  label: string;
+}
+
+export function createPersonCutoutRgbaDecoderArguments({
+  sourcePath,
+}: {
+  sourcePath: string;
+}) {
+  return [
+    "-v",
+    "error",
+    "-i",
+    sourcePath,
+    "-map",
+    "0:v:0",
+    "-pix_fmt",
+    "rgba",
+    "-f",
+    "rawvideo",
+    "pipe:1",
+  ];
+}
+
+function appendProcessOutputTail({
+  current,
+  next,
+}: {
+  current: string;
+  next: string;
+}) {
+  return `${current}${next}`.slice(-PROCESS_ERROR_TAIL_BYTES);
+}
+
+export function connectPersonCutoutProcessPipe({
+  consumer,
+  producer,
+}: {
+  consumer: ChildProcess;
+  producer: ChildProcess;
+}) {
+  if (!producer.stdout || !consumer.stdin) {
+    producer.kill("SIGTERM");
+    consumer.kill("SIGTERM");
+    throw new Error("无法建立人物蒙版预计算管线");
+  }
+  producer.stdout.pipe(consumer.stdin);
+  for (const stream of [producer.stdout, consumer.stdin]) {
+    stream.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code !== "EPIPE") consumer.kill("SIGTERM");
+    });
+  }
+}
+
+export function waitForPersonCutoutProcesses({
+  inactivityTimeoutMs,
+  onStderr,
+  processes,
+  signal,
+}: {
+  inactivityTimeoutMs?: number;
+  onStderr?: (event: { child: ChildProcess; chunk: Buffer }) => void;
+  processes: ManagedPersonCutoutProcess[];
+  signal?: AbortSignal;
+}) {
+  return new Promise<void>((resolve, reject) => {
+    const outputTails = new Map<ChildProcess, string>(
+      processes.map(({ child }) => [child, ""]),
+    );
+    let completed = 0;
+    let settled = false;
+    let inactivityWatchdog: ReturnType<
+      typeof createProcessInactivityWatchdog
+    > | null = null;
+    const terminate = () => {
+      for (const { child } of processes) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGTERM");
+        }
+      }
+      const forceKill = setTimeout(() => {
+        for (const { child } of processes) {
+          if (child.exitCode === null && child.signalCode === null) {
+            child.kill("SIGKILL");
+          }
+        }
+      }, 1000);
+      forceKill.unref();
+    };
+    const cleanup = () => {
+      inactivityWatchdog?.clear();
+      signal?.removeEventListener("abort", abort);
+    };
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      terminate();
+      reject(signal?.aborted ? createPersonCutoutAbortError() : error);
+    };
+    const abort = () => fail(createPersonCutoutAbortError());
+    signal?.addEventListener("abort", abort, { once: true });
+    if (inactivityTimeoutMs) {
+      inactivityWatchdog = createProcessInactivityWatchdog({
+        onTimeout: () =>
+          fail(
+            new Error(
+              `${processes.map(({ label }) => label).join("、")}长时间无响应，已停止并切换稳定模式`,
+            ),
+          ),
+        timeoutMs: inactivityTimeoutMs,
+      });
+      inactivityWatchdog.reset();
+    }
+
+    for (const { child, label } of processes) {
+      child.stderr?.on("data", (chunk: Buffer) => {
+        if (settled) return;
+        inactivityWatchdog?.reset();
+        outputTails.set(
+          child,
+          appendProcessOutputTail({
+            current: outputTails.get(child) ?? "",
+            next: chunk.toString("utf8"),
+          }),
+        );
+        onStderr?.({ child, chunk });
+      });
+      child.once("error", (error) => fail(error));
+      child.once("close", (code, closeSignal) => {
+        if (settled) return;
+        if (code !== 0) {
+          const details = processes
+            .map(
+              (candidate) =>
+                `${candidate.label}: ${outputTails.get(candidate.child) ?? ""}`,
+            )
+            .join("\n");
+          fail(
+            new Error(
+              `${label}失败（退出 ${code ?? closeSignal ?? "unknown"}）：\n${details}`,
+            ),
+          );
+          return;
+        }
+        completed += 1;
+        if (completed !== processes.length) return;
+        settled = true;
+        cleanup();
+        resolve();
+      });
+    }
+  });
+}

--- a/qcut/electron/jianying-person-cutout/runtime-assets.ts
+++ b/qcut/electron/jianying-person-cutout/runtime-assets.ts
@@ -28,7 +28,9 @@ export async function directoryMatches({
 	files: ReadonlyArray<HashedRuntimeFile>;
 }) {
 	const hashes = await Promise.all(
-		files.map(({ name }) => sha256File({ filePath: path.join(directory, name) }))
+		files.map(({ name }) =>
+			sha256File({ filePath: path.join(directory, name) })
+		)
 	);
 	return hashes.every((hash, index) => hash === files[index].sha256);
 }
@@ -54,7 +56,8 @@ export async function firstMatchingFile({
 	sha256: string;
 }) {
 	for (const candidate of candidates) {
-		if ((await sha256File({ filePath: candidate })) === sha256) return candidate;
+		if ((await sha256File({ filePath: candidate })) === sha256)
+			return candidate;
 	}
 	return null;
 }

--- a/qcut/electron/jianying-person-cutout/runtime-assets.ts
+++ b/qcut/electron/jianying-person-cutout/runtime-assets.ts
@@ -1,0 +1,60 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const VIDEO_FUSION_LIBRARY_SHA256 =
+	"b09c395d934169cb20ec865dd1d4032ca68023b287a7264e1b06ff4d71fd1be4";
+
+export interface HashedRuntimeFile {
+	name: string;
+	sha256: string;
+}
+
+export async function sha256File({ filePath }: { filePath: string }) {
+	try {
+		return createHash("sha256")
+			.update(await readFile(filePath))
+			.digest("hex");
+	} catch {
+		return null;
+	}
+}
+
+export async function directoryMatches({
+	directory,
+	files,
+}: {
+	directory: string;
+	files: ReadonlyArray<HashedRuntimeFile>;
+}) {
+	const hashes = await Promise.all(
+		files.map(({ name }) => sha256File({ filePath: path.join(directory, name) }))
+	);
+	return hashes.every((hash, index) => hash === files[index].sha256);
+}
+
+export async function firstMatchingDirectory({
+	candidates,
+	files,
+}: {
+	candidates: string[];
+	files: ReadonlyArray<HashedRuntimeFile>;
+}) {
+	for (const directory of candidates) {
+		if (await directoryMatches({ directory, files })) return directory;
+	}
+	return null;
+}
+
+export async function firstMatchingFile({
+	candidates,
+	sha256,
+}: {
+	candidates: string[];
+	sha256: string;
+}) {
+	for (const candidate of candidates) {
+		if ((await sha256File({ filePath: candidate })) === sha256) return candidate;
+	}
+	return null;
+}

--- a/qcut/electron/jianying-person-cutout/runtime-capability.ts
+++ b/qcut/electron/jianying-person-cutout/runtime-capability.ts
@@ -1,0 +1,55 @@
+import {
+	TEMATTING_COMPATIBLE_BLEND,
+	TEMATTING_NATIVE_METAL_BLEND,
+	type TemattingBlendImplementation,
+} from "./tematting-blend.js";
+
+export const NATIVE_METAL_LIBRARY_SHA256 =
+	"0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9";
+
+export function selectTemattingBlendImplementation({
+	arch,
+	disabled,
+	librarySha256,
+	platform,
+}: {
+	arch: string;
+	disabled: boolean;
+	librarySha256: string;
+	platform: NodeJS.Platform;
+}): TemattingBlendImplementation {
+	if (
+		platform === "darwin" &&
+		arch === "arm64" &&
+		!disabled &&
+		librarySha256 === NATIVE_METAL_LIBRARY_SHA256
+	) {
+		return TEMATTING_NATIVE_METAL_BLEND;
+	}
+	return TEMATTING_COMPATIBLE_BLEND;
+}
+
+export async function executeTemattingWithFallback({
+	execute,
+	onFallback,
+	preferred,
+}: {
+	execute: (implementation: TemattingBlendImplementation) => Promise<void>;
+	onFallback?: (error: unknown) => void;
+	preferred: TemattingBlendImplementation;
+}) {
+	try {
+		await execute(preferred);
+		return preferred;
+	} catch (error) {
+		if (
+			preferred !== TEMATTING_NATIVE_METAL_BLEND ||
+			(error instanceof Error && error.name === "AbortError")
+		) {
+			throw error;
+		}
+		onFallback?.(error);
+		await execute(TEMATTING_COMPATIBLE_BLEND);
+		return TEMATTING_COMPATIBLE_BLEND;
+	}
+}

--- a/qcut/electron/jianying-person-cutout/runtime-capability.ts
+++ b/qcut/electron/jianying-person-cutout/runtime-capability.ts
@@ -1,6 +1,6 @@
 import {
 	TEMATTING_COMPATIBLE_BLEND,
-	TEMATTING_NATIVE_METAL_BLEND,
+	TEMATTING_NATIVE_METAL_CANARY,
 	type TemattingBlendImplementation,
 } from "./tematting-blend.js";
 
@@ -24,7 +24,7 @@ export function selectTemattingBlendImplementation({
 		!disabled &&
 		librarySha256 === NATIVE_METAL_LIBRARY_SHA256
 	) {
-		return TEMATTING_NATIVE_METAL_BLEND;
+		return TEMATTING_NATIVE_METAL_CANARY;
 	}
 	return TEMATTING_COMPATIBLE_BLEND;
 }
@@ -43,7 +43,7 @@ export async function executeTemattingWithFallback({
 		return preferred;
 	} catch (error) {
 		if (
-			preferred !== TEMATTING_NATIVE_METAL_BLEND ||
+			preferred !== TEMATTING_NATIVE_METAL_CANARY ||
 			(error instanceof Error && error.name === "AbortError")
 		) {
 			throw error;

--- a/qcut/electron/jianying-person-cutout/runtime.ts
+++ b/qcut/electron/jianying-person-cutout/runtime.ts
@@ -1,1104 +1,1190 @@
-import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { access, mkdtemp, readFile, rename, rm, stat } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import type {
-	JianyingPersonCutoutRenderResult,
-	JianyingPersonCutoutStatus,
+  JianyingPersonCutoutRenderResult,
+  JianyingPersonCutoutStatus,
 } from "../jianying-person-cutout-contract.js";
 import { getFFmpegPath, getFFprobePath } from "../ffmpeg/utils.js";
-import { resolveJianyingPersonCutoutBridge } from "./bridge-resolver.js";
 import {
-	commitPersonCutoutMaskCache,
-	createPersonCutoutCacheIdentity,
-	createPersonCutoutCacheKey,
-	createPersonCutoutMaskCacheBuild,
-	discardPersonCutoutMaskCacheBuild,
-	inspectPersonCutoutMaskCache,
-	type PersonCutoutCacheIdentity,
-	type PersonCutoutMaskCacheEntry,
-	type PersonCutoutModelRoute,
+  createPersonCutoutAbortError,
+  throwIfPersonCutoutAborted,
+  waitForPersonCutoutPromise,
+} from "./abort.js";
+import { resolveJianyingPersonCutoutBridge } from "./bridge-resolver.js";
+import { parsePersonCutoutBridgeTiming } from "./bridge-timing.js";
+import {
+  resolvePersonCutoutFrameCountExpectation,
+  type PersonCutoutFrameCountExpectation,
+  validatePersonCutoutAlphaFrameCount,
+} from "./frame-count.js";
+import { executePersonCutoutInferencePipeline } from "./inference-pipeline.js";
+import {
+  commitPersonCutoutMaskCache,
+  createPersonCutoutCacheIdentity,
+  createPersonCutoutCacheKey,
+  createPersonCutoutMaskCacheBuild,
+  discardPersonCutoutMaskCacheBuild,
+  inspectPersonCutoutMaskCache,
+  type PersonCutoutCacheIdentity,
+  type PersonCutoutMaskCacheEntry,
+  type PersonCutoutModelRoute,
 } from "./mask-cache.js";
 import {
-	executeTemattingWithFallback,
-	selectTemattingBlendImplementation,
+  GRU_ONLY_PERSON_CUTOUT_PIPELINE,
+  GRU_VISION_PERSON_CUTOUT_PIPELINE,
+  SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE,
+  selectVideoObjectPersonCutoutPipeline,
+  type PersonCutoutPipelineDescriptor,
+} from "./pipeline-descriptor.js";
+import {
+  executeTemattingWithFallback,
+  selectTemattingBlendImplementation,
 } from "./runtime-capability.js";
 import {
-	buildTemattingOutputMetadata,
-	buildTemattingTransparentBlendFilter,
-	TEMATTING_COMPATIBLE_BLEND,
-	TEMATTING_NATIVE_METAL_BLEND,
-	type TemattingBlendImplementation,
+  buildTemattingOutputMetadata,
+  buildTemattingTransparentBlendFilter,
+  resolveTemattingOutputProvenance,
+  resolveTemattingOutputBlendImplementation,
+  TEMATTING_COMPATIBLE_BLEND,
+  TEMATTING_NATIVE_METAL_CANARY,
+  type TemattingBlendImplementation,
+  type TemattingNativeMetalCanaryStatus,
+  type TemattingOutputBlendImplementation,
 } from "./tematting-blend.js";
 import {
-	resolveJianyingSaliencyRuntime,
-	type JianyingSaliencyRuntime,
+  resolveJianyingSaliencyRuntime,
+  type JianyingSaliencyRuntime,
 } from "./saliency-runtime.js";
-import { resolvePersonCutoutRoutingMode } from "./model-router.js";
-import { executePersonCutoutRouteWithFallback } from "./model-route-fallback.js";
 import {
-	resolveJianyingVideoObjectRuntime,
-	type JianyingVideoObjectRuntime,
+  detectPersonCutoutModelRoute,
+  resolvePersonCutoutRoutingMode,
+  type PersonCutoutRouteDecision,
+} from "./model-router.js";
+import {
+  connectPersonCutoutProcessPipe,
+  createPersonCutoutRgbaDecoderArguments,
+  waitForPersonCutoutProcesses,
+} from "./process-pipeline.js";
+import {
+  resolveJianyingVideoObjectRuntimeCandidates,
+  type JianyingVideoObjectRuntimeCandidate,
 } from "./video-object-runtime.js";
+import { VideoObjectRuntimeCircuitBreaker } from "./video-object-circuit-breaker.js";
+import { createVideoObjectBridgeArguments } from "./video-object-bridge-arguments.js";
+import { resolveAutorotatedVideoDimensions } from "./video-display-dimensions.js";
 
 const execFileAsync = promisify(execFile);
 const MODEL_SHA256 =
-	"101688825490be3704babc7ce49f6d002cdb4fe69e879556b4687ac9006f8596";
+  "101688825490be3704babc7ce49f6d002cdb4fe69e879556b4687ac9006f8596";
 const MODEL_TYPE = "4";
 const MODEL_NAME = "tt_matting_video_gru_v1.0.model";
 const FINE_MODEL_NAME = "tt_matting_video_gru_v1.0+vision-person-v1";
-const BRIDGE_ERROR_TAIL_BYTES = 64 * 1024;
+const EFFECT_GRAPH_INACTIVITY_TIMEOUT_MS = 20_000;
+const videoObjectRuntimeCircuitBreaker = new VideoObjectRuntimeCircuitBreaker();
 const PRIVATE_RUNTIME_ROOT = path.join(
-	os.homedir(),
-	"Library",
-	"Application Support",
-	"QCut",
-	"PrivateRuntimes"
+  os.homedir(),
+  "Library",
+  "Application Support",
+  "QCut",
+  "PrivateRuntimes",
 );
 
 interface ReadyRuntime {
-	blendImplementation: TemattingBlendImplementation;
-	bridgePath: string;
-	frameworkDirectory: string;
-	libraryPath: string;
-	modelPath: string;
-	modelName: string;
-	modelRoute: PersonCutoutModelRoute;
-	modelSha256: string;
-	processorSha256: string;
-	saliency?: JianyingSaliencyRuntime;
-	videoObject?: JianyingVideoObjectRuntime;
+  blendImplementation: TemattingBlendImplementation;
+  bridgePath: string;
+  frameworkDirectory: string | null;
+  libraryPath: string | null;
+  modelPath: string;
+  modelName: string;
+  modelRoute: PersonCutoutModelRoute;
+  modelSha256: string;
+  processorSha256: string;
+  pipelineDescriptor: PersonCutoutPipelineDescriptor;
+  saliency?: JianyingSaliencyRuntime;
+  videoObject?: JianyingVideoObjectRuntimeCandidate;
+}
+
+interface SelectedInferenceRuntime {
+  didSelectionFallback: boolean;
+  fallbackRuntimes: ReadyRuntime[];
+  requestedModelRoute: PersonCutoutModelRoute | "auto";
+  routeDecision?: PersonCutoutRouteDecision;
+  runtime: ReadyRuntime;
 }
 
 interface VideoMetadata {
-	width: number;
-	height: number;
-	duration: number;
-	frameRate: number;
-	hasAudio: boolean;
+  width: number;
+  height: number;
+  duration: number;
+  frameCountExpectation: PersonCutoutFrameCountExpectation;
+  frameRate: number;
+  hasAudio: boolean;
 }
 
 interface PersonCutoutProgress {
-	progress: number;
-	status: string;
+  progress: number;
+  status: string;
+}
+
+interface CompletedPersonCutoutInference {
+  alphaCache: PersonCutoutMaskCacheEntry;
+  blendImplementation: TemattingOutputBlendImplementation;
+  completedImplementation: TemattingBlendImplementation;
+  nativeMetalCanary: TemattingNativeMetalCanaryStatus;
 }
 
 type ProgressCallback = (progress: PersonCutoutProgress) => void;
 
 function status({
-	available,
-	blendImplementation,
-	message,
+  available,
+  blendImplementation,
+  message,
+  pipelineDescriptor = GRU_VISION_PERSON_CUTOUT_PIPELINE,
 }: {
-	available: boolean;
-	blendImplementation: TemattingBlendImplementation;
-	message: string;
+  available: boolean;
+  blendImplementation: TemattingBlendImplementation;
+  message: string;
+  pipelineDescriptor?: PersonCutoutPipelineDescriptor;
 }): JianyingPersonCutoutStatus {
-	return {
-		available,
-		message,
-		provider: "jianying-gru-local-v1",
-		offlineReady: available,
-		blendImplementation,
-	};
+  return {
+    available,
+    message,
+    provider: pipelineDescriptor.providerId,
+    offlineReady: available,
+    blendImplementation: resolveTemattingOutputBlendImplementation({
+      pipelineDescriptor,
+    }),
+    nativeMetalCanaryEnabled:
+      blendImplementation === TEMATTING_NATIVE_METAL_CANARY,
+    pipelineId: pipelineDescriptor.pipelineId,
+    refinementProvider: pipelineDescriptor.refinementProvider,
+  };
 }
 
 async function readable({ filePath }: { filePath: string }) {
-	try {
-		await access(filePath, constants.R_OK);
-		return true;
-	} catch {
-		return false;
-	}
+  try {
+    await access(filePath, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function resolveRuntime(): Promise<ReadyRuntime | null> {
-	if (process.platform !== "darwin") return null;
-	const frameworkDirectory = path.join(
-		PRIVATE_RUNTIME_ROOT,
-		"JianyingTransition",
-		"current",
-		"Frameworks"
-	);
-	const libraryPath = path.join(frameworkDirectory, "libcccreator.dylib");
-	const modelPath = path.join(
-		PRIVATE_RUNTIME_ROOT,
-		"JianyingMatting",
-		"current",
-		"Models",
-		"mattingmodel",
-		"tt_matting_video_gru_v1.0.model"
-	);
-	const bridgePath = await resolveJianyingPersonCutoutBridge();
-	if (
-		!bridgePath ||
-		!(await readable({ filePath: libraryPath })) ||
-		!(await readable({ filePath: modelPath }))
-	) {
-		return null;
-	}
-	const [bridgeContents, modelContents, libraryContents] = await Promise.all([
-		readFile(bridgePath),
-		readFile(modelPath),
-		readFile(libraryPath),
-	]);
-	const modelHash = createHash("sha256").update(modelContents).digest("hex");
-	if (modelHash !== MODEL_SHA256) return null;
-	const libraryHash = createHash("sha256")
-		.update(libraryContents)
-		.digest("hex");
-	const blendImplementation = selectTemattingBlendImplementation({
-		arch: process.arch,
-		disabled: process.env.QCUT_DISABLE_NATIVE_MATTING_METAL === "1",
-		librarySha256: libraryHash,
-		platform: process.platform,
-	});
-	return {
-		blendImplementation,
-		bridgePath,
-		frameworkDirectory,
-		libraryPath,
-		modelPath,
-		modelName: FINE_MODEL_NAME,
-		modelRoute: "portrait-gru",
-		modelSha256: modelHash,
-		processorSha256: createHash("sha256")
-			.update(bridgeContents)
-			.update(os.release())
-			.digest("hex"),
-	};
+  if (process.platform !== "darwin") return null;
+  const frameworkDirectory = path.join(
+    PRIVATE_RUNTIME_ROOT,
+    "JianyingTransition",
+    "current",
+    "Frameworks",
+  );
+  const libraryPath = path.join(frameworkDirectory, "libcccreator.dylib");
+  const modelPath = path.join(
+    PRIVATE_RUNTIME_ROOT,
+    "JianyingMatting",
+    "current",
+    "Models",
+    "mattingmodel",
+    "tt_matting_video_gru_v1.0.model",
+  );
+  const bridgePath = await resolveJianyingPersonCutoutBridge();
+  if (
+    !bridgePath ||
+    !(await readable({ filePath: libraryPath })) ||
+    !(await readable({ filePath: modelPath }))
+  ) {
+    return null;
+  }
+  const [bridgeContents, modelContents, libraryContents] = await Promise.all([
+    readFile(bridgePath),
+    readFile(modelPath),
+    readFile(libraryPath),
+  ]);
+  const modelHash = createHash("sha256").update(modelContents).digest("hex");
+  if (modelHash !== MODEL_SHA256) return null;
+  const libraryHash = createHash("sha256")
+    .update(libraryContents)
+    .digest("hex");
+  const visionPersonFusionEnabled =
+    process.env.QCUT_DISABLE_VISION_PERSON_FUSION !== "1";
+  const nativeMetalDiagnosticEnabled =
+    process.env.QCUT_ENABLE_NATIVE_MATTING_DIAGNOSTIC === "1";
+  const blendImplementation = selectTemattingBlendImplementation({
+    arch: process.arch,
+    disabled:
+      !nativeMetalDiagnosticEnabled ||
+      process.env.QCUT_DISABLE_NATIVE_MATTING_METAL === "1",
+    librarySha256: libraryHash,
+    platform: process.platform,
+  });
+  const pipelineDescriptor = visionPersonFusionEnabled
+    ? GRU_VISION_PERSON_CUTOUT_PIPELINE
+    : GRU_ONLY_PERSON_CUTOUT_PIPELINE;
+  return {
+    blendImplementation,
+    bridgePath,
+    frameworkDirectory,
+    libraryPath,
+    modelPath,
+    modelName: visionPersonFusionEnabled ? FINE_MODEL_NAME : MODEL_NAME,
+    modelRoute: "portrait-gru",
+    modelSha256: modelHash,
+    processorSha256: createHash("sha256")
+      .update(bridgeContents)
+      .update(libraryHash)
+      .update(visionPersonFusionEnabled ? os.release() : "vision-disabled")
+      .digest("hex"),
+    pipelineDescriptor,
+  };
+}
+
+function createVideoObjectRuntime({
+  settings,
+  videoObject,
+}: {
+  settings: PersonCutoutCacheIdentity["settings"];
+  videoObject: JianyingVideoObjectRuntimeCandidate;
+}): ReadyRuntime {
+  console.info("QCut person-cutout video-object provider candidate", {
+    capabilitySha256: videoObject.capabilitySha256,
+    providerCapability: videoObject.providerCapability,
+    readiness: videoObject.readiness,
+  });
+  const pipelineDescriptor = selectVideoObjectPersonCutoutPipeline({
+    executionBackend: videoObject.executionBackend,
+    settings,
+  });
+  return {
+    blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+    bridgePath: videoObject.bridgePath,
+    frameworkDirectory: videoObject.frameworkDirectory,
+    libraryPath: videoObject.libraryPath,
+    modelPath: videoObject.modelPath,
+    modelName: "video_saliency_seg_bce",
+    modelRoute: "video-object",
+    modelSha256: videoObject.modelSha256,
+    pipelineDescriptor,
+    processorSha256: videoObject.processorSha256,
+    videoObject,
+  };
+}
+
+function createSaliencyRuntime({
+  saliency,
+}: {
+  saliency: JianyingSaliencyRuntime;
+}): ReadyRuntime {
+  return {
+    blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+    bridgePath: saliency.bridgePath,
+    frameworkDirectory: saliency.frameworkDirectory,
+    libraryPath: saliency.libraryPath,
+    modelPath: saliency.modelDirectory,
+    modelName: "saliency_script_for_cc_v1.2",
+    modelRoute: "saliency-script",
+    modelSha256: saliency.modelSha256,
+    pipelineDescriptor: SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE,
+    processorSha256: saliency.processorSha256,
+    saliency,
+  };
 }
 
 async function selectInferenceRuntime({
-	metadata,
-	portraitRuntime,
+  ffmpegPath,
+  metadata,
+  portraitRuntime,
+  settings,
+  signal,
+  sourcePath,
 }: {
-	metadata: VideoMetadata;
-	portraitRuntime: ReadyRuntime;
-}): Promise<ReadyRuntime> {
-	const routingMode = resolvePersonCutoutRoutingMode({
-		automaticRoutingEnabled:
-			process.env.QCUT_ENABLE_PERSON_CUTOUT_AUTO_ROUTE === "1",
-		requestedRoute: process.env.QCUT_PERSON_CUTOUT_ROUTE,
-	});
-	if (routingMode === "portrait-gru") {
-		return portraitRuntime;
-	}
-	if (routingMode === "auto") {
-		return portraitRuntime;
-	}
-	if (routingMode === "video-object") {
-		const videoObject = await resolveJianyingVideoObjectRuntime({
-			height: metadata.height,
-			width: metadata.width,
-		});
-		if (!videoObject) {
-			console.warn(
-				"Jianying video-object runtime is unavailable; falling back to portrait GRU."
-			);
-			return portraitRuntime;
-		}
-		return {
-			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-			bridgePath: videoObject.bridgePath,
-			frameworkDirectory: videoObject.frameworkDirectory,
-			libraryPath: videoObject.libraryPath,
-			modelPath: videoObject.modelDirectory,
-			modelName: "video_saliency_seg_bce",
-			modelRoute: "video-object",
-			modelSha256: videoObject.modelSha256,
-			processorSha256: videoObject.processorSha256,
-			videoObject,
-		};
-	}
-	const saliency = await resolveJianyingSaliencyRuntime();
-	if (!saliency) {
-		if (routingMode === "saliency-script") {
-			console.warn(
-				"Jianying saliency runtime is unavailable; falling back to portrait GRU."
-			);
-		}
-		return portraitRuntime;
-	}
-	return {
-		blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-		bridgePath: saliency.bridgePath,
-		frameworkDirectory: saliency.frameworkDirectory,
-		libraryPath: saliency.libraryPath,
-		modelPath: saliency.modelDirectory,
-		modelName: "saliency_script_for_cc_v1.2",
-		modelRoute: "saliency-script",
-		modelSha256: saliency.modelSha256,
-		processorSha256: saliency.processorSha256,
-		saliency,
-	};
+  ffmpegPath: string;
+  metadata: VideoMetadata;
+  portraitRuntime: ReadyRuntime;
+  settings: PersonCutoutCacheIdentity["settings"];
+  signal?: AbortSignal;
+  sourcePath: string;
+}): Promise<SelectedInferenceRuntime> {
+  throwIfPersonCutoutAborted({ signal });
+  const routingMode = resolvePersonCutoutRoutingMode({
+    automaticRoutingEnabled:
+      process.env.QCUT_DISABLE_PERSON_CUTOUT_AUTO_ROUTE !== "1" &&
+      process.env.QCUT_ENABLE_PERSON_CUTOUT_AUTO_ROUTE !== "0",
+    requestedRoute: process.env.QCUT_PERSON_CUTOUT_ROUTE,
+  });
+  if (routingMode === "portrait-gru") {
+    return {
+      didSelectionFallback: false,
+      fallbackRuntimes: [],
+      requestedModelRoute: "portrait-gru",
+      runtime: portraitRuntime,
+    };
+  }
+  if (routingMode === "video-object" || routingMode === "auto") {
+    const resolvedVideoObjects =
+      await resolveJianyingVideoObjectRuntimeCandidates({
+        height: metadata.height,
+        width: metadata.width,
+      });
+    throwIfPersonCutoutAborted({ signal });
+    const retryRejected = process.env.QCUT_RETRY_VIDEO_OBJECT_ROUTE === "1";
+    const videoObjects = resolvedVideoObjects.filter(
+      (candidate) =>
+        retryRejected ||
+        !videoObjectRuntimeCircuitBreaker.isOpen({
+          capabilitySha256: candidate.capabilitySha256,
+        }),
+    );
+    const didProviderSelectionFallback =
+      videoObjects.length !== resolvedVideoObjects.length;
+    if (didProviderSelectionFallback) {
+      console.info(
+        "QCut person-cutout skipped a video-object runtime rejected earlier in this app session.",
+      );
+    }
+    const videoObjectRuntimes = videoObjects.map((videoObject) =>
+      createVideoObjectRuntime({ settings, videoObject }),
+    );
+    const videoObjectRuntime = videoObjectRuntimes[0];
+    if (routingMode === "auto") {
+      const routeDecision = await detectPersonCutoutModelRoute({
+        duration: metadata.duration,
+        ffmpegPath,
+        frameRate: metadata.frameRate,
+        height: metadata.height,
+        signal,
+        sourcePath,
+        videoObjectCandidateAvailable: Boolean(videoObjectRuntime),
+        width: metadata.width,
+      });
+      console.info("QCut person-cutout automatic route", routeDecision);
+      const selectedVideoObject =
+        routeDecision.route === "video-object" ? videoObjectRuntime : undefined;
+      return {
+        didSelectionFallback:
+          Boolean(selectedVideoObject) && didProviderSelectionFallback,
+        fallbackRuntimes: selectedVideoObject
+          ? videoObjectRuntimes.slice(1)
+          : [],
+        requestedModelRoute: "auto",
+        routeDecision,
+        runtime: selectedVideoObject ?? portraitRuntime,
+      };
+    }
+    if (!videoObjectRuntime) {
+      console.warn(
+        "Jianying video-object runtime is unavailable; falling back to portrait GRU.",
+      );
+      return {
+        didSelectionFallback: true,
+        fallbackRuntimes: [],
+        requestedModelRoute: "video-object",
+        runtime: portraitRuntime,
+      };
+    }
+    return {
+      didSelectionFallback: didProviderSelectionFallback,
+      fallbackRuntimes: videoObjectRuntimes.slice(1),
+      requestedModelRoute: "video-object",
+      runtime: videoObjectRuntime,
+    };
+  }
+  const saliency = await resolveJianyingSaliencyRuntime();
+  throwIfPersonCutoutAborted({ signal });
+  if (!saliency) {
+    console.warn(
+      "Jianying saliency runtime is unavailable; falling back to portrait GRU.",
+    );
+    return {
+      didSelectionFallback: true,
+      fallbackRuntimes: [],
+      requestedModelRoute: "saliency-script",
+      runtime: portraitRuntime,
+    };
+  }
+  return {
+    didSelectionFallback: false,
+    fallbackRuntimes: [],
+    requestedModelRoute: "saliency-script",
+    runtime: createSaliencyRuntime({ saliency }),
+  };
 }
 
 export async function inspectJianyingPersonCutout() {
-	if (process.platform !== "darwin") {
-		return status({
-			available: false,
-			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-			message: "精细抠像目前只支持 macOS",
-		});
-	}
-	const runtime = await resolveRuntime();
-	return runtime
-		? status({
-				available: true,
-				blendImplementation: runtime.blendImplementation,
-				message: "精细抠像已就绪",
-			})
-		: status({
-				available: false,
-				blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-				message: "精细抠像所需的本机模型未就绪",
-			});
+  if (process.platform !== "darwin") {
+    return status({
+      available: false,
+      blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+      message: "精细抠像目前只支持 macOS",
+    });
+  }
+  const runtime = await resolveRuntime();
+  return runtime
+    ? status({
+        available: true,
+        blendImplementation: runtime.blendImplementation,
+        message: "精细抠像已就绪",
+        pipelineDescriptor: runtime.pipelineDescriptor,
+      })
+    : status({
+        available: false,
+        blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+        message: "精细抠像所需的本机模型未就绪",
+      });
 }
 
 function bridgeArguments({
-	blendImplementation,
-	height,
-	inputPath,
-	modelPath,
-	outputPath,
-	settings,
-	width,
-	libraryPath,
-	runtime,
+  blendImplementation,
+  height,
+  inputPath,
+  modelPath,
+  outputPath,
+  settings,
+  width,
+  libraryPath,
+  runtime,
 }: {
-	blendImplementation: TemattingBlendImplementation;
-	height: number;
-	inputPath: string;
-	libraryPath: string;
-	modelPath: string;
-	outputPath: string;
-	settings: {
-		threshold: number;
-		temporalSmoothing: number;
-		edgeShift: number;
-		feather: number;
-	};
-	width: number;
-	runtime: ReadyRuntime;
+  blendImplementation: TemattingBlendImplementation;
+  height: number;
+  inputPath: string;
+  libraryPath: string | null;
+  modelPath: string;
+  outputPath: string;
+  settings: {
+    threshold: number;
+    temporalSmoothing: number;
+    edgeShift: number;
+    feather: number;
+  };
+  width: number;
+  runtime: ReadyRuntime;
 }) {
-	if (runtime.modelRoute === "video-object") {
-		if (!runtime.videoObject) {
-			throw new Error("剪映物体抠像运行时不完整");
-		}
-		return [
-			libraryPath,
-			runtime.videoObject.modelDirectory,
-			runtime.videoObject.effectDirectory,
-			inputPath,
-			String(width),
-			String(height),
-			outputPath,
-			String(settings.threshold),
-			String(settings.temporalSmoothing),
-			String(settings.edgeShift),
-			String(settings.feather),
-			"--route",
-			"video-object",
-		];
-	}
-	if (runtime.modelRoute === "saliency-script") {
-		if (!runtime.saliency) {
-			throw new Error("剪映显著性抠像运行时不完整");
-		}
-		return [
-			libraryPath,
-			runtime.saliency.modelDirectory,
-			runtime.saliency.effectDirectory,
-			inputPath,
-			String(width),
-			String(height),
-			outputPath,
-			String(settings.threshold),
-			String(settings.temporalSmoothing),
-			String(settings.edgeShift),
-			String(settings.feather),
-		];
-	}
-	const args = [
-		libraryPath,
-		modelPath,
-		MODEL_TYPE,
-		inputPath,
-		String(width),
-		String(height),
-		outputPath,
-		String(settings.threshold),
-		String(settings.temporalSmoothing),
-		String(settings.edgeShift),
-		String(settings.feather),
-		"--vision-person-fusion",
-	];
-	if (blendImplementation === TEMATTING_NATIVE_METAL_BLEND) {
-		args.push("--blend", "native-metal");
-	}
-	return args;
+  if (runtime.modelRoute === "video-object") {
+    if (!runtime.videoObject) {
+      throw new Error("剪映物体抠像运行时不完整");
+    }
+    return createVideoObjectBridgeArguments({
+      height,
+      inputPath,
+      outputPath,
+      settings,
+      videoObject: runtime.videoObject,
+      width,
+    });
+  }
+  if (runtime.modelRoute === "saliency-script") {
+    if (!runtime.saliency || !libraryPath) {
+      throw new Error("剪映显著性抠像运行时不完整");
+    }
+    return [
+      libraryPath,
+      runtime.saliency.modelDirectory,
+      runtime.saliency.effectDirectory,
+      inputPath,
+      String(width),
+      String(height),
+      outputPath,
+      String(settings.threshold),
+      String(settings.temporalSmoothing),
+      String(settings.edgeShift),
+      String(settings.feather),
+    ];
+  }
+  if (!libraryPath) {
+    throw new Error("剪映人物抠像运行时不完整");
+  }
+  const args = [
+    libraryPath,
+    modelPath,
+    MODEL_TYPE,
+    inputPath,
+    String(width),
+    String(height),
+    outputPath,
+    String(settings.threshold),
+    String(settings.temporalSmoothing),
+    String(settings.edgeShift),
+    String(settings.feather),
+  ];
+  if (
+    runtime.pipelineDescriptor.pipelineId ===
+    GRU_VISION_PERSON_CUTOUT_PIPELINE.pipelineId
+  ) {
+    args.push("--vision-person-fusion");
+  }
+  args.push("--timing-json");
+  if (blendImplementation === TEMATTING_NATIVE_METAL_CANARY) {
+    args.push("--native-metal-canary");
+  }
+  return args;
 }
 
-function appendProcessOutputTail({
-	current,
-	next,
+export function createPersonCutoutBridgeEnvironment({
+  frameworkDirectory,
+  sourceEnvironment = process.env,
 }: {
-	current: string;
-	next: string;
-}) {
-	return `${current}${next}`.slice(-BRIDGE_ERROR_TAIL_BYTES);
-}
-
-function createAbortError() {
-	const error = new Error("人物抠像已取消");
-	error.name = "AbortError";
-	return error;
+  frameworkDirectory: string | null;
+  sourceEnvironment?: NodeJS.ProcessEnv;
+}): NodeJS.ProcessEnv {
+  const environment = { ...sourceEnvironment };
+  for (const key of Object.keys(environment)) {
+    if (key.startsWith("DYLD_")) Reflect.deleteProperty(environment, key);
+  }
+  Reflect.deleteProperty(environment, "QCUT_VIDEO_OBJECT_RESET_FRAMES");
+  if (frameworkDirectory) {
+    environment.DYLD_LIBRARY_PATH = frameworkDirectory;
+  }
+  return environment;
 }
 
 function clampProgress({ value }: { value: number }) {
-	return Math.max(0, Math.min(100, Math.round(value)));
-}
-
-interface ManagedProcess {
-	child: ChildProcess;
-	label: string;
-}
-
-async function runEffectGraphAlphaInference({
-	alphaPath,
-	ffmpegPath,
-	metadata,
-	onProgress,
-	runtime,
-	settings,
-	signal,
-	sourcePath,
-	workingDirectory,
-}: {
-	alphaPath: string;
-	ffmpegPath: string;
-	metadata: VideoMetadata;
-	onProgress?: ProgressCallback;
-	runtime: ReadyRuntime;
-	settings: PersonCutoutCacheIdentity["settings"];
-	signal?: AbortSignal;
-	sourcePath: string;
-	workingDirectory: string;
-}) {
-	const rgbaPath = path.join(workingDirectory, "source.rgba");
-	onProgress?.({ progress: 8, status: "正在准备精细人物分析..." });
-	const decoder = spawn(
-		ffmpegPath,
-		[
-			"-y",
-			"-v",
-			"error",
-			"-i",
-			sourcePath,
-			"-map",
-			"0:v:0",
-			"-pix_fmt",
-			"rgba",
-			"-f",
-			"rawvideo",
-			rgbaPath,
-		],
-		{ cwd: workingDirectory, stdio: ["ignore", "ignore", "pipe"] }
-	);
-	await waitForProcesses({
-		processes: [{ child: decoder, label: "视频解码" }],
-		signal,
-	});
-	const bridge = spawn(
-		runtime.bridgePath,
-		bridgeArguments({
-			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-			height: metadata.height,
-			inputPath: rgbaPath,
-			libraryPath: runtime.libraryPath,
-			modelPath: runtime.modelPath,
-			outputPath: alphaPath,
-			runtime,
-			settings,
-			width: metadata.width,
-		}),
-		{
-			cwd: workingDirectory,
-			env: {
-				...process.env,
-				DYLD_LIBRARY_PATH: runtime.frameworkDirectory,
-			},
-			stdio: ["ignore", "ignore", "pipe"],
-		}
-	);
-	let bridgeText = "";
-	let lastProgress = 8;
-	try {
-		await waitForProcesses({
-			processes: [{ child: bridge, label: "剪映主体分析" }],
-			signal,
-			onStderr: ({ chunk }) => {
-				bridgeText += chunk.toString("utf8");
-				const lines = bridgeText.split("\n");
-				bridgeText = lines.pop() ?? "";
-				for (const line of lines) {
-					const match = /progress frame=(\d+) total=(\d+)/.exec(line);
-					if (!match) continue;
-					const frame = Number(match[1]);
-					const total = Math.max(1, Number(match[2]));
-					const progress = clampProgress({
-						value: 8 + (frame / total) * 70,
-					});
-					if (progress <= lastProgress) continue;
-					lastProgress = progress;
-					onProgress?.({
-						progress,
-						status: `正在分析人物主体（${frame}/${total} 帧）...`,
-					});
-				}
-			},
-		});
-	} finally {
-		await rm(rgbaPath, { force: true });
-	}
-}
-
-function waitForProcesses({
-	onStderr,
-	processes,
-	signal,
-}: {
-	onStderr?: (event: { child: ChildProcess; chunk: Buffer }) => void;
-	processes: ManagedProcess[];
-	signal?: AbortSignal;
-}) {
-	return new Promise<void>((resolve, reject) => {
-		const outputTails = new Map<ChildProcess, string>(
-			processes.map(({ child }) => [child, ""])
-		);
-		let completed = 0;
-		let settled = false;
-		const terminate = () => {
-			for (const { child } of processes) {
-				if (child.exitCode === null && child.signalCode === null) {
-					child.kill("SIGTERM");
-				}
-			}
-			const forceKill = setTimeout(() => {
-				for (const { child } of processes) {
-					if (child.exitCode === null && child.signalCode === null) {
-						child.kill("SIGKILL");
-					}
-				}
-			}, 1000);
-			forceKill.unref();
-		};
-		const cleanup = () => signal?.removeEventListener("abort", abort);
-		const fail = (error: Error) => {
-			if (settled) return;
-			settled = true;
-			cleanup();
-			terminate();
-			reject(signal?.aborted ? createAbortError() : error);
-		};
-		const abort = () => fail(createAbortError());
-		signal?.addEventListener("abort", abort, { once: true });
-
-		for (const { child, label } of processes) {
-			child.stderr?.on("data", (chunk: Buffer) => {
-				outputTails.set(
-					child,
-					appendProcessOutputTail({
-						current: outputTails.get(child) ?? "",
-						next: chunk.toString("utf8"),
-					})
-				);
-				onStderr?.({ child, chunk });
-			});
-			child.once("error", (error) => fail(error));
-			child.once("close", (code, closeSignal) => {
-				if (settled) return;
-				if (code !== 0) {
-					const details = processes
-						.map(
-							(candidate) =>
-								`${candidate.label}: ${outputTails.get(candidate.child) ?? ""}`
-						)
-						.join("\n");
-					fail(
-						new Error(
-							`${label}失败（退出 ${code ?? closeSignal ?? "unknown"}）：\n${details}`
-						)
-					);
-					return;
-				}
-				completed += 1;
-				if (completed !== processes.length) return;
-				settled = true;
-				cleanup();
-				resolve();
-			});
-		}
-	});
+  return Math.max(0, Math.min(100, Math.round(value)));
 }
 
 function runAlphaInference({
-	alphaPath,
-	blendImplementation,
-	ffmpegPath,
-	metadata,
-	onProgress,
-	runtime,
-	settings,
-	signal,
-	sourcePath,
-	workingDirectory,
+  alphaPath,
+  blendImplementation,
+  ffmpegPath,
+  metadata,
+  onProgress,
+  runtime,
+  settings,
+  signal,
+  sourcePath,
+  workingDirectory,
 }: {
-	alphaPath: string;
-	blendImplementation: TemattingBlendImplementation;
-	ffmpegPath: string;
-	metadata: VideoMetadata;
-	onProgress?: ProgressCallback;
-	runtime: ReadyRuntime;
-	settings: PersonCutoutCacheIdentity["settings"];
-	signal?: AbortSignal;
-	sourcePath: string;
-	workingDirectory: string;
+  alphaPath: string;
+  blendImplementation: TemattingBlendImplementation;
+  ffmpegPath: string;
+  metadata: VideoMetadata;
+  onProgress?: ProgressCallback;
+  runtime: ReadyRuntime;
+  settings: PersonCutoutCacheIdentity["settings"];
+  signal?: AbortSignal;
+  sourcePath: string;
+  workingDirectory: string;
 }) {
-	if (signal?.aborted) return Promise.reject(createAbortError());
-	if (runtime.modelRoute !== "portrait-gru") {
-		return runEffectGraphAlphaInference({
-			alphaPath,
-			ffmpegPath,
-			metadata,
-			onProgress,
-			runtime,
-			settings,
-			signal,
-			sourcePath,
-			workingDirectory,
-		});
-	}
-	const decoder = spawn(
-		ffmpegPath,
-		[
-			"-v",
-			"error",
-			"-i",
-			sourcePath,
-			"-map",
-			"0:v:0",
-			"-pix_fmt",
-			"rgba",
-			"-f",
-			"rawvideo",
-			"pipe:1",
-		],
-		{ cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] }
-	);
-	const bridge = spawn(
-		runtime.bridgePath,
-		bridgeArguments({
-			blendImplementation,
-			height: metadata.height,
-			inputPath: "-",
-			libraryPath: runtime.libraryPath,
-			modelPath: runtime.modelPath,
-			outputPath: alphaPath,
-			settings,
-			width: metadata.width,
-			runtime,
-		}),
-		{
-			cwd: workingDirectory,
-			env: {
-				...process.env,
-				DYLD_LIBRARY_PATH: runtime.frameworkDirectory,
-			},
-			stdio: ["pipe", "ignore", "pipe"],
-		}
-	);
-	if (!decoder.stdout || !bridge.stdin) {
-		decoder.kill("SIGTERM");
-		bridge.kill("SIGTERM");
-		return Promise.reject(new Error("无法建立人物蒙版预计算管线"));
-	}
-	decoder.stdout.pipe(bridge.stdin);
-	for (const stream of [decoder.stdout, bridge.stdin]) {
-		stream.on("error", (error: NodeJS.ErrnoException) => {
-			if (error.code !== "EPIPE") bridge.kill("SIGTERM");
-		});
-	}
-	let bridgeText = "";
-	let lastProgress = 8;
-	return waitForProcesses({
-		processes: [
-			{ child: decoder, label: "视频解码" },
-			{ child: bridge, label: "人物蒙版预计算" },
-		],
-		signal,
-		onStderr: ({ child, chunk }) => {
-			if (child !== bridge) return;
-			bridgeText += chunk.toString("utf8");
-			const lines = bridgeText.split("\n");
-			bridgeText = lines.pop() ?? "";
-			for (const line of lines) {
-				const match = /progress frame=(\d+) total=(\d+)/.exec(line);
-				if (!match) continue;
-				const frame = Number(match[1]);
-				const reportedTotal = Number(match[2]);
-				const total =
-					reportedTotal > 0
-						? reportedTotal
-						: Math.max(1, Math.round(metadata.duration * metadata.frameRate));
-				const progress = clampProgress({ value: 8 + (frame / total) * 70 });
-				if (progress <= lastProgress) continue;
-				lastProgress = progress;
-				onProgress?.({
-					progress,
-					status: `正在预计算人物蒙版（${frame}/${total} 帧）...`,
-				});
-			}
-		},
-	});
+  if (signal?.aborted) return Promise.reject(createPersonCutoutAbortError());
+  const decoder = spawn(
+    ffmpegPath,
+    createPersonCutoutRgbaDecoderArguments({ sourcePath }),
+    { cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const bridge = spawn(
+    runtime.bridgePath,
+    bridgeArguments({
+      blendImplementation,
+      height: metadata.height,
+      inputPath: "-",
+      libraryPath: runtime.libraryPath,
+      modelPath: runtime.modelPath,
+      outputPath: alphaPath,
+      settings,
+      width: metadata.width,
+      runtime,
+    }),
+    {
+      cwd: workingDirectory,
+      env: createPersonCutoutBridgeEnvironment({
+        frameworkDirectory: runtime.frameworkDirectory,
+      }),
+      stdio: ["pipe", "ignore", "pipe"],
+    },
+  );
+  connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
+  const isPortraitGru = runtime.modelRoute === "portrait-gru";
+  const bridgeLabel = isPortraitGru ? "人物蒙版预计算" : "剪映主体分析";
+  const progressStatus = isPortraitGru
+    ? "正在预计算人物蒙版"
+    : "正在分析人物主体";
+  let bridgeText = "";
+  let lastProgress = 8;
+  return waitForPersonCutoutProcesses({
+    inactivityTimeoutMs: isPortraitGru
+      ? undefined
+      : EFFECT_GRAPH_INACTIVITY_TIMEOUT_MS,
+    processes: [
+      { child: decoder, label: "视频解码" },
+      { child: bridge, label: bridgeLabel },
+    ],
+    signal,
+    onStderr: ({ child, chunk }) => {
+      if (child !== bridge) return;
+      bridgeText += chunk.toString("utf8");
+      const lines = bridgeText.split("\n");
+      bridgeText = lines.pop() ?? "";
+      for (const line of lines) {
+        const timing = parsePersonCutoutBridgeTiming({ line });
+        if (timing) {
+          console.info("QCut person-cutout bridge timing", timing);
+          continue;
+        }
+        const match = /progress frame=(\d+) total=(\d+)/.exec(line);
+        if (!match) continue;
+        const frame = Number(match[1]);
+        const reportedTotal = Number(match[2]);
+        const total =
+          reportedTotal > 0
+            ? reportedTotal
+            : metadata.frameCountExpectation.count;
+        const progress = clampProgress({ value: 8 + (frame / total) * 70 });
+        if (progress <= lastProgress) continue;
+        lastProgress = progress;
+        onProgress?.({
+          progress,
+          status: `${progressStatus}（${frame}/${total} 帧）...`,
+        });
+      }
+    },
+  });
 }
 
 const activeMaskCacheBuilds = new Map<
-	string,
-	Promise<PersonCutoutMaskCacheEntry>
+  string,
+  Promise<PersonCutoutMaskCacheEntry>
 >();
 
 async function buildMaskCache({
-	blendImplementation,
-	ffmpegPath,
-	identity,
-	metadata,
-	onProgress,
-	runtime,
-	settings,
-	signal,
-	sourcePath,
+  blendImplementation,
+  ffmpegPath,
+  identity,
+  metadata,
+  onProgress,
+  runtime,
+  settings,
+  sourcePath,
 }: {
-	blendImplementation: TemattingBlendImplementation;
-	ffmpegPath: string;
-	identity: PersonCutoutCacheIdentity;
-	metadata: VideoMetadata;
-	onProgress?: ProgressCallback;
-	runtime: ReadyRuntime;
-	settings: PersonCutoutCacheIdentity["settings"];
-	signal?: AbortSignal;
-	sourcePath: string;
+  blendImplementation: TemattingBlendImplementation;
+  ffmpegPath: string;
+  identity: PersonCutoutCacheIdentity;
+  metadata: VideoMetadata;
+  onProgress?: ProgressCallback;
+  runtime: ReadyRuntime;
+  settings: PersonCutoutCacheIdentity["settings"];
+  sourcePath: string;
 }) {
-	const build = await createPersonCutoutMaskCacheBuild({ identity });
-	try {
-		await runAlphaInference({
-			alphaPath: build.alphaPath,
-			blendImplementation,
-			ffmpegPath,
-			metadata,
-			onProgress,
-			runtime,
-			settings,
-			signal,
-			sourcePath,
-			workingDirectory: build.directory,
-		});
-		const alphaStat = await stat(build.alphaPath);
-		const bytesPerFrame = metadata.width * metadata.height;
-		if (alphaStat.size === 0 || alphaStat.size % bytesPerFrame !== 0) {
-			throw new Error("人物蒙版帧不完整，已停止导出");
-		}
-		return await commitPersonCutoutMaskCache({
-			buildDirectory: build.directory,
-			frameCount: alphaStat.size / bytesPerFrame,
-			identity,
-		});
-	} catch (error) {
-		await discardPersonCutoutMaskCacheBuild({
-			buildDirectory: build.directory,
-		});
-		throw error;
-	}
+  const build = await createPersonCutoutMaskCacheBuild({ identity });
+  try {
+    await runAlphaInference({
+      alphaPath: build.alphaPath,
+      blendImplementation,
+      ffmpegPath,
+      metadata,
+      onProgress,
+      runtime,
+      settings,
+      sourcePath,
+      workingDirectory: build.directory,
+    });
+    const alphaStat = await stat(build.alphaPath);
+    const bytesPerFrame = metadata.width * metadata.height;
+    if (alphaStat.size === 0 || alphaStat.size % bytesPerFrame !== 0) {
+      throw new Error("人物蒙版帧不完整，已停止导出");
+    }
+    const frameCount = alphaStat.size / bytesPerFrame;
+    validatePersonCutoutAlphaFrameCount({
+      actualFrameCount: frameCount,
+      expectation: metadata.frameCountExpectation,
+    });
+    return await commitPersonCutoutMaskCache({
+      buildDirectory: build.directory,
+      frameCount,
+      identity,
+    });
+  } catch (error) {
+    await discardPersonCutoutMaskCacheBuild({
+      buildDirectory: build.directory,
+    });
+    throw error;
+  }
 }
 
 async function ensureMaskCache({
-	blendImplementation,
-	ffmpegPath,
-	metadata,
-	onProgress,
-	runtime,
-	settings,
-	signal,
-	sourcePath,
+  blendImplementation,
+  ffmpegPath,
+  metadata,
+  onProgress,
+  runtime,
+  settings,
+  signal,
+  sourcePath,
 }: {
-	blendImplementation: TemattingBlendImplementation;
-	ffmpegPath: string;
-	metadata: VideoMetadata;
-	onProgress?: ProgressCallback;
-	runtime: ReadyRuntime;
-	settings: PersonCutoutCacheIdentity["settings"];
-	signal?: AbortSignal;
-	sourcePath: string;
+  blendImplementation: TemattingBlendImplementation;
+  ffmpegPath: string;
+  metadata: VideoMetadata;
+  onProgress?: ProgressCallback;
+  runtime: ReadyRuntime;
+  settings: PersonCutoutCacheIdentity["settings"];
+  signal?: AbortSignal;
+  sourcePath: string;
 }) {
-	const identity = await createPersonCutoutCacheIdentity({
-		blendImplementation,
-		frameRate: metadata.frameRate,
-		height: metadata.height,
-		modelName: runtime.modelName,
-		modelRoute: runtime.modelRoute,
-		modelSha256: runtime.modelSha256,
-		processorSha256: runtime.processorSha256,
-		settings,
-		sourcePath,
-		width: metadata.width,
-	});
-	const cached = await inspectPersonCutoutMaskCache({ identity });
-	if (cached) {
-		onProgress?.({ progress: 78, status: "人物蒙版缓存完整，正在导出..." });
-		return cached;
-	}
-	const cacheKey = createPersonCutoutCacheKey({ identity });
-	const activeBuild = activeMaskCacheBuilds.get(cacheKey);
-	if (activeBuild) return activeBuild;
-	const build = buildMaskCache({
-		blendImplementation,
-		ffmpegPath,
-		identity,
-		metadata,
-		onProgress,
-		runtime,
-		settings,
-		signal,
-		sourcePath,
-	});
-	activeMaskCacheBuilds.set(cacheKey, build);
-	try {
-		return await build;
-	} finally {
-		activeMaskCacheBuilds.delete(cacheKey);
-	}
+  const identity = await createPersonCutoutCacheIdentity({
+    blendImplementation,
+    frameRate: metadata.frameRate,
+    height: metadata.height,
+    modelName: runtime.modelName,
+    modelRoute: runtime.modelRoute,
+    modelSha256: runtime.modelSha256,
+    pipelineDescriptor: runtime.pipelineDescriptor,
+    processorSha256: runtime.processorSha256,
+    settings,
+    signal,
+    sourcePath,
+    width: metadata.width,
+  });
+  const cached = await inspectPersonCutoutMaskCache({ identity, signal });
+  if (cached) {
+    onProgress?.({ progress: 78, status: "人物蒙版缓存完整，正在导出..." });
+    return cached;
+  }
+  const cacheKey = createPersonCutoutCacheKey({ identity });
+  const activeBuild = activeMaskCacheBuilds.get(cacheKey);
+  if (activeBuild) {
+    return waitForPersonCutoutPromise({ promise: activeBuild, signal });
+  }
+  const build = buildMaskCache({
+    blendImplementation,
+    ffmpegPath,
+    identity,
+    metadata,
+    onProgress,
+    runtime,
+    settings,
+    sourcePath,
+  });
+  activeMaskCacheBuilds.set(cacheKey, build);
+  const clearActiveBuild = () => {
+    if (activeMaskCacheBuilds.get(cacheKey) === build) {
+      activeMaskCacheBuilds.delete(cacheKey);
+    }
+  };
+  void build.then(clearActiveBuild, clearActiveBuild);
+  return waitForPersonCutoutPromise({ promise: build, signal });
 }
 
 function runTransparentEncoder({
-	alphaCache,
-	blendImplementation,
-	ffmpegPath,
-	metadata,
-	onProgress,
-	outputPath,
-	runtime,
-	signal,
-	sourcePath,
-	workingDirectory,
+  alphaCache,
+  blendImplementation,
+  ffmpegPath,
+  metadata,
+  nativeMetalCanary,
+  onProgress,
+  outputPath,
+  runtime,
+  signal,
+  sourcePath,
+  workingDirectory,
 }: {
-	alphaCache: PersonCutoutMaskCacheEntry;
-	blendImplementation: TemattingBlendImplementation;
-	ffmpegPath: string;
-	metadata: VideoMetadata;
-	onProgress?: ProgressCallback;
-	outputPath: string;
-	runtime: ReadyRuntime;
-	signal?: AbortSignal;
-	sourcePath: string;
-	workingDirectory: string;
+  alphaCache: PersonCutoutMaskCacheEntry;
+  blendImplementation: TemattingBlendImplementation;
+  ffmpegPath: string;
+  metadata: VideoMetadata;
+  nativeMetalCanary: TemattingNativeMetalCanaryStatus;
+  onProgress?: ProgressCallback;
+  outputPath: string;
+  runtime: ReadyRuntime;
+  signal?: AbortSignal;
+  sourcePath: string;
+  workingDirectory: string;
 }) {
-	if (signal?.aborted) return Promise.reject(createAbortError());
-	const encoder = spawn(
-		ffmpegPath,
-		[
-			"-y",
-			"-v",
-			"error",
-			"-i",
-			sourcePath,
-			"-f",
-			"rawvideo",
-			"-pixel_format",
-			"gray",
-			"-video_size",
-			`${metadata.width}x${metadata.height}`,
-			"-framerate",
-			String(metadata.frameRate),
-			"-i",
-			alphaCache.alphaPath,
-			"-filter_complex",
-			buildTemattingTransparentBlendFilter(),
-			"-map",
-			"[cutout]",
-			"-map",
-			"0:a?",
-			"-frames:v",
-			String(alphaCache.frameCount),
-			"-c:v",
-			"libvpx-vp9",
-			"-pix_fmt",
-			"yuva420p",
-			"-metadata:s:v:0",
-			"alpha_mode=1",
-			...buildTemattingOutputMetadata({
-				implementation: blendImplementation,
-				modelName: runtime.modelName,
-				modelRoute: runtime.modelRoute,
-			}),
-			"-c:a",
-			"libopus",
-			"-shortest",
-			"-progress",
-			"pipe:1",
-			"-nostats",
-			outputPath,
-		],
-		{ cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] }
-	);
-	let encoderText = "";
-	let lastProgress = 78;
-	encoder.stdout?.on("data", (chunk: Buffer) => {
-		encoderText += chunk.toString("utf8");
-		const lines = encoderText.split("\n");
-		encoderText = lines.pop() ?? "";
-		for (const line of lines) {
-			const match = /^out_time_us=(\d+)$/.exec(line.trim());
-			if (!match || metadata.duration <= 0) continue;
-			const seconds = Number(match[1]) / 1_000_000;
-			const progress = clampProgress({
-				value: 78 + (seconds / metadata.duration) * 20,
-			});
-			if (progress <= lastProgress) continue;
-			lastProgress = progress;
-			onProgress?.({ progress, status: "正在生成透明视频..." });
-		}
-	});
-	return waitForProcesses({
-		processes: [{ child: encoder, label: "透明视频编码" }],
-		signal,
-	});
+  if (signal?.aborted) return Promise.reject(createPersonCutoutAbortError());
+  const encoder = spawn(
+    ffmpegPath,
+    [
+      "-y",
+      "-v",
+      "error",
+      "-i",
+      sourcePath,
+      "-f",
+      "rawvideo",
+      "-pixel_format",
+      "gray",
+      "-video_size",
+      `${metadata.width}x${metadata.height}`,
+      "-framerate",
+      String(metadata.frameRate),
+      "-i",
+      alphaCache.alphaPath,
+      "-filter_complex",
+      buildTemattingTransparentBlendFilter(),
+      "-map",
+      "[cutout]",
+      "-map",
+      "0:a?",
+      "-frames:v",
+      String(alphaCache.frameCount),
+      "-c:v",
+      "libvpx-vp9",
+      "-pix_fmt",
+      "yuva420p",
+      "-metadata:s:v:0",
+      "alpha_mode=1",
+      ...buildTemattingOutputMetadata({
+        implementation: blendImplementation,
+        modelName: runtime.modelName,
+        modelRoute: runtime.modelRoute,
+        nativeMetalCanary,
+        pipelineDescriptor: runtime.pipelineDescriptor,
+      }),
+      "-c:a",
+      "libopus",
+      "-shortest",
+      "-progress",
+      "pipe:1",
+      "-nostats",
+      outputPath,
+    ],
+    { cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  let encoderText = "";
+  let lastProgress = 78;
+  encoder.stdout?.on("data", (chunk: Buffer) => {
+    encoderText += chunk.toString("utf8");
+    const lines = encoderText.split("\n");
+    encoderText = lines.pop() ?? "";
+    for (const line of lines) {
+      const match = /^out_time_us=(\d+)$/.exec(line.trim());
+      if (!match || metadata.duration <= 0) continue;
+      const seconds = Number(match[1]) / 1_000_000;
+      const progress = clampProgress({
+        value: 78 + (seconds / metadata.duration) * 20,
+      });
+      if (progress <= lastProgress) continue;
+      lastProgress = progress;
+      onProgress?.({ progress, status: "正在生成透明视频..." });
+    }
+  });
+  return waitForPersonCutoutProcesses({
+    processes: [{ child: encoder, label: "透明视频编码" }],
+    signal,
+  });
 }
 
-async function runCachedPipeline({
-	blendImplementation,
-	ffmpegPath,
-	metadata,
-	onProgress,
-	outputPath,
-	runtime,
-	settings,
-	signal,
-	sourcePath,
-	workingDirectory,
+async function preparePersonCutoutInference({
+  ffmpegPath,
+  metadata,
+  onProgress,
+  runtime,
+  settings,
+  signal,
+  sourcePath,
 }: {
-	blendImplementation: TemattingBlendImplementation;
-	ffmpegPath: string;
-	metadata: VideoMetadata;
-	onProgress?: ProgressCallback;
-	outputPath: string;
-	runtime: ReadyRuntime;
-	settings: PersonCutoutCacheIdentity["settings"];
-	signal?: AbortSignal;
-	sourcePath: string;
-	workingDirectory: string;
-}) {
-	const alphaCache = await ensureMaskCache({
-		blendImplementation,
-		ffmpegPath,
-		metadata,
-		onProgress,
-		runtime,
-		settings,
-		signal,
-		sourcePath,
-	});
-	await runTransparentEncoder({
-		alphaCache,
-		blendImplementation,
-		ffmpegPath,
-		metadata,
-		onProgress,
-		outputPath,
-		runtime,
-		signal,
-		sourcePath,
-		workingDirectory,
-	});
-	return alphaCache.frameCount;
+  ffmpegPath: string;
+  metadata: VideoMetadata;
+  onProgress?: ProgressCallback;
+  runtime: ReadyRuntime;
+  settings: PersonCutoutCacheIdentity["settings"];
+  signal?: AbortSignal;
+  sourcePath: string;
+}): Promise<CompletedPersonCutoutInference> {
+  let alphaCache: PersonCutoutMaskCacheEntry | null = null;
+  const completedImplementation = await executeTemattingWithFallback({
+    execute: async (implementation) => {
+      alphaCache = await ensureMaskCache({
+        blendImplementation: implementation,
+        ffmpegPath,
+        metadata,
+        onProgress,
+        runtime,
+        settings,
+        signal,
+        sourcePath,
+      });
+    },
+    onFallback: (error) => {
+      console.warn(
+        "Native matting validation failed; retrying the compatible path.",
+        error,
+      );
+      onProgress?.({
+        progress: 8,
+        status: "硬件校验未通过，正在切换稳定模式...",
+      });
+    },
+    preferred: runtime.blendImplementation,
+  });
+  if (!alphaCache) throw new Error("人物蒙版推理未生成缓存");
+  const provenance = resolveTemattingOutputProvenance({
+    completedImplementation,
+    pipelineDescriptor: runtime.pipelineDescriptor,
+    preferredImplementation: runtime.blendImplementation,
+  });
+  return {
+    alphaCache,
+    blendImplementation: provenance.blendImplementation,
+    completedImplementation,
+    nativeMetalCanary: provenance.nativeMetalCanary,
+  };
 }
 
 function parseFrameRate({ value }: { value: string }) {
-	const [numeratorText, denominatorText = "1"] = value.split("/");
-	const numerator = Number(numeratorText);
-	const denominator = Number(denominatorText);
-	if (
-		!Number.isFinite(numerator) ||
-		!Number.isFinite(denominator) ||
-		denominator <= 0
-	) {
-		throw new Error("无法读取视频帧率");
-	}
-	return numerator / denominator;
+  const [numeratorText, denominatorText = "1"] = value.split("/");
+  const numerator = Number(numeratorText);
+  const denominator = Number(denominatorText);
+  if (
+    !Number.isFinite(numerator) ||
+    !Number.isFinite(denominator) ||
+    denominator <= 0
+  ) {
+    throw new Error("无法读取视频帧率");
+  }
+  return numerator / denominator;
 }
 
-async function probeVideo({ sourcePath }: { sourcePath: string }) {
-	const ffprobePath = await getFFprobePath();
-	const { stdout } = await execFileAsync(
-		ffprobePath,
-		[
-			"-v",
-			"error",
-			"-show_entries",
-			"stream=codec_type,width,height,avg_frame_rate:format=duration",
-			"-of",
-			"json",
-			sourcePath,
-		],
-		{ maxBuffer: 4 * 1024 * 1024 }
-	);
-	const value = JSON.parse(stdout) as {
-		streams?: Array<{
-			codec_type?: string;
-			width?: number;
-			height?: number;
-			avg_frame_rate?: string;
-		}>;
-		format?: { duration?: string };
-	};
-	const video = value.streams?.find((stream) => stream.codec_type === "video");
-	const duration = Number(value.format?.duration);
-	if (
-		!video?.width ||
-		!video.height ||
-		!video.avg_frame_rate ||
-		!Number.isFinite(duration)
-	) {
-		throw new Error("无法读取视频信息");
-	}
-	return {
-		width: video.width,
-		height: video.height,
-		duration,
-		frameRate: parseFrameRate({ value: video.avg_frame_rate }),
-		hasAudio:
-			value.streams?.some((stream) => stream.codec_type === "audio") === true,
-	} satisfies VideoMetadata;
+async function countVideoFrames({
+  ffprobePath,
+  signal,
+  sourcePath,
+}: {
+  ffprobePath: string;
+  signal?: AbortSignal;
+  sourcePath: string;
+}) {
+  const { stdout } = await execFileAsync(
+    ffprobePath,
+    [
+      "-v",
+      "error",
+      "-count_frames",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=nb_read_frames",
+      "-of",
+      "default=noprint_wrappers=1:nokey=1",
+      sourcePath,
+    ],
+    { maxBuffer: 4 * 1024 * 1024, signal },
+  );
+  return stdout.trim().split(/\s+/)[0];
+}
+
+async function probeVideo({
+  signal,
+  sourcePath,
+}: {
+  signal?: AbortSignal;
+  sourcePath: string;
+}) {
+  const ffprobePath = await getFFprobePath();
+  const { stdout } = await execFileAsync(
+    ffprobePath,
+    [
+      "-v",
+      "error",
+      "-show_entries",
+      "stream=codec_type,width,height,avg_frame_rate,nb_frames:stream_tags=rotate:stream_side_data=rotation:format=duration",
+      "-of",
+      "json",
+      sourcePath,
+    ],
+    { maxBuffer: 4 * 1024 * 1024, signal },
+  );
+  const value = JSON.parse(stdout) as {
+    streams?: Array<{
+      codec_type?: string;
+      width?: number;
+      height?: number;
+      avg_frame_rate?: string;
+      nb_frames?: string;
+      side_data_list?: Array<{ rotation?: number | string }>;
+      tags?: { rotate?: string };
+    }>;
+    format?: { duration?: string };
+  };
+  const video = value.streams?.find((stream) => stream.codec_type === "video");
+  const duration = Number(value.format?.duration);
+  if (
+    !video?.width ||
+    !video.height ||
+    !video.avg_frame_rate ||
+    !Number.isFinite(duration)
+  ) {
+    throw new Error("无法读取视频信息");
+  }
+  const displayDimensions = resolveAutorotatedVideoDimensions({
+    height: video.height,
+    sideDataList: video.side_data_list,
+    tags: video.tags,
+    width: video.width,
+  });
+  const frameRate = parseFrameRate({ value: video.avg_frame_rate });
+  const declaredFrameCount = Number(video.nb_frames);
+  const readFrames =
+    Number.isSafeInteger(declaredFrameCount) && declaredFrameCount > 0
+      ? undefined
+      : await countVideoFrames({ ffprobePath, signal, sourcePath });
+  return {
+    width: displayDimensions.width,
+    height: displayDimensions.height,
+    duration,
+    frameCountExpectation: resolvePersonCutoutFrameCountExpectation({
+      declaredFrames: video.nb_frames,
+      duration,
+      frameRate,
+      readFrames,
+    }),
+    frameRate,
+    hasAudio:
+      value.streams?.some((stream) => stream.codec_type === "audio") === true,
+  } satisfies VideoMetadata;
 }
 
 async function validateSourcePath({ sourcePath }: { sourcePath: string }) {
-	if (!path.isAbsolute(sourcePath)) throw new Error("视频文件路径无效");
-	const sourceStat = await stat(sourcePath);
-	if (!sourceStat.isFile()) throw new Error("视频文件不存在");
+  if (!path.isAbsolute(sourcePath)) throw new Error("视频文件路径无效");
+  const sourceStat = await stat(sourcePath);
+  if (!sourceStat.isFile()) throw new Error("视频文件不存在");
 }
 
 export async function renderJianyingPersonCutout({
-	onProgress,
-	signal,
-	sourcePath,
-	settings,
+  onProgress,
+  signal,
+  sourcePath,
+  settings,
 }: {
-	onProgress?: ProgressCallback;
-	signal?: AbortSignal;
-	sourcePath: string;
-	settings: {
-		threshold: number;
-		temporalSmoothing: number;
-		edgeShift: number;
-		feather: number;
-	};
+  onProgress?: ProgressCallback;
+  signal?: AbortSignal;
+  sourcePath: string;
+  settings: {
+    threshold: number;
+    temporalSmoothing: number;
+    edgeShift: number;
+    feather: number;
+  };
 }): Promise<JianyingPersonCutoutRenderResult> {
-	if (signal?.aborted) throw createAbortError();
-	onProgress?.({ progress: 2, status: "正在检查视频..." });
-	await validateSourcePath({ sourcePath });
-	const portraitRuntime = await resolveRuntime();
-	if (!portraitRuntime) throw new Error("精细抠像所需的本机模型未就绪");
-	const metadata = await probeVideo({ sourcePath });
-	const ffmpegPath = await getFFmpegPath();
-	const runtime = await selectInferenceRuntime({
-		metadata,
-		portraitRuntime,
-	});
-	const outputDirectory = await mkdtemp(
-		path.join(os.tmpdir(), "qcut-person-cutout-")
-	);
-	const outputPath = path.join(outputDirectory, "person-cutout.webm");
-	try {
-		onProgress?.({ progress: 8, status: "正在检查人物蒙版缓存..." });
-		let frameCount = 0;
-		const blendImplementation = await executeTemattingWithFallback({
-			execute: async (implementation) => {
-				const attemptPath = path.join(
-					outputDirectory,
-					implementation === TEMATTING_NATIVE_METAL_BLEND
-						? "person-cutout-native.webm"
-						: "person-cutout-compatible.webm"
-				);
-				const routeAttempt = await executePersonCutoutRouteWithFallback({
-					execute: (candidateRuntime) =>
-						runCachedPipeline({
-							blendImplementation: implementation,
-							ffmpegPath,
-							metadata,
-							onProgress,
-							outputPath: attemptPath,
-							runtime: candidateRuntime,
-							settings,
-							signal,
-							sourcePath,
-							workingDirectory: outputDirectory,
-						}),
-					onFallback: (error) => {
-						console.warn(
-							"Advanced person-cutout route failed; retrying portrait GRU.",
-							error
-						);
-						onProgress?.({
-							progress: 8,
-							status: "物体分析不可用，正在切换精细人物抠像...",
-						});
-					},
-					portraitRuntime,
-					selectedRuntime: runtime,
-				});
-				frameCount = routeAttempt.result;
-				await rename(attemptPath, outputPath);
-			},
-			onFallback: (error) => {
-				console.warn(
-					"Native matting blend failed; retrying the compatible path.",
-					error
-				);
-				onProgress?.({
-					progress: 8,
-					status: "原生处理不可用，正在切换兼容模式...",
-				});
-			},
-			preferred: runtime.blendImplementation,
-		});
-		if (signal?.aborted) throw createAbortError();
-		return {
-			blendImplementation,
-			provider: "jianying-gru-local-v1",
-			outputPath,
-			width: metadata.width,
-			height: metadata.height,
-			duration: metadata.duration,
-			frameRate: metadata.frameRate,
-			frameCount,
-			hasAudio: metadata.hasAudio,
-			codec: "vp9",
-		};
-	} catch (error) {
-		await rm(outputDirectory, { recursive: true, force: true });
-		throw error;
-	}
+  if (signal?.aborted) throw createPersonCutoutAbortError();
+  onProgress?.({ progress: 2, status: "正在检查视频..." });
+  await validateSourcePath({ sourcePath });
+  const portraitRuntime = await resolveRuntime();
+  throwIfPersonCutoutAborted({ signal });
+  if (!portraitRuntime) throw new Error("精细抠像所需的本机模型未就绪");
+  const metadata = await probeVideo({ signal, sourcePath });
+  throwIfPersonCutoutAborted({ signal });
+  const ffmpegPath = await getFFmpegPath();
+  const selection = await selectInferenceRuntime({
+    ffmpegPath,
+    metadata,
+    portraitRuntime,
+    settings,
+    signal,
+    sourcePath,
+  });
+  const outputDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "qcut-person-cutout-"),
+  );
+  const outputPath = path.join(outputDirectory, "person-cutout.webm");
+  try {
+    onProgress?.({ progress: 8, status: "正在检查人物蒙版缓存..." });
+    const pipelineAttempt = await executePersonCutoutInferencePipeline({
+      executeInference: async (candidateRuntime) =>
+        preparePersonCutoutInference({
+          ffmpegPath,
+          metadata,
+          onProgress,
+          runtime: candidateRuntime,
+          settings,
+          signal,
+          sourcePath,
+        }),
+      fallbackRuntimes: selection.fallbackRuntimes,
+      finalize: async ({ inferenceResult, runtime }) => {
+        await runTransparentEncoder({
+          alphaCache: inferenceResult.alphaCache,
+          blendImplementation: inferenceResult.completedImplementation,
+          ffmpegPath,
+          metadata,
+          nativeMetalCanary: inferenceResult.nativeMetalCanary,
+          onProgress,
+          outputPath,
+          runtime,
+          signal,
+          sourcePath,
+          workingDirectory: outputDirectory,
+        });
+        return inferenceResult.alphaCache.frameCount;
+      },
+      onFallback: ({ error, failedRuntime, nextRuntime }) => {
+        const videoObjectCandidate = failedRuntime.videoObject;
+        if (
+          failedRuntime.modelRoute === "video-object" &&
+          videoObjectCandidate
+        ) {
+          const circuitOpened = videoObjectRuntimeCircuitBreaker.reject({
+            capabilitySha256: videoObjectCandidate.capabilitySha256,
+            error,
+          });
+          if (circuitOpened) {
+            console.warn(
+              "QCut rejected the video-object candidate after its confirmed hostless Alpha signature.",
+              {
+                capabilitySha256: videoObjectCandidate.capabilitySha256,
+                providerCapability: videoObjectCandidate.providerCapability,
+              },
+            );
+          }
+        }
+        if (nextRuntime.modelRoute === "video-object") {
+          console.warn(
+            "Video-object provider failed; retrying the next pinned provider.",
+            error,
+          );
+          onProgress?.({
+            progress: 8,
+            status: "主体分析引擎不可用，正在切换备用引擎...",
+          });
+          return;
+        }
+        console.warn(
+          "Advanced person-cutout route failed; retrying portrait GRU.",
+          error,
+        );
+        onProgress?.({
+          progress: 8,
+          status: "主体分析不可用，正在切换精细人物抠像...",
+        });
+      },
+      portraitRuntime,
+      selectedRuntime: selection.runtime,
+    });
+    if (signal?.aborted) throw createPersonCutoutAbortError();
+    const { inferenceAttempt } = pipelineAttempt;
+    const actualRuntime = inferenceAttempt.runtime;
+    return {
+      blendImplementation: inferenceAttempt.result.blendImplementation,
+      didModelRouteFallback:
+        selection.didSelectionFallback || inferenceAttempt.didFallback,
+      modelRoute: actualRuntime.modelRoute,
+      nativeMetalCanary: inferenceAttempt.result.nativeMetalCanary,
+      pipelineId: actualRuntime.pipelineDescriptor.pipelineId,
+      provider: actualRuntime.pipelineDescriptor.providerId,
+      refinementProvider: actualRuntime.pipelineDescriptor.refinementProvider,
+      requestedModelRoute: selection.requestedModelRoute,
+      outputPath,
+      width: metadata.width,
+      height: metadata.height,
+      duration: metadata.duration,
+      frameRate: metadata.frameRate,
+      frameCount: pipelineAttempt.finalResult,
+      hasAudio: metadata.hasAudio,
+      codec: "vp9",
+    };
+  } catch (error) {
+    await rm(outputDirectory, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 export async function releaseJianyingPersonCutout({
-	outputPath,
+  outputPath,
 }: {
-	outputPath: string;
+  outputPath: string;
 }) {
-	const outputDirectory = path.dirname(outputPath);
-	if (!path.basename(outputDirectory).startsWith("qcut-person-cutout-")) return;
-	await rm(outputDirectory, { recursive: true, force: true });
+  const outputDirectory = path.dirname(outputPath);
+  if (!path.basename(outputDirectory).startsWith("qcut-person-cutout-")) return;
+  await rm(outputDirectory, { recursive: true, force: true });
 }

--- a/qcut/electron/jianying-person-cutout/runtime.ts
+++ b/qcut/electron/jianying-person-cutout/runtime.ts
@@ -1,0 +1,1104 @@
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { access, mkdtemp, readFile, rename, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import type {
+	JianyingPersonCutoutRenderResult,
+	JianyingPersonCutoutStatus,
+} from "../jianying-person-cutout-contract.js";
+import { getFFmpegPath, getFFprobePath } from "../ffmpeg/utils.js";
+import { resolveJianyingPersonCutoutBridge } from "./bridge-resolver.js";
+import {
+	commitPersonCutoutMaskCache,
+	createPersonCutoutCacheIdentity,
+	createPersonCutoutCacheKey,
+	createPersonCutoutMaskCacheBuild,
+	discardPersonCutoutMaskCacheBuild,
+	inspectPersonCutoutMaskCache,
+	type PersonCutoutCacheIdentity,
+	type PersonCutoutMaskCacheEntry,
+	type PersonCutoutModelRoute,
+} from "./mask-cache.js";
+import {
+	executeTemattingWithFallback,
+	selectTemattingBlendImplementation,
+} from "./runtime-capability.js";
+import {
+	buildTemattingOutputMetadata,
+	buildTemattingTransparentBlendFilter,
+	TEMATTING_COMPATIBLE_BLEND,
+	TEMATTING_NATIVE_METAL_BLEND,
+	type TemattingBlendImplementation,
+} from "./tematting-blend.js";
+import {
+	resolveJianyingSaliencyRuntime,
+	type JianyingSaliencyRuntime,
+} from "./saliency-runtime.js";
+import { resolvePersonCutoutRoutingMode } from "./model-router.js";
+import { executePersonCutoutRouteWithFallback } from "./model-route-fallback.js";
+import {
+	resolveJianyingVideoObjectRuntime,
+	type JianyingVideoObjectRuntime,
+} from "./video-object-runtime.js";
+
+const execFileAsync = promisify(execFile);
+const MODEL_SHA256 =
+	"101688825490be3704babc7ce49f6d002cdb4fe69e879556b4687ac9006f8596";
+const MODEL_TYPE = "4";
+const MODEL_NAME = "tt_matting_video_gru_v1.0.model";
+const FINE_MODEL_NAME = "tt_matting_video_gru_v1.0+vision-person-v1";
+const BRIDGE_ERROR_TAIL_BYTES = 64 * 1024;
+const PRIVATE_RUNTIME_ROOT = path.join(
+	os.homedir(),
+	"Library",
+	"Application Support",
+	"QCut",
+	"PrivateRuntimes"
+);
+
+interface ReadyRuntime {
+	blendImplementation: TemattingBlendImplementation;
+	bridgePath: string;
+	frameworkDirectory: string;
+	libraryPath: string;
+	modelPath: string;
+	modelName: string;
+	modelRoute: PersonCutoutModelRoute;
+	modelSha256: string;
+	processorSha256: string;
+	saliency?: JianyingSaliencyRuntime;
+	videoObject?: JianyingVideoObjectRuntime;
+}
+
+interface VideoMetadata {
+	width: number;
+	height: number;
+	duration: number;
+	frameRate: number;
+	hasAudio: boolean;
+}
+
+interface PersonCutoutProgress {
+	progress: number;
+	status: string;
+}
+
+type ProgressCallback = (progress: PersonCutoutProgress) => void;
+
+function status({
+	available,
+	blendImplementation,
+	message,
+}: {
+	available: boolean;
+	blendImplementation: TemattingBlendImplementation;
+	message: string;
+}): JianyingPersonCutoutStatus {
+	return {
+		available,
+		message,
+		provider: "jianying-gru-local-v1",
+		offlineReady: available,
+		blendImplementation,
+	};
+}
+
+async function readable({ filePath }: { filePath: string }) {
+	try {
+		await access(filePath, constants.R_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function resolveRuntime(): Promise<ReadyRuntime | null> {
+	if (process.platform !== "darwin") return null;
+	const frameworkDirectory = path.join(
+		PRIVATE_RUNTIME_ROOT,
+		"JianyingTransition",
+		"current",
+		"Frameworks"
+	);
+	const libraryPath = path.join(frameworkDirectory, "libcccreator.dylib");
+	const modelPath = path.join(
+		PRIVATE_RUNTIME_ROOT,
+		"JianyingMatting",
+		"current",
+		"Models",
+		"mattingmodel",
+		"tt_matting_video_gru_v1.0.model"
+	);
+	const bridgePath = await resolveJianyingPersonCutoutBridge();
+	if (
+		!bridgePath ||
+		!(await readable({ filePath: libraryPath })) ||
+		!(await readable({ filePath: modelPath }))
+	) {
+		return null;
+	}
+	const [bridgeContents, modelContents, libraryContents] = await Promise.all([
+		readFile(bridgePath),
+		readFile(modelPath),
+		readFile(libraryPath),
+	]);
+	const modelHash = createHash("sha256").update(modelContents).digest("hex");
+	if (modelHash !== MODEL_SHA256) return null;
+	const libraryHash = createHash("sha256")
+		.update(libraryContents)
+		.digest("hex");
+	const blendImplementation = selectTemattingBlendImplementation({
+		arch: process.arch,
+		disabled: process.env.QCUT_DISABLE_NATIVE_MATTING_METAL === "1",
+		librarySha256: libraryHash,
+		platform: process.platform,
+	});
+	return {
+		blendImplementation,
+		bridgePath,
+		frameworkDirectory,
+		libraryPath,
+		modelPath,
+		modelName: FINE_MODEL_NAME,
+		modelRoute: "portrait-gru",
+		modelSha256: modelHash,
+		processorSha256: createHash("sha256")
+			.update(bridgeContents)
+			.update(os.release())
+			.digest("hex"),
+	};
+}
+
+async function selectInferenceRuntime({
+	metadata,
+	portraitRuntime,
+}: {
+	metadata: VideoMetadata;
+	portraitRuntime: ReadyRuntime;
+}): Promise<ReadyRuntime> {
+	const routingMode = resolvePersonCutoutRoutingMode({
+		automaticRoutingEnabled:
+			process.env.QCUT_ENABLE_PERSON_CUTOUT_AUTO_ROUTE === "1",
+		requestedRoute: process.env.QCUT_PERSON_CUTOUT_ROUTE,
+	});
+	if (routingMode === "portrait-gru") {
+		return portraitRuntime;
+	}
+	if (routingMode === "auto") {
+		return portraitRuntime;
+	}
+	if (routingMode === "video-object") {
+		const videoObject = await resolveJianyingVideoObjectRuntime({
+			height: metadata.height,
+			width: metadata.width,
+		});
+		if (!videoObject) {
+			console.warn(
+				"Jianying video-object runtime is unavailable; falling back to portrait GRU."
+			);
+			return portraitRuntime;
+		}
+		return {
+			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+			bridgePath: videoObject.bridgePath,
+			frameworkDirectory: videoObject.frameworkDirectory,
+			libraryPath: videoObject.libraryPath,
+			modelPath: videoObject.modelDirectory,
+			modelName: "video_saliency_seg_bce",
+			modelRoute: "video-object",
+			modelSha256: videoObject.modelSha256,
+			processorSha256: videoObject.processorSha256,
+			videoObject,
+		};
+	}
+	const saliency = await resolveJianyingSaliencyRuntime();
+	if (!saliency) {
+		if (routingMode === "saliency-script") {
+			console.warn(
+				"Jianying saliency runtime is unavailable; falling back to portrait GRU."
+			);
+		}
+		return portraitRuntime;
+	}
+	return {
+		blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+		bridgePath: saliency.bridgePath,
+		frameworkDirectory: saliency.frameworkDirectory,
+		libraryPath: saliency.libraryPath,
+		modelPath: saliency.modelDirectory,
+		modelName: "saliency_script_for_cc_v1.2",
+		modelRoute: "saliency-script",
+		modelSha256: saliency.modelSha256,
+		processorSha256: saliency.processorSha256,
+		saliency,
+	};
+}
+
+export async function inspectJianyingPersonCutout() {
+	if (process.platform !== "darwin") {
+		return status({
+			available: false,
+			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+			message: "精细抠像目前只支持 macOS",
+		});
+	}
+	const runtime = await resolveRuntime();
+	return runtime
+		? status({
+				available: true,
+				blendImplementation: runtime.blendImplementation,
+				message: "精细抠像已就绪",
+			})
+		: status({
+				available: false,
+				blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+				message: "精细抠像所需的本机模型未就绪",
+			});
+}
+
+function bridgeArguments({
+	blendImplementation,
+	height,
+	inputPath,
+	modelPath,
+	outputPath,
+	settings,
+	width,
+	libraryPath,
+	runtime,
+}: {
+	blendImplementation: TemattingBlendImplementation;
+	height: number;
+	inputPath: string;
+	libraryPath: string;
+	modelPath: string;
+	outputPath: string;
+	settings: {
+		threshold: number;
+		temporalSmoothing: number;
+		edgeShift: number;
+		feather: number;
+	};
+	width: number;
+	runtime: ReadyRuntime;
+}) {
+	if (runtime.modelRoute === "video-object") {
+		if (!runtime.videoObject) {
+			throw new Error("剪映物体抠像运行时不完整");
+		}
+		return [
+			libraryPath,
+			runtime.videoObject.modelDirectory,
+			runtime.videoObject.effectDirectory,
+			inputPath,
+			String(width),
+			String(height),
+			outputPath,
+			String(settings.threshold),
+			String(settings.temporalSmoothing),
+			String(settings.edgeShift),
+			String(settings.feather),
+			"--route",
+			"video-object",
+		];
+	}
+	if (runtime.modelRoute === "saliency-script") {
+		if (!runtime.saliency) {
+			throw new Error("剪映显著性抠像运行时不完整");
+		}
+		return [
+			libraryPath,
+			runtime.saliency.modelDirectory,
+			runtime.saliency.effectDirectory,
+			inputPath,
+			String(width),
+			String(height),
+			outputPath,
+			String(settings.threshold),
+			String(settings.temporalSmoothing),
+			String(settings.edgeShift),
+			String(settings.feather),
+		];
+	}
+	const args = [
+		libraryPath,
+		modelPath,
+		MODEL_TYPE,
+		inputPath,
+		String(width),
+		String(height),
+		outputPath,
+		String(settings.threshold),
+		String(settings.temporalSmoothing),
+		String(settings.edgeShift),
+		String(settings.feather),
+		"--vision-person-fusion",
+	];
+	if (blendImplementation === TEMATTING_NATIVE_METAL_BLEND) {
+		args.push("--blend", "native-metal");
+	}
+	return args;
+}
+
+function appendProcessOutputTail({
+	current,
+	next,
+}: {
+	current: string;
+	next: string;
+}) {
+	return `${current}${next}`.slice(-BRIDGE_ERROR_TAIL_BYTES);
+}
+
+function createAbortError() {
+	const error = new Error("人物抠像已取消");
+	error.name = "AbortError";
+	return error;
+}
+
+function clampProgress({ value }: { value: number }) {
+	return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+interface ManagedProcess {
+	child: ChildProcess;
+	label: string;
+}
+
+async function runEffectGraphAlphaInference({
+	alphaPath,
+	ffmpegPath,
+	metadata,
+	onProgress,
+	runtime,
+	settings,
+	signal,
+	sourcePath,
+	workingDirectory,
+}: {
+	alphaPath: string;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	runtime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	signal?: AbortSignal;
+	sourcePath: string;
+	workingDirectory: string;
+}) {
+	const rgbaPath = path.join(workingDirectory, "source.rgba");
+	onProgress?.({ progress: 8, status: "正在准备精细人物分析..." });
+	const decoder = spawn(
+		ffmpegPath,
+		[
+			"-y",
+			"-v",
+			"error",
+			"-i",
+			sourcePath,
+			"-map",
+			"0:v:0",
+			"-pix_fmt",
+			"rgba",
+			"-f",
+			"rawvideo",
+			rgbaPath,
+		],
+		{ cwd: workingDirectory, stdio: ["ignore", "ignore", "pipe"] }
+	);
+	await waitForProcesses({
+		processes: [{ child: decoder, label: "视频解码" }],
+		signal,
+	});
+	const bridge = spawn(
+		runtime.bridgePath,
+		bridgeArguments({
+			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+			height: metadata.height,
+			inputPath: rgbaPath,
+			libraryPath: runtime.libraryPath,
+			modelPath: runtime.modelPath,
+			outputPath: alphaPath,
+			runtime,
+			settings,
+			width: metadata.width,
+		}),
+		{
+			cwd: workingDirectory,
+			env: {
+				...process.env,
+				DYLD_LIBRARY_PATH: runtime.frameworkDirectory,
+			},
+			stdio: ["ignore", "ignore", "pipe"],
+		}
+	);
+	let bridgeText = "";
+	let lastProgress = 8;
+	try {
+		await waitForProcesses({
+			processes: [{ child: bridge, label: "剪映主体分析" }],
+			signal,
+			onStderr: ({ chunk }) => {
+				bridgeText += chunk.toString("utf8");
+				const lines = bridgeText.split("\n");
+				bridgeText = lines.pop() ?? "";
+				for (const line of lines) {
+					const match = /progress frame=(\d+) total=(\d+)/.exec(line);
+					if (!match) continue;
+					const frame = Number(match[1]);
+					const total = Math.max(1, Number(match[2]));
+					const progress = clampProgress({
+						value: 8 + (frame / total) * 70,
+					});
+					if (progress <= lastProgress) continue;
+					lastProgress = progress;
+					onProgress?.({
+						progress,
+						status: `正在分析人物主体（${frame}/${total} 帧）...`,
+					});
+				}
+			},
+		});
+	} finally {
+		await rm(rgbaPath, { force: true });
+	}
+}
+
+function waitForProcesses({
+	onStderr,
+	processes,
+	signal,
+}: {
+	onStderr?: (event: { child: ChildProcess; chunk: Buffer }) => void;
+	processes: ManagedProcess[];
+	signal?: AbortSignal;
+}) {
+	return new Promise<void>((resolve, reject) => {
+		const outputTails = new Map<ChildProcess, string>(
+			processes.map(({ child }) => [child, ""])
+		);
+		let completed = 0;
+		let settled = false;
+		const terminate = () => {
+			for (const { child } of processes) {
+				if (child.exitCode === null && child.signalCode === null) {
+					child.kill("SIGTERM");
+				}
+			}
+			const forceKill = setTimeout(() => {
+				for (const { child } of processes) {
+					if (child.exitCode === null && child.signalCode === null) {
+						child.kill("SIGKILL");
+					}
+				}
+			}, 1000);
+			forceKill.unref();
+		};
+		const cleanup = () => signal?.removeEventListener("abort", abort);
+		const fail = (error: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			terminate();
+			reject(signal?.aborted ? createAbortError() : error);
+		};
+		const abort = () => fail(createAbortError());
+		signal?.addEventListener("abort", abort, { once: true });
+
+		for (const { child, label } of processes) {
+			child.stderr?.on("data", (chunk: Buffer) => {
+				outputTails.set(
+					child,
+					appendProcessOutputTail({
+						current: outputTails.get(child) ?? "",
+						next: chunk.toString("utf8"),
+					})
+				);
+				onStderr?.({ child, chunk });
+			});
+			child.once("error", (error) => fail(error));
+			child.once("close", (code, closeSignal) => {
+				if (settled) return;
+				if (code !== 0) {
+					const details = processes
+						.map(
+							(candidate) =>
+								`${candidate.label}: ${outputTails.get(candidate.child) ?? ""}`
+						)
+						.join("\n");
+					fail(
+						new Error(
+							`${label}失败（退出 ${code ?? closeSignal ?? "unknown"}）：\n${details}`
+						)
+					);
+					return;
+				}
+				completed += 1;
+				if (completed !== processes.length) return;
+				settled = true;
+				cleanup();
+				resolve();
+			});
+		}
+	});
+}
+
+function runAlphaInference({
+	alphaPath,
+	blendImplementation,
+	ffmpegPath,
+	metadata,
+	onProgress,
+	runtime,
+	settings,
+	signal,
+	sourcePath,
+	workingDirectory,
+}: {
+	alphaPath: string;
+	blendImplementation: TemattingBlendImplementation;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	runtime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	signal?: AbortSignal;
+	sourcePath: string;
+	workingDirectory: string;
+}) {
+	if (signal?.aborted) return Promise.reject(createAbortError());
+	if (runtime.modelRoute !== "portrait-gru") {
+		return runEffectGraphAlphaInference({
+			alphaPath,
+			ffmpegPath,
+			metadata,
+			onProgress,
+			runtime,
+			settings,
+			signal,
+			sourcePath,
+			workingDirectory,
+		});
+	}
+	const decoder = spawn(
+		ffmpegPath,
+		[
+			"-v",
+			"error",
+			"-i",
+			sourcePath,
+			"-map",
+			"0:v:0",
+			"-pix_fmt",
+			"rgba",
+			"-f",
+			"rawvideo",
+			"pipe:1",
+		],
+		{ cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] }
+	);
+	const bridge = spawn(
+		runtime.bridgePath,
+		bridgeArguments({
+			blendImplementation,
+			height: metadata.height,
+			inputPath: "-",
+			libraryPath: runtime.libraryPath,
+			modelPath: runtime.modelPath,
+			outputPath: alphaPath,
+			settings,
+			width: metadata.width,
+			runtime,
+		}),
+		{
+			cwd: workingDirectory,
+			env: {
+				...process.env,
+				DYLD_LIBRARY_PATH: runtime.frameworkDirectory,
+			},
+			stdio: ["pipe", "ignore", "pipe"],
+		}
+	);
+	if (!decoder.stdout || !bridge.stdin) {
+		decoder.kill("SIGTERM");
+		bridge.kill("SIGTERM");
+		return Promise.reject(new Error("无法建立人物蒙版预计算管线"));
+	}
+	decoder.stdout.pipe(bridge.stdin);
+	for (const stream of [decoder.stdout, bridge.stdin]) {
+		stream.on("error", (error: NodeJS.ErrnoException) => {
+			if (error.code !== "EPIPE") bridge.kill("SIGTERM");
+		});
+	}
+	let bridgeText = "";
+	let lastProgress = 8;
+	return waitForProcesses({
+		processes: [
+			{ child: decoder, label: "视频解码" },
+			{ child: bridge, label: "人物蒙版预计算" },
+		],
+		signal,
+		onStderr: ({ child, chunk }) => {
+			if (child !== bridge) return;
+			bridgeText += chunk.toString("utf8");
+			const lines = bridgeText.split("\n");
+			bridgeText = lines.pop() ?? "";
+			for (const line of lines) {
+				const match = /progress frame=(\d+) total=(\d+)/.exec(line);
+				if (!match) continue;
+				const frame = Number(match[1]);
+				const reportedTotal = Number(match[2]);
+				const total =
+					reportedTotal > 0
+						? reportedTotal
+						: Math.max(1, Math.round(metadata.duration * metadata.frameRate));
+				const progress = clampProgress({ value: 8 + (frame / total) * 70 });
+				if (progress <= lastProgress) continue;
+				lastProgress = progress;
+				onProgress?.({
+					progress,
+					status: `正在预计算人物蒙版（${frame}/${total} 帧）...`,
+				});
+			}
+		},
+	});
+}
+
+const activeMaskCacheBuilds = new Map<
+	string,
+	Promise<PersonCutoutMaskCacheEntry>
+>();
+
+async function buildMaskCache({
+	blendImplementation,
+	ffmpegPath,
+	identity,
+	metadata,
+	onProgress,
+	runtime,
+	settings,
+	signal,
+	sourcePath,
+}: {
+	blendImplementation: TemattingBlendImplementation;
+	ffmpegPath: string;
+	identity: PersonCutoutCacheIdentity;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	runtime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	signal?: AbortSignal;
+	sourcePath: string;
+}) {
+	const build = await createPersonCutoutMaskCacheBuild({ identity });
+	try {
+		await runAlphaInference({
+			alphaPath: build.alphaPath,
+			blendImplementation,
+			ffmpegPath,
+			metadata,
+			onProgress,
+			runtime,
+			settings,
+			signal,
+			sourcePath,
+			workingDirectory: build.directory,
+		});
+		const alphaStat = await stat(build.alphaPath);
+		const bytesPerFrame = metadata.width * metadata.height;
+		if (alphaStat.size === 0 || alphaStat.size % bytesPerFrame !== 0) {
+			throw new Error("人物蒙版帧不完整，已停止导出");
+		}
+		return await commitPersonCutoutMaskCache({
+			buildDirectory: build.directory,
+			frameCount: alphaStat.size / bytesPerFrame,
+			identity,
+		});
+	} catch (error) {
+		await discardPersonCutoutMaskCacheBuild({
+			buildDirectory: build.directory,
+		});
+		throw error;
+	}
+}
+
+async function ensureMaskCache({
+	blendImplementation,
+	ffmpegPath,
+	metadata,
+	onProgress,
+	runtime,
+	settings,
+	signal,
+	sourcePath,
+}: {
+	blendImplementation: TemattingBlendImplementation;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	runtime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	signal?: AbortSignal;
+	sourcePath: string;
+}) {
+	const identity = await createPersonCutoutCacheIdentity({
+		blendImplementation,
+		frameRate: metadata.frameRate,
+		height: metadata.height,
+		modelName: runtime.modelName,
+		modelRoute: runtime.modelRoute,
+		modelSha256: runtime.modelSha256,
+		processorSha256: runtime.processorSha256,
+		settings,
+		sourcePath,
+		width: metadata.width,
+	});
+	const cached = await inspectPersonCutoutMaskCache({ identity });
+	if (cached) {
+		onProgress?.({ progress: 78, status: "人物蒙版缓存完整，正在导出..." });
+		return cached;
+	}
+	const cacheKey = createPersonCutoutCacheKey({ identity });
+	const activeBuild = activeMaskCacheBuilds.get(cacheKey);
+	if (activeBuild) return activeBuild;
+	const build = buildMaskCache({
+		blendImplementation,
+		ffmpegPath,
+		identity,
+		metadata,
+		onProgress,
+		runtime,
+		settings,
+		signal,
+		sourcePath,
+	});
+	activeMaskCacheBuilds.set(cacheKey, build);
+	try {
+		return await build;
+	} finally {
+		activeMaskCacheBuilds.delete(cacheKey);
+	}
+}
+
+function runTransparentEncoder({
+	alphaCache,
+	blendImplementation,
+	ffmpegPath,
+	metadata,
+	onProgress,
+	outputPath,
+	runtime,
+	signal,
+	sourcePath,
+	workingDirectory,
+}: {
+	alphaCache: PersonCutoutMaskCacheEntry;
+	blendImplementation: TemattingBlendImplementation;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	outputPath: string;
+	runtime: ReadyRuntime;
+	signal?: AbortSignal;
+	sourcePath: string;
+	workingDirectory: string;
+}) {
+	if (signal?.aborted) return Promise.reject(createAbortError());
+	const encoder = spawn(
+		ffmpegPath,
+		[
+			"-y",
+			"-v",
+			"error",
+			"-i",
+			sourcePath,
+			"-f",
+			"rawvideo",
+			"-pixel_format",
+			"gray",
+			"-video_size",
+			`${metadata.width}x${metadata.height}`,
+			"-framerate",
+			String(metadata.frameRate),
+			"-i",
+			alphaCache.alphaPath,
+			"-filter_complex",
+			buildTemattingTransparentBlendFilter(),
+			"-map",
+			"[cutout]",
+			"-map",
+			"0:a?",
+			"-frames:v",
+			String(alphaCache.frameCount),
+			"-c:v",
+			"libvpx-vp9",
+			"-pix_fmt",
+			"yuva420p",
+			"-metadata:s:v:0",
+			"alpha_mode=1",
+			...buildTemattingOutputMetadata({
+				implementation: blendImplementation,
+				modelName: runtime.modelName,
+				modelRoute: runtime.modelRoute,
+			}),
+			"-c:a",
+			"libopus",
+			"-shortest",
+			"-progress",
+			"pipe:1",
+			"-nostats",
+			outputPath,
+		],
+		{ cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] }
+	);
+	let encoderText = "";
+	let lastProgress = 78;
+	encoder.stdout?.on("data", (chunk: Buffer) => {
+		encoderText += chunk.toString("utf8");
+		const lines = encoderText.split("\n");
+		encoderText = lines.pop() ?? "";
+		for (const line of lines) {
+			const match = /^out_time_us=(\d+)$/.exec(line.trim());
+			if (!match || metadata.duration <= 0) continue;
+			const seconds = Number(match[1]) / 1_000_000;
+			const progress = clampProgress({
+				value: 78 + (seconds / metadata.duration) * 20,
+			});
+			if (progress <= lastProgress) continue;
+			lastProgress = progress;
+			onProgress?.({ progress, status: "正在生成透明视频..." });
+		}
+	});
+	return waitForProcesses({
+		processes: [{ child: encoder, label: "透明视频编码" }],
+		signal,
+	});
+}
+
+async function runCachedPipeline({
+	blendImplementation,
+	ffmpegPath,
+	metadata,
+	onProgress,
+	outputPath,
+	runtime,
+	settings,
+	signal,
+	sourcePath,
+	workingDirectory,
+}: {
+	blendImplementation: TemattingBlendImplementation;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	outputPath: string;
+	runtime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	signal?: AbortSignal;
+	sourcePath: string;
+	workingDirectory: string;
+}) {
+	const alphaCache = await ensureMaskCache({
+		blendImplementation,
+		ffmpegPath,
+		metadata,
+		onProgress,
+		runtime,
+		settings,
+		signal,
+		sourcePath,
+	});
+	await runTransparentEncoder({
+		alphaCache,
+		blendImplementation,
+		ffmpegPath,
+		metadata,
+		onProgress,
+		outputPath,
+		runtime,
+		signal,
+		sourcePath,
+		workingDirectory,
+	});
+	return alphaCache.frameCount;
+}
+
+function parseFrameRate({ value }: { value: string }) {
+	const [numeratorText, denominatorText = "1"] = value.split("/");
+	const numerator = Number(numeratorText);
+	const denominator = Number(denominatorText);
+	if (
+		!Number.isFinite(numerator) ||
+		!Number.isFinite(denominator) ||
+		denominator <= 0
+	) {
+		throw new Error("无法读取视频帧率");
+	}
+	return numerator / denominator;
+}
+
+async function probeVideo({ sourcePath }: { sourcePath: string }) {
+	const ffprobePath = await getFFprobePath();
+	const { stdout } = await execFileAsync(
+		ffprobePath,
+		[
+			"-v",
+			"error",
+			"-show_entries",
+			"stream=codec_type,width,height,avg_frame_rate:format=duration",
+			"-of",
+			"json",
+			sourcePath,
+		],
+		{ maxBuffer: 4 * 1024 * 1024 }
+	);
+	const value = JSON.parse(stdout) as {
+		streams?: Array<{
+			codec_type?: string;
+			width?: number;
+			height?: number;
+			avg_frame_rate?: string;
+		}>;
+		format?: { duration?: string };
+	};
+	const video = value.streams?.find((stream) => stream.codec_type === "video");
+	const duration = Number(value.format?.duration);
+	if (
+		!video?.width ||
+		!video.height ||
+		!video.avg_frame_rate ||
+		!Number.isFinite(duration)
+	) {
+		throw new Error("无法读取视频信息");
+	}
+	return {
+		width: video.width,
+		height: video.height,
+		duration,
+		frameRate: parseFrameRate({ value: video.avg_frame_rate }),
+		hasAudio:
+			value.streams?.some((stream) => stream.codec_type === "audio") === true,
+	} satisfies VideoMetadata;
+}
+
+async function validateSourcePath({ sourcePath }: { sourcePath: string }) {
+	if (!path.isAbsolute(sourcePath)) throw new Error("视频文件路径无效");
+	const sourceStat = await stat(sourcePath);
+	if (!sourceStat.isFile()) throw new Error("视频文件不存在");
+}
+
+export async function renderJianyingPersonCutout({
+	onProgress,
+	signal,
+	sourcePath,
+	settings,
+}: {
+	onProgress?: ProgressCallback;
+	signal?: AbortSignal;
+	sourcePath: string;
+	settings: {
+		threshold: number;
+		temporalSmoothing: number;
+		edgeShift: number;
+		feather: number;
+	};
+}): Promise<JianyingPersonCutoutRenderResult> {
+	if (signal?.aborted) throw createAbortError();
+	onProgress?.({ progress: 2, status: "正在检查视频..." });
+	await validateSourcePath({ sourcePath });
+	const portraitRuntime = await resolveRuntime();
+	if (!portraitRuntime) throw new Error("精细抠像所需的本机模型未就绪");
+	const metadata = await probeVideo({ sourcePath });
+	const ffmpegPath = await getFFmpegPath();
+	const runtime = await selectInferenceRuntime({
+		metadata,
+		portraitRuntime,
+	});
+	const outputDirectory = await mkdtemp(
+		path.join(os.tmpdir(), "qcut-person-cutout-")
+	);
+	const outputPath = path.join(outputDirectory, "person-cutout.webm");
+	try {
+		onProgress?.({ progress: 8, status: "正在检查人物蒙版缓存..." });
+		let frameCount = 0;
+		const blendImplementation = await executeTemattingWithFallback({
+			execute: async (implementation) => {
+				const attemptPath = path.join(
+					outputDirectory,
+					implementation === TEMATTING_NATIVE_METAL_BLEND
+						? "person-cutout-native.webm"
+						: "person-cutout-compatible.webm"
+				);
+				const routeAttempt = await executePersonCutoutRouteWithFallback({
+					execute: (candidateRuntime) =>
+						runCachedPipeline({
+							blendImplementation: implementation,
+							ffmpegPath,
+							metadata,
+							onProgress,
+							outputPath: attemptPath,
+							runtime: candidateRuntime,
+							settings,
+							signal,
+							sourcePath,
+							workingDirectory: outputDirectory,
+						}),
+					onFallback: (error) => {
+						console.warn(
+							"Advanced person-cutout route failed; retrying portrait GRU.",
+							error
+						);
+						onProgress?.({
+							progress: 8,
+							status: "物体分析不可用，正在切换精细人物抠像...",
+						});
+					},
+					portraitRuntime,
+					selectedRuntime: runtime,
+				});
+				frameCount = routeAttempt.result;
+				await rename(attemptPath, outputPath);
+			},
+			onFallback: (error) => {
+				console.warn(
+					"Native matting blend failed; retrying the compatible path.",
+					error
+				);
+				onProgress?.({
+					progress: 8,
+					status: "原生处理不可用，正在切换兼容模式...",
+				});
+			},
+			preferred: runtime.blendImplementation,
+		});
+		if (signal?.aborted) throw createAbortError();
+		return {
+			blendImplementation,
+			provider: "jianying-gru-local-v1",
+			outputPath,
+			width: metadata.width,
+			height: metadata.height,
+			duration: metadata.duration,
+			frameRate: metadata.frameRate,
+			frameCount,
+			hasAudio: metadata.hasAudio,
+			codec: "vp9",
+		};
+	} catch (error) {
+		await rm(outputDirectory, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+export async function releaseJianyingPersonCutout({
+	outputPath,
+}: {
+	outputPath: string;
+}) {
+	const outputDirectory = path.dirname(outputPath);
+	if (!path.basename(outputDirectory).startsWith("qcut-person-cutout-")) return;
+	await rm(outputDirectory, { recursive: true, force: true });
+}

--- a/qcut/electron/jianying-person-cutout/runtime.ts
+++ b/qcut/electron/jianying-person-cutout/runtime.ts
@@ -6,73 +6,73 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import type {
-  JianyingPersonCutoutRenderResult,
-  JianyingPersonCutoutStatus,
+	JianyingPersonCutoutRenderResult,
+	JianyingPersonCutoutStatus,
 } from "../jianying-person-cutout-contract.js";
 import { getFFmpegPath, getFFprobePath } from "../ffmpeg/utils.js";
 import {
-  createPersonCutoutAbortError,
-  throwIfPersonCutoutAborted,
-  waitForPersonCutoutPromise,
+	createPersonCutoutAbortError,
+	throwIfPersonCutoutAborted,
+	waitForPersonCutoutPromise,
 } from "./abort.js";
 import { resolveJianyingPersonCutoutBridge } from "./bridge-resolver.js";
 import { parsePersonCutoutBridgeTiming } from "./bridge-timing.js";
 import {
-  resolvePersonCutoutFrameCountExpectation,
-  type PersonCutoutFrameCountExpectation,
-  validatePersonCutoutAlphaFrameCount,
+	resolvePersonCutoutFrameCountExpectation,
+	type PersonCutoutFrameCountExpectation,
+	validatePersonCutoutAlphaFrameCount,
 } from "./frame-count.js";
 import { executePersonCutoutInferencePipeline } from "./inference-pipeline.js";
 import {
-  commitPersonCutoutMaskCache,
-  createPersonCutoutCacheIdentity,
-  createPersonCutoutCacheKey,
-  createPersonCutoutMaskCacheBuild,
-  discardPersonCutoutMaskCacheBuild,
-  inspectPersonCutoutMaskCache,
-  type PersonCutoutCacheIdentity,
-  type PersonCutoutMaskCacheEntry,
-  type PersonCutoutModelRoute,
+	commitPersonCutoutMaskCache,
+	createPersonCutoutCacheIdentity,
+	createPersonCutoutCacheKey,
+	createPersonCutoutMaskCacheBuild,
+	discardPersonCutoutMaskCacheBuild,
+	inspectPersonCutoutMaskCache,
+	type PersonCutoutCacheIdentity,
+	type PersonCutoutMaskCacheEntry,
+	type PersonCutoutModelRoute,
 } from "./mask-cache.js";
 import {
-  GRU_ONLY_PERSON_CUTOUT_PIPELINE,
-  GRU_VISION_PERSON_CUTOUT_PIPELINE,
-  SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE,
-  selectVideoObjectPersonCutoutPipeline,
-  type PersonCutoutPipelineDescriptor,
+	GRU_ONLY_PERSON_CUTOUT_PIPELINE,
+	GRU_VISION_PERSON_CUTOUT_PIPELINE,
+	SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE,
+	selectVideoObjectPersonCutoutPipeline,
+	type PersonCutoutPipelineDescriptor,
 } from "./pipeline-descriptor.js";
 import {
-  executeTemattingWithFallback,
-  selectTemattingBlendImplementation,
+	executeTemattingWithFallback,
+	selectTemattingBlendImplementation,
 } from "./runtime-capability.js";
 import {
-  buildTemattingOutputMetadata,
-  buildTemattingTransparentBlendFilter,
-  resolveTemattingOutputProvenance,
-  resolveTemattingOutputBlendImplementation,
-  TEMATTING_COMPATIBLE_BLEND,
-  TEMATTING_NATIVE_METAL_CANARY,
-  type TemattingBlendImplementation,
-  type TemattingNativeMetalCanaryStatus,
-  type TemattingOutputBlendImplementation,
+	buildTemattingOutputMetadata,
+	buildTemattingTransparentBlendFilter,
+	resolveTemattingOutputProvenance,
+	resolveTemattingOutputBlendImplementation,
+	TEMATTING_COMPATIBLE_BLEND,
+	TEMATTING_NATIVE_METAL_CANARY,
+	type TemattingBlendImplementation,
+	type TemattingNativeMetalCanaryStatus,
+	type TemattingOutputBlendImplementation,
 } from "./tematting-blend.js";
 import {
-  resolveJianyingSaliencyRuntime,
-  type JianyingSaliencyRuntime,
+	resolveJianyingSaliencyRuntime,
+	type JianyingSaliencyRuntime,
 } from "./saliency-runtime.js";
 import {
-  detectPersonCutoutModelRoute,
-  resolvePersonCutoutRoutingMode,
-  type PersonCutoutRouteDecision,
+	detectPersonCutoutModelRoute,
+	resolvePersonCutoutRoutingMode,
+	type PersonCutoutRouteDecision,
 } from "./model-router.js";
 import {
-  connectPersonCutoutProcessPipe,
-  createPersonCutoutRgbaDecoderArguments,
-  waitForPersonCutoutProcesses,
+	connectPersonCutoutProcessPipe,
+	createPersonCutoutRgbaDecoderArguments,
+	waitForPersonCutoutProcesses,
 } from "./process-pipeline.js";
 import {
-  resolveJianyingVideoObjectRuntimeCandidates,
-  type JianyingVideoObjectRuntimeCandidate,
+	resolveJianyingVideoObjectRuntimeCandidates,
+	type JianyingVideoObjectRuntimeCandidate,
 } from "./video-object-runtime.js";
 import { VideoObjectRuntimeCircuitBreaker } from "./video-object-circuit-breaker.js";
 import { createVideoObjectBridgeArguments } from "./video-object-bridge-arguments.js";
@@ -80,1111 +80,1111 @@ import { resolveAutorotatedVideoDimensions } from "./video-display-dimensions.js
 
 const execFileAsync = promisify(execFile);
 const MODEL_SHA256 =
-  "101688825490be3704babc7ce49f6d002cdb4fe69e879556b4687ac9006f8596";
+	"101688825490be3704babc7ce49f6d002cdb4fe69e879556b4687ac9006f8596";
 const MODEL_TYPE = "4";
 const MODEL_NAME = "tt_matting_video_gru_v1.0.model";
 const FINE_MODEL_NAME = "tt_matting_video_gru_v1.0+vision-person-v1";
 const EFFECT_GRAPH_INACTIVITY_TIMEOUT_MS = 20_000;
 const videoObjectRuntimeCircuitBreaker = new VideoObjectRuntimeCircuitBreaker();
 const PRIVATE_RUNTIME_ROOT = path.join(
-  os.homedir(),
-  "Library",
-  "Application Support",
-  "QCut",
-  "PrivateRuntimes",
+	os.homedir(),
+	"Library",
+	"Application Support",
+	"QCut",
+	"PrivateRuntimes"
 );
 
 interface ReadyRuntime {
-  blendImplementation: TemattingBlendImplementation;
-  bridgePath: string;
-  frameworkDirectory: string | null;
-  libraryPath: string | null;
-  modelPath: string;
-  modelName: string;
-  modelRoute: PersonCutoutModelRoute;
-  modelSha256: string;
-  processorSha256: string;
-  pipelineDescriptor: PersonCutoutPipelineDescriptor;
-  saliency?: JianyingSaliencyRuntime;
-  videoObject?: JianyingVideoObjectRuntimeCandidate;
+	blendImplementation: TemattingBlendImplementation;
+	bridgePath: string;
+	frameworkDirectory: string | null;
+	libraryPath: string | null;
+	modelPath: string;
+	modelName: string;
+	modelRoute: PersonCutoutModelRoute;
+	modelSha256: string;
+	processorSha256: string;
+	pipelineDescriptor: PersonCutoutPipelineDescriptor;
+	saliency?: JianyingSaliencyRuntime;
+	videoObject?: JianyingVideoObjectRuntimeCandidate;
 }
 
 interface SelectedInferenceRuntime {
-  didSelectionFallback: boolean;
-  fallbackRuntimes: ReadyRuntime[];
-  requestedModelRoute: PersonCutoutModelRoute | "auto";
-  routeDecision?: PersonCutoutRouteDecision;
-  runtime: ReadyRuntime;
+	didSelectionFallback: boolean;
+	fallbackRuntimes: ReadyRuntime[];
+	requestedModelRoute: PersonCutoutModelRoute | "auto";
+	routeDecision?: PersonCutoutRouteDecision;
+	runtime: ReadyRuntime;
 }
 
 interface VideoMetadata {
-  width: number;
-  height: number;
-  duration: number;
-  frameCountExpectation: PersonCutoutFrameCountExpectation;
-  frameRate: number;
-  hasAudio: boolean;
+	width: number;
+	height: number;
+	duration: number;
+	frameCountExpectation: PersonCutoutFrameCountExpectation;
+	frameRate: number;
+	hasAudio: boolean;
 }
 
 interface PersonCutoutProgress {
-  progress: number;
-  status: string;
+	progress: number;
+	status: string;
 }
 
 interface CompletedPersonCutoutInference {
-  alphaCache: PersonCutoutMaskCacheEntry;
-  blendImplementation: TemattingOutputBlendImplementation;
-  completedImplementation: TemattingBlendImplementation;
-  nativeMetalCanary: TemattingNativeMetalCanaryStatus;
+	alphaCache: PersonCutoutMaskCacheEntry;
+	blendImplementation: TemattingOutputBlendImplementation;
+	completedImplementation: TemattingBlendImplementation;
+	nativeMetalCanary: TemattingNativeMetalCanaryStatus;
 }
 
 type ProgressCallback = (progress: PersonCutoutProgress) => void;
 
 function status({
-  available,
-  blendImplementation,
-  message,
-  pipelineDescriptor = GRU_VISION_PERSON_CUTOUT_PIPELINE,
+	available,
+	blendImplementation,
+	message,
+	pipelineDescriptor = GRU_VISION_PERSON_CUTOUT_PIPELINE,
 }: {
-  available: boolean;
-  blendImplementation: TemattingBlendImplementation;
-  message: string;
-  pipelineDescriptor?: PersonCutoutPipelineDescriptor;
+	available: boolean;
+	blendImplementation: TemattingBlendImplementation;
+	message: string;
+	pipelineDescriptor?: PersonCutoutPipelineDescriptor;
 }): JianyingPersonCutoutStatus {
-  return {
-    available,
-    message,
-    provider: pipelineDescriptor.providerId,
-    offlineReady: available,
-    blendImplementation: resolveTemattingOutputBlendImplementation({
-      pipelineDescriptor,
-    }),
-    nativeMetalCanaryEnabled:
-      blendImplementation === TEMATTING_NATIVE_METAL_CANARY,
-    pipelineId: pipelineDescriptor.pipelineId,
-    refinementProvider: pipelineDescriptor.refinementProvider,
-  };
+	return {
+		available,
+		message,
+		provider: pipelineDescriptor.providerId,
+		offlineReady: available,
+		blendImplementation: resolveTemattingOutputBlendImplementation({
+			pipelineDescriptor,
+		}),
+		nativeMetalCanaryEnabled:
+			blendImplementation === TEMATTING_NATIVE_METAL_CANARY,
+		pipelineId: pipelineDescriptor.pipelineId,
+		refinementProvider: pipelineDescriptor.refinementProvider,
+	};
 }
 
 async function readable({ filePath }: { filePath: string }) {
-  try {
-    await access(filePath, constants.R_OK);
-    return true;
-  } catch {
-    return false;
-  }
+	try {
+		await access(filePath, constants.R_OK);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 async function resolveRuntime(): Promise<ReadyRuntime | null> {
-  if (process.platform !== "darwin") return null;
-  const frameworkDirectory = path.join(
-    PRIVATE_RUNTIME_ROOT,
-    "JianyingTransition",
-    "current",
-    "Frameworks",
-  );
-  const libraryPath = path.join(frameworkDirectory, "libcccreator.dylib");
-  const modelPath = path.join(
-    PRIVATE_RUNTIME_ROOT,
-    "JianyingMatting",
-    "current",
-    "Models",
-    "mattingmodel",
-    "tt_matting_video_gru_v1.0.model",
-  );
-  const bridgePath = await resolveJianyingPersonCutoutBridge();
-  if (
-    !bridgePath ||
-    !(await readable({ filePath: libraryPath })) ||
-    !(await readable({ filePath: modelPath }))
-  ) {
-    return null;
-  }
-  const [bridgeContents, modelContents, libraryContents] = await Promise.all([
-    readFile(bridgePath),
-    readFile(modelPath),
-    readFile(libraryPath),
-  ]);
-  const modelHash = createHash("sha256").update(modelContents).digest("hex");
-  if (modelHash !== MODEL_SHA256) return null;
-  const libraryHash = createHash("sha256")
-    .update(libraryContents)
-    .digest("hex");
-  const visionPersonFusionEnabled =
-    process.env.QCUT_DISABLE_VISION_PERSON_FUSION !== "1";
-  const nativeMetalDiagnosticEnabled =
-    process.env.QCUT_ENABLE_NATIVE_MATTING_DIAGNOSTIC === "1";
-  const blendImplementation = selectTemattingBlendImplementation({
-    arch: process.arch,
-    disabled:
-      !nativeMetalDiagnosticEnabled ||
-      process.env.QCUT_DISABLE_NATIVE_MATTING_METAL === "1",
-    librarySha256: libraryHash,
-    platform: process.platform,
-  });
-  const pipelineDescriptor = visionPersonFusionEnabled
-    ? GRU_VISION_PERSON_CUTOUT_PIPELINE
-    : GRU_ONLY_PERSON_CUTOUT_PIPELINE;
-  return {
-    blendImplementation,
-    bridgePath,
-    frameworkDirectory,
-    libraryPath,
-    modelPath,
-    modelName: visionPersonFusionEnabled ? FINE_MODEL_NAME : MODEL_NAME,
-    modelRoute: "portrait-gru",
-    modelSha256: modelHash,
-    processorSha256: createHash("sha256")
-      .update(bridgeContents)
-      .update(libraryHash)
-      .update(visionPersonFusionEnabled ? os.release() : "vision-disabled")
-      .digest("hex"),
-    pipelineDescriptor,
-  };
+	if (process.platform !== "darwin") return null;
+	const frameworkDirectory = path.join(
+		PRIVATE_RUNTIME_ROOT,
+		"JianyingTransition",
+		"current",
+		"Frameworks"
+	);
+	const libraryPath = path.join(frameworkDirectory, "libcccreator.dylib");
+	const modelPath = path.join(
+		PRIVATE_RUNTIME_ROOT,
+		"JianyingMatting",
+		"current",
+		"Models",
+		"mattingmodel",
+		"tt_matting_video_gru_v1.0.model"
+	);
+	const bridgePath = await resolveJianyingPersonCutoutBridge();
+	if (
+		!bridgePath ||
+		!(await readable({ filePath: libraryPath })) ||
+		!(await readable({ filePath: modelPath }))
+	) {
+		return null;
+	}
+	const [bridgeContents, modelContents, libraryContents] = await Promise.all([
+		readFile(bridgePath),
+		readFile(modelPath),
+		readFile(libraryPath),
+	]);
+	const modelHash = createHash("sha256").update(modelContents).digest("hex");
+	if (modelHash !== MODEL_SHA256) return null;
+	const libraryHash = createHash("sha256")
+		.update(libraryContents)
+		.digest("hex");
+	const visionPersonFusionEnabled =
+		process.env.QCUT_DISABLE_VISION_PERSON_FUSION !== "1";
+	const nativeMetalDiagnosticEnabled =
+		process.env.QCUT_ENABLE_NATIVE_MATTING_DIAGNOSTIC === "1";
+	const blendImplementation = selectTemattingBlendImplementation({
+		arch: process.arch,
+		disabled:
+			!nativeMetalDiagnosticEnabled ||
+			process.env.QCUT_DISABLE_NATIVE_MATTING_METAL === "1",
+		librarySha256: libraryHash,
+		platform: process.platform,
+	});
+	const pipelineDescriptor = visionPersonFusionEnabled
+		? GRU_VISION_PERSON_CUTOUT_PIPELINE
+		: GRU_ONLY_PERSON_CUTOUT_PIPELINE;
+	return {
+		blendImplementation,
+		bridgePath,
+		frameworkDirectory,
+		libraryPath,
+		modelPath,
+		modelName: visionPersonFusionEnabled ? FINE_MODEL_NAME : MODEL_NAME,
+		modelRoute: "portrait-gru",
+		modelSha256: modelHash,
+		processorSha256: createHash("sha256")
+			.update(bridgeContents)
+			.update(libraryHash)
+			.update(visionPersonFusionEnabled ? os.release() : "vision-disabled")
+			.digest("hex"),
+		pipelineDescriptor,
+	};
 }
 
 function createVideoObjectRuntime({
-  settings,
-  videoObject,
+	settings,
+	videoObject,
 }: {
-  settings: PersonCutoutCacheIdentity["settings"];
-  videoObject: JianyingVideoObjectRuntimeCandidate;
+	settings: PersonCutoutCacheIdentity["settings"];
+	videoObject: JianyingVideoObjectRuntimeCandidate;
 }): ReadyRuntime {
-  console.info("QCut person-cutout video-object provider candidate", {
-    capabilitySha256: videoObject.capabilitySha256,
-    providerCapability: videoObject.providerCapability,
-    readiness: videoObject.readiness,
-  });
-  const pipelineDescriptor = selectVideoObjectPersonCutoutPipeline({
-    executionBackend: videoObject.executionBackend,
-    settings,
-  });
-  return {
-    blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-    bridgePath: videoObject.bridgePath,
-    frameworkDirectory: videoObject.frameworkDirectory,
-    libraryPath: videoObject.libraryPath,
-    modelPath: videoObject.modelPath,
-    modelName: "video_saliency_seg_bce",
-    modelRoute: "video-object",
-    modelSha256: videoObject.modelSha256,
-    pipelineDescriptor,
-    processorSha256: videoObject.processorSha256,
-    videoObject,
-  };
+	console.info("QCut person-cutout video-object provider candidate", {
+		capabilitySha256: videoObject.capabilitySha256,
+		providerCapability: videoObject.providerCapability,
+		readiness: videoObject.readiness,
+	});
+	const pipelineDescriptor = selectVideoObjectPersonCutoutPipeline({
+		executionBackend: videoObject.executionBackend,
+		settings,
+	});
+	return {
+		blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+		bridgePath: videoObject.bridgePath,
+		frameworkDirectory: videoObject.frameworkDirectory,
+		libraryPath: videoObject.libraryPath,
+		modelPath: videoObject.modelPath,
+		modelName: "video_saliency_seg_bce",
+		modelRoute: "video-object",
+		modelSha256: videoObject.modelSha256,
+		pipelineDescriptor,
+		processorSha256: videoObject.processorSha256,
+		videoObject,
+	};
 }
 
 function createSaliencyRuntime({
-  saliency,
+	saliency,
 }: {
-  saliency: JianyingSaliencyRuntime;
+	saliency: JianyingSaliencyRuntime;
 }): ReadyRuntime {
-  return {
-    blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-    bridgePath: saliency.bridgePath,
-    frameworkDirectory: saliency.frameworkDirectory,
-    libraryPath: saliency.libraryPath,
-    modelPath: saliency.modelDirectory,
-    modelName: "saliency_script_for_cc_v1.2",
-    modelRoute: "saliency-script",
-    modelSha256: saliency.modelSha256,
-    pipelineDescriptor: SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE,
-    processorSha256: saliency.processorSha256,
-    saliency,
-  };
+	return {
+		blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+		bridgePath: saliency.bridgePath,
+		frameworkDirectory: saliency.frameworkDirectory,
+		libraryPath: saliency.libraryPath,
+		modelPath: saliency.modelDirectory,
+		modelName: "saliency_script_for_cc_v1.2",
+		modelRoute: "saliency-script",
+		modelSha256: saliency.modelSha256,
+		pipelineDescriptor: SALIENCY_SCRIPT_PERSON_CUTOUT_PIPELINE,
+		processorSha256: saliency.processorSha256,
+		saliency,
+	};
 }
 
 async function selectInferenceRuntime({
-  ffmpegPath,
-  metadata,
-  portraitRuntime,
-  settings,
-  signal,
-  sourcePath,
+	ffmpegPath,
+	metadata,
+	portraitRuntime,
+	settings,
+	signal,
+	sourcePath,
 }: {
-  ffmpegPath: string;
-  metadata: VideoMetadata;
-  portraitRuntime: ReadyRuntime;
-  settings: PersonCutoutCacheIdentity["settings"];
-  signal?: AbortSignal;
-  sourcePath: string;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	portraitRuntime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	signal?: AbortSignal;
+	sourcePath: string;
 }): Promise<SelectedInferenceRuntime> {
-  throwIfPersonCutoutAborted({ signal });
-  const routingMode = resolvePersonCutoutRoutingMode({
-    automaticRoutingEnabled:
-      process.env.QCUT_DISABLE_PERSON_CUTOUT_AUTO_ROUTE !== "1" &&
-      process.env.QCUT_ENABLE_PERSON_CUTOUT_AUTO_ROUTE !== "0",
-    requestedRoute: process.env.QCUT_PERSON_CUTOUT_ROUTE,
-  });
-  if (routingMode === "portrait-gru") {
-    return {
-      didSelectionFallback: false,
-      fallbackRuntimes: [],
-      requestedModelRoute: "portrait-gru",
-      runtime: portraitRuntime,
-    };
-  }
-  if (routingMode === "video-object" || routingMode === "auto") {
-    const resolvedVideoObjects =
-      await resolveJianyingVideoObjectRuntimeCandidates({
-        height: metadata.height,
-        width: metadata.width,
-      });
-    throwIfPersonCutoutAborted({ signal });
-    const retryRejected = process.env.QCUT_RETRY_VIDEO_OBJECT_ROUTE === "1";
-    const videoObjects = resolvedVideoObjects.filter(
-      (candidate) =>
-        retryRejected ||
-        !videoObjectRuntimeCircuitBreaker.isOpen({
-          capabilitySha256: candidate.capabilitySha256,
-        }),
-    );
-    const didProviderSelectionFallback =
-      videoObjects.length !== resolvedVideoObjects.length;
-    if (didProviderSelectionFallback) {
-      console.info(
-        "QCut person-cutout skipped a video-object runtime rejected earlier in this app session.",
-      );
-    }
-    const videoObjectRuntimes = videoObjects.map((videoObject) =>
-      createVideoObjectRuntime({ settings, videoObject }),
-    );
-    const videoObjectRuntime = videoObjectRuntimes[0];
-    if (routingMode === "auto") {
-      const routeDecision = await detectPersonCutoutModelRoute({
-        duration: metadata.duration,
-        ffmpegPath,
-        frameRate: metadata.frameRate,
-        height: metadata.height,
-        signal,
-        sourcePath,
-        videoObjectCandidateAvailable: Boolean(videoObjectRuntime),
-        width: metadata.width,
-      });
-      console.info("QCut person-cutout automatic route", routeDecision);
-      const selectedVideoObject =
-        routeDecision.route === "video-object" ? videoObjectRuntime : undefined;
-      return {
-        didSelectionFallback:
-          Boolean(selectedVideoObject) && didProviderSelectionFallback,
-        fallbackRuntimes: selectedVideoObject
-          ? videoObjectRuntimes.slice(1)
-          : [],
-        requestedModelRoute: "auto",
-        routeDecision,
-        runtime: selectedVideoObject ?? portraitRuntime,
-      };
-    }
-    if (!videoObjectRuntime) {
-      console.warn(
-        "Jianying video-object runtime is unavailable; falling back to portrait GRU.",
-      );
-      return {
-        didSelectionFallback: true,
-        fallbackRuntimes: [],
-        requestedModelRoute: "video-object",
-        runtime: portraitRuntime,
-      };
-    }
-    return {
-      didSelectionFallback: didProviderSelectionFallback,
-      fallbackRuntimes: videoObjectRuntimes.slice(1),
-      requestedModelRoute: "video-object",
-      runtime: videoObjectRuntime,
-    };
-  }
-  const saliency = await resolveJianyingSaliencyRuntime();
-  throwIfPersonCutoutAborted({ signal });
-  if (!saliency) {
-    console.warn(
-      "Jianying saliency runtime is unavailable; falling back to portrait GRU.",
-    );
-    return {
-      didSelectionFallback: true,
-      fallbackRuntimes: [],
-      requestedModelRoute: "saliency-script",
-      runtime: portraitRuntime,
-    };
-  }
-  return {
-    didSelectionFallback: false,
-    fallbackRuntimes: [],
-    requestedModelRoute: "saliency-script",
-    runtime: createSaliencyRuntime({ saliency }),
-  };
+	throwIfPersonCutoutAborted({ signal });
+	const routingMode = resolvePersonCutoutRoutingMode({
+		automaticRoutingEnabled:
+			process.env.QCUT_DISABLE_PERSON_CUTOUT_AUTO_ROUTE !== "1" &&
+			process.env.QCUT_ENABLE_PERSON_CUTOUT_AUTO_ROUTE !== "0",
+		requestedRoute: process.env.QCUT_PERSON_CUTOUT_ROUTE,
+	});
+	if (routingMode === "portrait-gru") {
+		return {
+			didSelectionFallback: false,
+			fallbackRuntimes: [],
+			requestedModelRoute: "portrait-gru",
+			runtime: portraitRuntime,
+		};
+	}
+	if (routingMode === "video-object" || routingMode === "auto") {
+		const resolvedVideoObjects =
+			await resolveJianyingVideoObjectRuntimeCandidates({
+				height: metadata.height,
+				width: metadata.width,
+			});
+		throwIfPersonCutoutAborted({ signal });
+		const retryRejected = process.env.QCUT_RETRY_VIDEO_OBJECT_ROUTE === "1";
+		const videoObjects = resolvedVideoObjects.filter(
+			(candidate) =>
+				retryRejected ||
+				!videoObjectRuntimeCircuitBreaker.isOpen({
+					capabilitySha256: candidate.capabilitySha256,
+				})
+		);
+		const didProviderSelectionFallback =
+			videoObjects.length !== resolvedVideoObjects.length;
+		if (didProviderSelectionFallback) {
+			console.info(
+				"QCut person-cutout skipped a video-object runtime rejected earlier in this app session."
+			);
+		}
+		const videoObjectRuntimes = videoObjects.map((videoObject) =>
+			createVideoObjectRuntime({ settings, videoObject })
+		);
+		const videoObjectRuntime = videoObjectRuntimes[0];
+		if (routingMode === "auto") {
+			const routeDecision = await detectPersonCutoutModelRoute({
+				duration: metadata.duration,
+				ffmpegPath,
+				frameRate: metadata.frameRate,
+				height: metadata.height,
+				signal,
+				sourcePath,
+				videoObjectCandidateAvailable: Boolean(videoObjectRuntime),
+				width: metadata.width,
+			});
+			console.info("QCut person-cutout automatic route", routeDecision);
+			const selectedVideoObject =
+				routeDecision.route === "video-object" ? videoObjectRuntime : undefined;
+			return {
+				didSelectionFallback:
+					Boolean(selectedVideoObject) && didProviderSelectionFallback,
+				fallbackRuntimes: selectedVideoObject
+					? videoObjectRuntimes.slice(1)
+					: [],
+				requestedModelRoute: "auto",
+				routeDecision,
+				runtime: selectedVideoObject ?? portraitRuntime,
+			};
+		}
+		if (!videoObjectRuntime) {
+			console.warn(
+				"Jianying video-object runtime is unavailable; falling back to portrait GRU."
+			);
+			return {
+				didSelectionFallback: true,
+				fallbackRuntimes: [],
+				requestedModelRoute: "video-object",
+				runtime: portraitRuntime,
+			};
+		}
+		return {
+			didSelectionFallback: didProviderSelectionFallback,
+			fallbackRuntimes: videoObjectRuntimes.slice(1),
+			requestedModelRoute: "video-object",
+			runtime: videoObjectRuntime,
+		};
+	}
+	const saliency = await resolveJianyingSaliencyRuntime();
+	throwIfPersonCutoutAborted({ signal });
+	if (!saliency) {
+		console.warn(
+			"Jianying saliency runtime is unavailable; falling back to portrait GRU."
+		);
+		return {
+			didSelectionFallback: true,
+			fallbackRuntimes: [],
+			requestedModelRoute: "saliency-script",
+			runtime: portraitRuntime,
+		};
+	}
+	return {
+		didSelectionFallback: false,
+		fallbackRuntimes: [],
+		requestedModelRoute: "saliency-script",
+		runtime: createSaliencyRuntime({ saliency }),
+	};
 }
 
 export async function inspectJianyingPersonCutout() {
-  if (process.platform !== "darwin") {
-    return status({
-      available: false,
-      blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-      message: "精细抠像目前只支持 macOS",
-    });
-  }
-  const runtime = await resolveRuntime();
-  return runtime
-    ? status({
-        available: true,
-        blendImplementation: runtime.blendImplementation,
-        message: "精细抠像已就绪",
-        pipelineDescriptor: runtime.pipelineDescriptor,
-      })
-    : status({
-        available: false,
-        blendImplementation: TEMATTING_COMPATIBLE_BLEND,
-        message: "精细抠像所需的本机模型未就绪",
-      });
+	if (process.platform !== "darwin") {
+		return status({
+			available: false,
+			blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+			message: "精细抠像目前只支持 macOS",
+		});
+	}
+	const runtime = await resolveRuntime();
+	return runtime
+		? status({
+				available: true,
+				blendImplementation: runtime.blendImplementation,
+				message: "精细抠像已就绪",
+				pipelineDescriptor: runtime.pipelineDescriptor,
+			})
+		: status({
+				available: false,
+				blendImplementation: TEMATTING_COMPATIBLE_BLEND,
+				message: "精细抠像所需的本机模型未就绪",
+			});
 }
 
 function bridgeArguments({
-  blendImplementation,
-  height,
-  inputPath,
-  modelPath,
-  outputPath,
-  settings,
-  width,
-  libraryPath,
-  runtime,
+	blendImplementation,
+	height,
+	inputPath,
+	modelPath,
+	outputPath,
+	settings,
+	width,
+	libraryPath,
+	runtime,
 }: {
-  blendImplementation: TemattingBlendImplementation;
-  height: number;
-  inputPath: string;
-  libraryPath: string | null;
-  modelPath: string;
-  outputPath: string;
-  settings: {
-    threshold: number;
-    temporalSmoothing: number;
-    edgeShift: number;
-    feather: number;
-  };
-  width: number;
-  runtime: ReadyRuntime;
+	blendImplementation: TemattingBlendImplementation;
+	height: number;
+	inputPath: string;
+	libraryPath: string | null;
+	modelPath: string;
+	outputPath: string;
+	settings: {
+		threshold: number;
+		temporalSmoothing: number;
+		edgeShift: number;
+		feather: number;
+	};
+	width: number;
+	runtime: ReadyRuntime;
 }) {
-  if (runtime.modelRoute === "video-object") {
-    if (!runtime.videoObject) {
-      throw new Error("剪映物体抠像运行时不完整");
-    }
-    return createVideoObjectBridgeArguments({
-      height,
-      inputPath,
-      outputPath,
-      settings,
-      videoObject: runtime.videoObject,
-      width,
-    });
-  }
-  if (runtime.modelRoute === "saliency-script") {
-    if (!runtime.saliency || !libraryPath) {
-      throw new Error("剪映显著性抠像运行时不完整");
-    }
-    return [
-      libraryPath,
-      runtime.saliency.modelDirectory,
-      runtime.saliency.effectDirectory,
-      inputPath,
-      String(width),
-      String(height),
-      outputPath,
-      String(settings.threshold),
-      String(settings.temporalSmoothing),
-      String(settings.edgeShift),
-      String(settings.feather),
-    ];
-  }
-  if (!libraryPath) {
-    throw new Error("剪映人物抠像运行时不完整");
-  }
-  const args = [
-    libraryPath,
-    modelPath,
-    MODEL_TYPE,
-    inputPath,
-    String(width),
-    String(height),
-    outputPath,
-    String(settings.threshold),
-    String(settings.temporalSmoothing),
-    String(settings.edgeShift),
-    String(settings.feather),
-  ];
-  if (
-    runtime.pipelineDescriptor.pipelineId ===
-    GRU_VISION_PERSON_CUTOUT_PIPELINE.pipelineId
-  ) {
-    args.push("--vision-person-fusion");
-  }
-  args.push("--timing-json");
-  if (blendImplementation === TEMATTING_NATIVE_METAL_CANARY) {
-    args.push("--native-metal-canary");
-  }
-  return args;
+	if (runtime.modelRoute === "video-object") {
+		if (!runtime.videoObject) {
+			throw new Error("剪映物体抠像运行时不完整");
+		}
+		return createVideoObjectBridgeArguments({
+			height,
+			inputPath,
+			outputPath,
+			settings,
+			videoObject: runtime.videoObject,
+			width,
+		});
+	}
+	if (runtime.modelRoute === "saliency-script") {
+		if (!runtime.saliency || !libraryPath) {
+			throw new Error("剪映显著性抠像运行时不完整");
+		}
+		return [
+			libraryPath,
+			runtime.saliency.modelDirectory,
+			runtime.saliency.effectDirectory,
+			inputPath,
+			String(width),
+			String(height),
+			outputPath,
+			String(settings.threshold),
+			String(settings.temporalSmoothing),
+			String(settings.edgeShift),
+			String(settings.feather),
+		];
+	}
+	if (!libraryPath) {
+		throw new Error("剪映人物抠像运行时不完整");
+	}
+	const args = [
+		libraryPath,
+		modelPath,
+		MODEL_TYPE,
+		inputPath,
+		String(width),
+		String(height),
+		outputPath,
+		String(settings.threshold),
+		String(settings.temporalSmoothing),
+		String(settings.edgeShift),
+		String(settings.feather),
+	];
+	if (
+		runtime.pipelineDescriptor.pipelineId ===
+		GRU_VISION_PERSON_CUTOUT_PIPELINE.pipelineId
+	) {
+		args.push("--vision-person-fusion");
+	}
+	args.push("--timing-json");
+	if (blendImplementation === TEMATTING_NATIVE_METAL_CANARY) {
+		args.push("--native-metal-canary");
+	}
+	return args;
 }
 
 export function createPersonCutoutBridgeEnvironment({
-  frameworkDirectory,
-  sourceEnvironment = process.env,
+	frameworkDirectory,
+	sourceEnvironment = process.env,
 }: {
-  frameworkDirectory: string | null;
-  sourceEnvironment?: NodeJS.ProcessEnv;
+	frameworkDirectory: string | null;
+	sourceEnvironment?: NodeJS.ProcessEnv;
 }): NodeJS.ProcessEnv {
-  const environment = { ...sourceEnvironment };
-  for (const key of Object.keys(environment)) {
-    if (key.startsWith("DYLD_")) Reflect.deleteProperty(environment, key);
-  }
-  Reflect.deleteProperty(environment, "QCUT_VIDEO_OBJECT_RESET_FRAMES");
-  if (frameworkDirectory) {
-    environment.DYLD_LIBRARY_PATH = frameworkDirectory;
-  }
-  return environment;
+	const environment = { ...sourceEnvironment };
+	for (const key of Object.keys(environment)) {
+		if (key.startsWith("DYLD_")) Reflect.deleteProperty(environment, key);
+	}
+	Reflect.deleteProperty(environment, "QCUT_VIDEO_OBJECT_RESET_FRAMES");
+	if (frameworkDirectory) {
+		environment.DYLD_LIBRARY_PATH = frameworkDirectory;
+	}
+	return environment;
 }
 
 function clampProgress({ value }: { value: number }) {
-  return Math.max(0, Math.min(100, Math.round(value)));
+	return Math.max(0, Math.min(100, Math.round(value)));
 }
 
 function runAlphaInference({
-  alphaPath,
-  blendImplementation,
-  ffmpegPath,
-  metadata,
-  onProgress,
-  runtime,
-  settings,
-  signal,
-  sourcePath,
-  workingDirectory,
+	alphaPath,
+	blendImplementation,
+	ffmpegPath,
+	metadata,
+	onProgress,
+	runtime,
+	settings,
+	signal,
+	sourcePath,
+	workingDirectory,
 }: {
-  alphaPath: string;
-  blendImplementation: TemattingBlendImplementation;
-  ffmpegPath: string;
-  metadata: VideoMetadata;
-  onProgress?: ProgressCallback;
-  runtime: ReadyRuntime;
-  settings: PersonCutoutCacheIdentity["settings"];
-  signal?: AbortSignal;
-  sourcePath: string;
-  workingDirectory: string;
+	alphaPath: string;
+	blendImplementation: TemattingBlendImplementation;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	runtime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	signal?: AbortSignal;
+	sourcePath: string;
+	workingDirectory: string;
 }) {
-  if (signal?.aborted) return Promise.reject(createPersonCutoutAbortError());
-  const decoder = spawn(
-    ffmpegPath,
-    createPersonCutoutRgbaDecoderArguments({ sourcePath }),
-    { cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] },
-  );
-  const bridge = spawn(
-    runtime.bridgePath,
-    bridgeArguments({
-      blendImplementation,
-      height: metadata.height,
-      inputPath: "-",
-      libraryPath: runtime.libraryPath,
-      modelPath: runtime.modelPath,
-      outputPath: alphaPath,
-      settings,
-      width: metadata.width,
-      runtime,
-    }),
-    {
-      cwd: workingDirectory,
-      env: createPersonCutoutBridgeEnvironment({
-        frameworkDirectory: runtime.frameworkDirectory,
-      }),
-      stdio: ["pipe", "ignore", "pipe"],
-    },
-  );
-  connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
-  const isPortraitGru = runtime.modelRoute === "portrait-gru";
-  const bridgeLabel = isPortraitGru ? "人物蒙版预计算" : "剪映主体分析";
-  const progressStatus = isPortraitGru
-    ? "正在预计算人物蒙版"
-    : "正在分析人物主体";
-  let bridgeText = "";
-  let lastProgress = 8;
-  return waitForPersonCutoutProcesses({
-    inactivityTimeoutMs: isPortraitGru
-      ? undefined
-      : EFFECT_GRAPH_INACTIVITY_TIMEOUT_MS,
-    processes: [
-      { child: decoder, label: "视频解码" },
-      { child: bridge, label: bridgeLabel },
-    ],
-    signal,
-    onStderr: ({ child, chunk }) => {
-      if (child !== bridge) return;
-      bridgeText += chunk.toString("utf8");
-      const lines = bridgeText.split("\n");
-      bridgeText = lines.pop() ?? "";
-      for (const line of lines) {
-        const timing = parsePersonCutoutBridgeTiming({ line });
-        if (timing) {
-          console.info("QCut person-cutout bridge timing", timing);
-          continue;
-        }
-        const match = /progress frame=(\d+) total=(\d+)/.exec(line);
-        if (!match) continue;
-        const frame = Number(match[1]);
-        const reportedTotal = Number(match[2]);
-        const total =
-          reportedTotal > 0
-            ? reportedTotal
-            : metadata.frameCountExpectation.count;
-        const progress = clampProgress({ value: 8 + (frame / total) * 70 });
-        if (progress <= lastProgress) continue;
-        lastProgress = progress;
-        onProgress?.({
-          progress,
-          status: `${progressStatus}（${frame}/${total} 帧）...`,
-        });
-      }
-    },
-  });
+	if (signal?.aborted) return Promise.reject(createPersonCutoutAbortError());
+	const decoder = spawn(
+		ffmpegPath,
+		createPersonCutoutRgbaDecoderArguments({ sourcePath }),
+		{ cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] }
+	);
+	const bridge = spawn(
+		runtime.bridgePath,
+		bridgeArguments({
+			blendImplementation,
+			height: metadata.height,
+			inputPath: "-",
+			libraryPath: runtime.libraryPath,
+			modelPath: runtime.modelPath,
+			outputPath: alphaPath,
+			settings,
+			width: metadata.width,
+			runtime,
+		}),
+		{
+			cwd: workingDirectory,
+			env: createPersonCutoutBridgeEnvironment({
+				frameworkDirectory: runtime.frameworkDirectory,
+			}),
+			stdio: ["pipe", "ignore", "pipe"],
+		}
+	);
+	connectPersonCutoutProcessPipe({ consumer: bridge, producer: decoder });
+	const isPortraitGru = runtime.modelRoute === "portrait-gru";
+	const bridgeLabel = isPortraitGru ? "人物蒙版预计算" : "剪映主体分析";
+	const progressStatus = isPortraitGru
+		? "正在预计算人物蒙版"
+		: "正在分析人物主体";
+	let bridgeText = "";
+	let lastProgress = 8;
+	return waitForPersonCutoutProcesses({
+		inactivityTimeoutMs: isPortraitGru
+			? undefined
+			: EFFECT_GRAPH_INACTIVITY_TIMEOUT_MS,
+		processes: [
+			{ child: decoder, label: "视频解码" },
+			{ child: bridge, label: bridgeLabel },
+		],
+		signal,
+		onStderr: ({ child, chunk }) => {
+			if (child !== bridge) return;
+			bridgeText += chunk.toString("utf8");
+			const lines = bridgeText.split("\n");
+			bridgeText = lines.pop() ?? "";
+			for (const line of lines) {
+				const timing = parsePersonCutoutBridgeTiming({ line });
+				if (timing) {
+					console.info("QCut person-cutout bridge timing", timing);
+					continue;
+				}
+				const match = /progress frame=(\d+) total=(\d+)/.exec(line);
+				if (!match) continue;
+				const frame = Number(match[1]);
+				const reportedTotal = Number(match[2]);
+				const total =
+					reportedTotal > 0
+						? reportedTotal
+						: metadata.frameCountExpectation.count;
+				const progress = clampProgress({ value: 8 + (frame / total) * 70 });
+				if (progress <= lastProgress) continue;
+				lastProgress = progress;
+				onProgress?.({
+					progress,
+					status: `${progressStatus}（${frame}/${total} 帧）...`,
+				});
+			}
+		},
+	});
 }
 
 const activeMaskCacheBuilds = new Map<
-  string,
-  Promise<PersonCutoutMaskCacheEntry>
+	string,
+	Promise<PersonCutoutMaskCacheEntry>
 >();
 
 async function buildMaskCache({
-  blendImplementation,
-  ffmpegPath,
-  identity,
-  metadata,
-  onProgress,
-  runtime,
-  settings,
-  sourcePath,
+	blendImplementation,
+	ffmpegPath,
+	identity,
+	metadata,
+	onProgress,
+	runtime,
+	settings,
+	sourcePath,
 }: {
-  blendImplementation: TemattingBlendImplementation;
-  ffmpegPath: string;
-  identity: PersonCutoutCacheIdentity;
-  metadata: VideoMetadata;
-  onProgress?: ProgressCallback;
-  runtime: ReadyRuntime;
-  settings: PersonCutoutCacheIdentity["settings"];
-  sourcePath: string;
+	blendImplementation: TemattingBlendImplementation;
+	ffmpegPath: string;
+	identity: PersonCutoutCacheIdentity;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	runtime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	sourcePath: string;
 }) {
-  const build = await createPersonCutoutMaskCacheBuild({ identity });
-  try {
-    await runAlphaInference({
-      alphaPath: build.alphaPath,
-      blendImplementation,
-      ffmpegPath,
-      metadata,
-      onProgress,
-      runtime,
-      settings,
-      sourcePath,
-      workingDirectory: build.directory,
-    });
-    const alphaStat = await stat(build.alphaPath);
-    const bytesPerFrame = metadata.width * metadata.height;
-    if (alphaStat.size === 0 || alphaStat.size % bytesPerFrame !== 0) {
-      throw new Error("人物蒙版帧不完整，已停止导出");
-    }
-    const frameCount = alphaStat.size / bytesPerFrame;
-    validatePersonCutoutAlphaFrameCount({
-      actualFrameCount: frameCount,
-      expectation: metadata.frameCountExpectation,
-    });
-    return await commitPersonCutoutMaskCache({
-      buildDirectory: build.directory,
-      frameCount,
-      identity,
-    });
-  } catch (error) {
-    await discardPersonCutoutMaskCacheBuild({
-      buildDirectory: build.directory,
-    });
-    throw error;
-  }
+	const build = await createPersonCutoutMaskCacheBuild({ identity });
+	try {
+		await runAlphaInference({
+			alphaPath: build.alphaPath,
+			blendImplementation,
+			ffmpegPath,
+			metadata,
+			onProgress,
+			runtime,
+			settings,
+			sourcePath,
+			workingDirectory: build.directory,
+		});
+		const alphaStat = await stat(build.alphaPath);
+		const bytesPerFrame = metadata.width * metadata.height;
+		if (alphaStat.size === 0 || alphaStat.size % bytesPerFrame !== 0) {
+			throw new Error("人物蒙版帧不完整，已停止导出");
+		}
+		const frameCount = alphaStat.size / bytesPerFrame;
+		validatePersonCutoutAlphaFrameCount({
+			actualFrameCount: frameCount,
+			expectation: metadata.frameCountExpectation,
+		});
+		return await commitPersonCutoutMaskCache({
+			buildDirectory: build.directory,
+			frameCount,
+			identity,
+		});
+	} catch (error) {
+		await discardPersonCutoutMaskCacheBuild({
+			buildDirectory: build.directory,
+		});
+		throw error;
+	}
 }
 
 async function ensureMaskCache({
-  blendImplementation,
-  ffmpegPath,
-  metadata,
-  onProgress,
-  runtime,
-  settings,
-  signal,
-  sourcePath,
+	blendImplementation,
+	ffmpegPath,
+	metadata,
+	onProgress,
+	runtime,
+	settings,
+	signal,
+	sourcePath,
 }: {
-  blendImplementation: TemattingBlendImplementation;
-  ffmpegPath: string;
-  metadata: VideoMetadata;
-  onProgress?: ProgressCallback;
-  runtime: ReadyRuntime;
-  settings: PersonCutoutCacheIdentity["settings"];
-  signal?: AbortSignal;
-  sourcePath: string;
+	blendImplementation: TemattingBlendImplementation;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	runtime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	signal?: AbortSignal;
+	sourcePath: string;
 }) {
-  const identity = await createPersonCutoutCacheIdentity({
-    blendImplementation,
-    frameRate: metadata.frameRate,
-    height: metadata.height,
-    modelName: runtime.modelName,
-    modelRoute: runtime.modelRoute,
-    modelSha256: runtime.modelSha256,
-    pipelineDescriptor: runtime.pipelineDescriptor,
-    processorSha256: runtime.processorSha256,
-    settings,
-    signal,
-    sourcePath,
-    width: metadata.width,
-  });
-  const cached = await inspectPersonCutoutMaskCache({ identity, signal });
-  if (cached) {
-    onProgress?.({ progress: 78, status: "人物蒙版缓存完整，正在导出..." });
-    return cached;
-  }
-  const cacheKey = createPersonCutoutCacheKey({ identity });
-  const activeBuild = activeMaskCacheBuilds.get(cacheKey);
-  if (activeBuild) {
-    return waitForPersonCutoutPromise({ promise: activeBuild, signal });
-  }
-  const build = buildMaskCache({
-    blendImplementation,
-    ffmpegPath,
-    identity,
-    metadata,
-    onProgress,
-    runtime,
-    settings,
-    sourcePath,
-  });
-  activeMaskCacheBuilds.set(cacheKey, build);
-  const clearActiveBuild = () => {
-    if (activeMaskCacheBuilds.get(cacheKey) === build) {
-      activeMaskCacheBuilds.delete(cacheKey);
-    }
-  };
-  void build.then(clearActiveBuild, clearActiveBuild);
-  return waitForPersonCutoutPromise({ promise: build, signal });
+	const identity = await createPersonCutoutCacheIdentity({
+		blendImplementation,
+		frameRate: metadata.frameRate,
+		height: metadata.height,
+		modelName: runtime.modelName,
+		modelRoute: runtime.modelRoute,
+		modelSha256: runtime.modelSha256,
+		pipelineDescriptor: runtime.pipelineDescriptor,
+		processorSha256: runtime.processorSha256,
+		settings,
+		signal,
+		sourcePath,
+		width: metadata.width,
+	});
+	const cached = await inspectPersonCutoutMaskCache({ identity, signal });
+	if (cached) {
+		onProgress?.({ progress: 78, status: "人物蒙版缓存完整，正在导出..." });
+		return cached;
+	}
+	const cacheKey = createPersonCutoutCacheKey({ identity });
+	const activeBuild = activeMaskCacheBuilds.get(cacheKey);
+	if (activeBuild) {
+		return waitForPersonCutoutPromise({ promise: activeBuild, signal });
+	}
+	const build = buildMaskCache({
+		blendImplementation,
+		ffmpegPath,
+		identity,
+		metadata,
+		onProgress,
+		runtime,
+		settings,
+		sourcePath,
+	});
+	activeMaskCacheBuilds.set(cacheKey, build);
+	const clearActiveBuild = () => {
+		if (activeMaskCacheBuilds.get(cacheKey) === build) {
+			activeMaskCacheBuilds.delete(cacheKey);
+		}
+	};
+	void build.then(clearActiveBuild, clearActiveBuild);
+	return waitForPersonCutoutPromise({ promise: build, signal });
 }
 
 function runTransparentEncoder({
-  alphaCache,
-  blendImplementation,
-  ffmpegPath,
-  metadata,
-  nativeMetalCanary,
-  onProgress,
-  outputPath,
-  runtime,
-  signal,
-  sourcePath,
-  workingDirectory,
+	alphaCache,
+	blendImplementation,
+	ffmpegPath,
+	metadata,
+	nativeMetalCanary,
+	onProgress,
+	outputPath,
+	runtime,
+	signal,
+	sourcePath,
+	workingDirectory,
 }: {
-  alphaCache: PersonCutoutMaskCacheEntry;
-  blendImplementation: TemattingBlendImplementation;
-  ffmpegPath: string;
-  metadata: VideoMetadata;
-  nativeMetalCanary: TemattingNativeMetalCanaryStatus;
-  onProgress?: ProgressCallback;
-  outputPath: string;
-  runtime: ReadyRuntime;
-  signal?: AbortSignal;
-  sourcePath: string;
-  workingDirectory: string;
+	alphaCache: PersonCutoutMaskCacheEntry;
+	blendImplementation: TemattingBlendImplementation;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	nativeMetalCanary: TemattingNativeMetalCanaryStatus;
+	onProgress?: ProgressCallback;
+	outputPath: string;
+	runtime: ReadyRuntime;
+	signal?: AbortSignal;
+	sourcePath: string;
+	workingDirectory: string;
 }) {
-  if (signal?.aborted) return Promise.reject(createPersonCutoutAbortError());
-  const encoder = spawn(
-    ffmpegPath,
-    [
-      "-y",
-      "-v",
-      "error",
-      "-i",
-      sourcePath,
-      "-f",
-      "rawvideo",
-      "-pixel_format",
-      "gray",
-      "-video_size",
-      `${metadata.width}x${metadata.height}`,
-      "-framerate",
-      String(metadata.frameRate),
-      "-i",
-      alphaCache.alphaPath,
-      "-filter_complex",
-      buildTemattingTransparentBlendFilter(),
-      "-map",
-      "[cutout]",
-      "-map",
-      "0:a?",
-      "-frames:v",
-      String(alphaCache.frameCount),
-      "-c:v",
-      "libvpx-vp9",
-      "-pix_fmt",
-      "yuva420p",
-      "-metadata:s:v:0",
-      "alpha_mode=1",
-      ...buildTemattingOutputMetadata({
-        implementation: blendImplementation,
-        modelName: runtime.modelName,
-        modelRoute: runtime.modelRoute,
-        nativeMetalCanary,
-        pipelineDescriptor: runtime.pipelineDescriptor,
-      }),
-      "-c:a",
-      "libopus",
-      "-shortest",
-      "-progress",
-      "pipe:1",
-      "-nostats",
-      outputPath,
-    ],
-    { cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] },
-  );
-  let encoderText = "";
-  let lastProgress = 78;
-  encoder.stdout?.on("data", (chunk: Buffer) => {
-    encoderText += chunk.toString("utf8");
-    const lines = encoderText.split("\n");
-    encoderText = lines.pop() ?? "";
-    for (const line of lines) {
-      const match = /^out_time_us=(\d+)$/.exec(line.trim());
-      if (!match || metadata.duration <= 0) continue;
-      const seconds = Number(match[1]) / 1_000_000;
-      const progress = clampProgress({
-        value: 78 + (seconds / metadata.duration) * 20,
-      });
-      if (progress <= lastProgress) continue;
-      lastProgress = progress;
-      onProgress?.({ progress, status: "正在生成透明视频..." });
-    }
-  });
-  return waitForPersonCutoutProcesses({
-    processes: [{ child: encoder, label: "透明视频编码" }],
-    signal,
-  });
+	if (signal?.aborted) return Promise.reject(createPersonCutoutAbortError());
+	const encoder = spawn(
+		ffmpegPath,
+		[
+			"-y",
+			"-v",
+			"error",
+			"-i",
+			sourcePath,
+			"-f",
+			"rawvideo",
+			"-pixel_format",
+			"gray",
+			"-video_size",
+			`${metadata.width}x${metadata.height}`,
+			"-framerate",
+			String(metadata.frameRate),
+			"-i",
+			alphaCache.alphaPath,
+			"-filter_complex",
+			buildTemattingTransparentBlendFilter(),
+			"-map",
+			"[cutout]",
+			"-map",
+			"0:a?",
+			"-frames:v",
+			String(alphaCache.frameCount),
+			"-c:v",
+			"libvpx-vp9",
+			"-pix_fmt",
+			"yuva420p",
+			"-metadata:s:v:0",
+			"alpha_mode=1",
+			...buildTemattingOutputMetadata({
+				implementation: blendImplementation,
+				modelName: runtime.modelName,
+				modelRoute: runtime.modelRoute,
+				nativeMetalCanary,
+				pipelineDescriptor: runtime.pipelineDescriptor,
+			}),
+			"-c:a",
+			"libopus",
+			"-shortest",
+			"-progress",
+			"pipe:1",
+			"-nostats",
+			outputPath,
+		],
+		{ cwd: workingDirectory, stdio: ["ignore", "pipe", "pipe"] }
+	);
+	let encoderText = "";
+	let lastProgress = 78;
+	encoder.stdout?.on("data", (chunk: Buffer) => {
+		encoderText += chunk.toString("utf8");
+		const lines = encoderText.split("\n");
+		encoderText = lines.pop() ?? "";
+		for (const line of lines) {
+			const match = /^out_time_us=(\d+)$/.exec(line.trim());
+			if (!match || metadata.duration <= 0) continue;
+			const seconds = Number(match[1]) / 1_000_000;
+			const progress = clampProgress({
+				value: 78 + (seconds / metadata.duration) * 20,
+			});
+			if (progress <= lastProgress) continue;
+			lastProgress = progress;
+			onProgress?.({ progress, status: "正在生成透明视频..." });
+		}
+	});
+	return waitForPersonCutoutProcesses({
+		processes: [{ child: encoder, label: "透明视频编码" }],
+		signal,
+	});
 }
 
 async function preparePersonCutoutInference({
-  ffmpegPath,
-  metadata,
-  onProgress,
-  runtime,
-  settings,
-  signal,
-  sourcePath,
+	ffmpegPath,
+	metadata,
+	onProgress,
+	runtime,
+	settings,
+	signal,
+	sourcePath,
 }: {
-  ffmpegPath: string;
-  metadata: VideoMetadata;
-  onProgress?: ProgressCallback;
-  runtime: ReadyRuntime;
-  settings: PersonCutoutCacheIdentity["settings"];
-  signal?: AbortSignal;
-  sourcePath: string;
+	ffmpegPath: string;
+	metadata: VideoMetadata;
+	onProgress?: ProgressCallback;
+	runtime: ReadyRuntime;
+	settings: PersonCutoutCacheIdentity["settings"];
+	signal?: AbortSignal;
+	sourcePath: string;
 }): Promise<CompletedPersonCutoutInference> {
-  let alphaCache: PersonCutoutMaskCacheEntry | null = null;
-  const completedImplementation = await executeTemattingWithFallback({
-    execute: async (implementation) => {
-      alphaCache = await ensureMaskCache({
-        blendImplementation: implementation,
-        ffmpegPath,
-        metadata,
-        onProgress,
-        runtime,
-        settings,
-        signal,
-        sourcePath,
-      });
-    },
-    onFallback: (error) => {
-      console.warn(
-        "Native matting validation failed; retrying the compatible path.",
-        error,
-      );
-      onProgress?.({
-        progress: 8,
-        status: "硬件校验未通过，正在切换稳定模式...",
-      });
-    },
-    preferred: runtime.blendImplementation,
-  });
-  if (!alphaCache) throw new Error("人物蒙版推理未生成缓存");
-  const provenance = resolveTemattingOutputProvenance({
-    completedImplementation,
-    pipelineDescriptor: runtime.pipelineDescriptor,
-    preferredImplementation: runtime.blendImplementation,
-  });
-  return {
-    alphaCache,
-    blendImplementation: provenance.blendImplementation,
-    completedImplementation,
-    nativeMetalCanary: provenance.nativeMetalCanary,
-  };
+	let alphaCache: PersonCutoutMaskCacheEntry | null = null;
+	const completedImplementation = await executeTemattingWithFallback({
+		execute: async (implementation) => {
+			alphaCache = await ensureMaskCache({
+				blendImplementation: implementation,
+				ffmpegPath,
+				metadata,
+				onProgress,
+				runtime,
+				settings,
+				signal,
+				sourcePath,
+			});
+		},
+		onFallback: (error) => {
+			console.warn(
+				"Native matting validation failed; retrying the compatible path.",
+				error
+			);
+			onProgress?.({
+				progress: 8,
+				status: "硬件校验未通过，正在切换稳定模式...",
+			});
+		},
+		preferred: runtime.blendImplementation,
+	});
+	if (!alphaCache) throw new Error("人物蒙版推理未生成缓存");
+	const provenance = resolveTemattingOutputProvenance({
+		completedImplementation,
+		pipelineDescriptor: runtime.pipelineDescriptor,
+		preferredImplementation: runtime.blendImplementation,
+	});
+	return {
+		alphaCache,
+		blendImplementation: provenance.blendImplementation,
+		completedImplementation,
+		nativeMetalCanary: provenance.nativeMetalCanary,
+	};
 }
 
 function parseFrameRate({ value }: { value: string }) {
-  const [numeratorText, denominatorText = "1"] = value.split("/");
-  const numerator = Number(numeratorText);
-  const denominator = Number(denominatorText);
-  if (
-    !Number.isFinite(numerator) ||
-    !Number.isFinite(denominator) ||
-    denominator <= 0
-  ) {
-    throw new Error("无法读取视频帧率");
-  }
-  return numerator / denominator;
+	const [numeratorText, denominatorText = "1"] = value.split("/");
+	const numerator = Number(numeratorText);
+	const denominator = Number(denominatorText);
+	if (
+		!Number.isFinite(numerator) ||
+		!Number.isFinite(denominator) ||
+		denominator <= 0
+	) {
+		throw new Error("无法读取视频帧率");
+	}
+	return numerator / denominator;
 }
 
 async function countVideoFrames({
-  ffprobePath,
-  signal,
-  sourcePath,
+	ffprobePath,
+	signal,
+	sourcePath,
 }: {
-  ffprobePath: string;
-  signal?: AbortSignal;
-  sourcePath: string;
+	ffprobePath: string;
+	signal?: AbortSignal;
+	sourcePath: string;
 }) {
-  const { stdout } = await execFileAsync(
-    ffprobePath,
-    [
-      "-v",
-      "error",
-      "-count_frames",
-      "-select_streams",
-      "v:0",
-      "-show_entries",
-      "stream=nb_read_frames",
-      "-of",
-      "default=noprint_wrappers=1:nokey=1",
-      sourcePath,
-    ],
-    { maxBuffer: 4 * 1024 * 1024, signal },
-  );
-  return stdout.trim().split(/\s+/)[0];
+	const { stdout } = await execFileAsync(
+		ffprobePath,
+		[
+			"-v",
+			"error",
+			"-count_frames",
+			"-select_streams",
+			"v:0",
+			"-show_entries",
+			"stream=nb_read_frames",
+			"-of",
+			"default=noprint_wrappers=1:nokey=1",
+			sourcePath,
+		],
+		{ maxBuffer: 4 * 1024 * 1024, signal }
+	);
+	return stdout.trim().split(/\s+/)[0];
 }
 
 async function probeVideo({
-  signal,
-  sourcePath,
+	signal,
+	sourcePath,
 }: {
-  signal?: AbortSignal;
-  sourcePath: string;
+	signal?: AbortSignal;
+	sourcePath: string;
 }) {
-  const ffprobePath = await getFFprobePath();
-  const { stdout } = await execFileAsync(
-    ffprobePath,
-    [
-      "-v",
-      "error",
-      "-show_entries",
-      "stream=codec_type,width,height,avg_frame_rate,nb_frames:stream_tags=rotate:stream_side_data=rotation:format=duration",
-      "-of",
-      "json",
-      sourcePath,
-    ],
-    { maxBuffer: 4 * 1024 * 1024, signal },
-  );
-  const value = JSON.parse(stdout) as {
-    streams?: Array<{
-      codec_type?: string;
-      width?: number;
-      height?: number;
-      avg_frame_rate?: string;
-      nb_frames?: string;
-      side_data_list?: Array<{ rotation?: number | string }>;
-      tags?: { rotate?: string };
-    }>;
-    format?: { duration?: string };
-  };
-  const video = value.streams?.find((stream) => stream.codec_type === "video");
-  const duration = Number(value.format?.duration);
-  if (
-    !video?.width ||
-    !video.height ||
-    !video.avg_frame_rate ||
-    !Number.isFinite(duration)
-  ) {
-    throw new Error("无法读取视频信息");
-  }
-  const displayDimensions = resolveAutorotatedVideoDimensions({
-    height: video.height,
-    sideDataList: video.side_data_list,
-    tags: video.tags,
-    width: video.width,
-  });
-  const frameRate = parseFrameRate({ value: video.avg_frame_rate });
-  const declaredFrameCount = Number(video.nb_frames);
-  const readFrames =
-    Number.isSafeInteger(declaredFrameCount) && declaredFrameCount > 0
-      ? undefined
-      : await countVideoFrames({ ffprobePath, signal, sourcePath });
-  return {
-    width: displayDimensions.width,
-    height: displayDimensions.height,
-    duration,
-    frameCountExpectation: resolvePersonCutoutFrameCountExpectation({
-      declaredFrames: video.nb_frames,
-      duration,
-      frameRate,
-      readFrames,
-    }),
-    frameRate,
-    hasAudio:
-      value.streams?.some((stream) => stream.codec_type === "audio") === true,
-  } satisfies VideoMetadata;
+	const ffprobePath = await getFFprobePath();
+	const { stdout } = await execFileAsync(
+		ffprobePath,
+		[
+			"-v",
+			"error",
+			"-show_entries",
+			"stream=codec_type,width,height,avg_frame_rate,nb_frames:stream_tags=rotate:stream_side_data=rotation:format=duration",
+			"-of",
+			"json",
+			sourcePath,
+		],
+		{ maxBuffer: 4 * 1024 * 1024, signal }
+	);
+	const value = JSON.parse(stdout) as {
+		streams?: Array<{
+			codec_type?: string;
+			width?: number;
+			height?: number;
+			avg_frame_rate?: string;
+			nb_frames?: string;
+			side_data_list?: Array<{ rotation?: number | string }>;
+			tags?: { rotate?: string };
+		}>;
+		format?: { duration?: string };
+	};
+	const video = value.streams?.find((stream) => stream.codec_type === "video");
+	const duration = Number(value.format?.duration);
+	if (
+		!video?.width ||
+		!video.height ||
+		!video.avg_frame_rate ||
+		!Number.isFinite(duration)
+	) {
+		throw new Error("无法读取视频信息");
+	}
+	const displayDimensions = resolveAutorotatedVideoDimensions({
+		height: video.height,
+		sideDataList: video.side_data_list,
+		tags: video.tags,
+		width: video.width,
+	});
+	const frameRate = parseFrameRate({ value: video.avg_frame_rate });
+	const declaredFrameCount = Number(video.nb_frames);
+	const readFrames =
+		Number.isSafeInteger(declaredFrameCount) && declaredFrameCount > 0
+			? undefined
+			: await countVideoFrames({ ffprobePath, signal, sourcePath });
+	return {
+		width: displayDimensions.width,
+		height: displayDimensions.height,
+		duration,
+		frameCountExpectation: resolvePersonCutoutFrameCountExpectation({
+			declaredFrames: video.nb_frames,
+			duration,
+			frameRate,
+			readFrames,
+		}),
+		frameRate,
+		hasAudio:
+			value.streams?.some((stream) => stream.codec_type === "audio") === true,
+	} satisfies VideoMetadata;
 }
 
 async function validateSourcePath({ sourcePath }: { sourcePath: string }) {
-  if (!path.isAbsolute(sourcePath)) throw new Error("视频文件路径无效");
-  const sourceStat = await stat(sourcePath);
-  if (!sourceStat.isFile()) throw new Error("视频文件不存在");
+	if (!path.isAbsolute(sourcePath)) throw new Error("视频文件路径无效");
+	const sourceStat = await stat(sourcePath);
+	if (!sourceStat.isFile()) throw new Error("视频文件不存在");
 }
 
 export async function renderJianyingPersonCutout({
-  onProgress,
-  signal,
-  sourcePath,
-  settings,
+	onProgress,
+	signal,
+	sourcePath,
+	settings,
 }: {
-  onProgress?: ProgressCallback;
-  signal?: AbortSignal;
-  sourcePath: string;
-  settings: {
-    threshold: number;
-    temporalSmoothing: number;
-    edgeShift: number;
-    feather: number;
-  };
+	onProgress?: ProgressCallback;
+	signal?: AbortSignal;
+	sourcePath: string;
+	settings: {
+		threshold: number;
+		temporalSmoothing: number;
+		edgeShift: number;
+		feather: number;
+	};
 }): Promise<JianyingPersonCutoutRenderResult> {
-  if (signal?.aborted) throw createPersonCutoutAbortError();
-  onProgress?.({ progress: 2, status: "正在检查视频..." });
-  await validateSourcePath({ sourcePath });
-  const portraitRuntime = await resolveRuntime();
-  throwIfPersonCutoutAborted({ signal });
-  if (!portraitRuntime) throw new Error("精细抠像所需的本机模型未就绪");
-  const metadata = await probeVideo({ signal, sourcePath });
-  throwIfPersonCutoutAborted({ signal });
-  const ffmpegPath = await getFFmpegPath();
-  const selection = await selectInferenceRuntime({
-    ffmpegPath,
-    metadata,
-    portraitRuntime,
-    settings,
-    signal,
-    sourcePath,
-  });
-  const outputDirectory = await mkdtemp(
-    path.join(os.tmpdir(), "qcut-person-cutout-"),
-  );
-  const outputPath = path.join(outputDirectory, "person-cutout.webm");
-  try {
-    onProgress?.({ progress: 8, status: "正在检查人物蒙版缓存..." });
-    const pipelineAttempt = await executePersonCutoutInferencePipeline({
-      executeInference: async (candidateRuntime) =>
-        preparePersonCutoutInference({
-          ffmpegPath,
-          metadata,
-          onProgress,
-          runtime: candidateRuntime,
-          settings,
-          signal,
-          sourcePath,
-        }),
-      fallbackRuntimes: selection.fallbackRuntimes,
-      finalize: async ({ inferenceResult, runtime }) => {
-        await runTransparentEncoder({
-          alphaCache: inferenceResult.alphaCache,
-          blendImplementation: inferenceResult.completedImplementation,
-          ffmpegPath,
-          metadata,
-          nativeMetalCanary: inferenceResult.nativeMetalCanary,
-          onProgress,
-          outputPath,
-          runtime,
-          signal,
-          sourcePath,
-          workingDirectory: outputDirectory,
-        });
-        return inferenceResult.alphaCache.frameCount;
-      },
-      onFallback: ({ error, failedRuntime, nextRuntime }) => {
-        const videoObjectCandidate = failedRuntime.videoObject;
-        if (
-          failedRuntime.modelRoute === "video-object" &&
-          videoObjectCandidate
-        ) {
-          const circuitOpened = videoObjectRuntimeCircuitBreaker.reject({
-            capabilitySha256: videoObjectCandidate.capabilitySha256,
-            error,
-          });
-          if (circuitOpened) {
-            console.warn(
-              "QCut rejected the video-object candidate after its confirmed hostless Alpha signature.",
-              {
-                capabilitySha256: videoObjectCandidate.capabilitySha256,
-                providerCapability: videoObjectCandidate.providerCapability,
-              },
-            );
-          }
-        }
-        if (nextRuntime.modelRoute === "video-object") {
-          console.warn(
-            "Video-object provider failed; retrying the next pinned provider.",
-            error,
-          );
-          onProgress?.({
-            progress: 8,
-            status: "主体分析引擎不可用，正在切换备用引擎...",
-          });
-          return;
-        }
-        console.warn(
-          "Advanced person-cutout route failed; retrying portrait GRU.",
-          error,
-        );
-        onProgress?.({
-          progress: 8,
-          status: "主体分析不可用，正在切换精细人物抠像...",
-        });
-      },
-      portraitRuntime,
-      selectedRuntime: selection.runtime,
-    });
-    if (signal?.aborted) throw createPersonCutoutAbortError();
-    const { inferenceAttempt } = pipelineAttempt;
-    const actualRuntime = inferenceAttempt.runtime;
-    return {
-      blendImplementation: inferenceAttempt.result.blendImplementation,
-      didModelRouteFallback:
-        selection.didSelectionFallback || inferenceAttempt.didFallback,
-      modelRoute: actualRuntime.modelRoute,
-      nativeMetalCanary: inferenceAttempt.result.nativeMetalCanary,
-      pipelineId: actualRuntime.pipelineDescriptor.pipelineId,
-      provider: actualRuntime.pipelineDescriptor.providerId,
-      refinementProvider: actualRuntime.pipelineDescriptor.refinementProvider,
-      requestedModelRoute: selection.requestedModelRoute,
-      outputPath,
-      width: metadata.width,
-      height: metadata.height,
-      duration: metadata.duration,
-      frameRate: metadata.frameRate,
-      frameCount: pipelineAttempt.finalResult,
-      hasAudio: metadata.hasAudio,
-      codec: "vp9",
-    };
-  } catch (error) {
-    await rm(outputDirectory, { recursive: true, force: true });
-    throw error;
-  }
+	if (signal?.aborted) throw createPersonCutoutAbortError();
+	onProgress?.({ progress: 2, status: "正在检查视频..." });
+	await validateSourcePath({ sourcePath });
+	const portraitRuntime = await resolveRuntime();
+	throwIfPersonCutoutAborted({ signal });
+	if (!portraitRuntime) throw new Error("精细抠像所需的本机模型未就绪");
+	const metadata = await probeVideo({ signal, sourcePath });
+	throwIfPersonCutoutAborted({ signal });
+	const ffmpegPath = await getFFmpegPath();
+	const selection = await selectInferenceRuntime({
+		ffmpegPath,
+		metadata,
+		portraitRuntime,
+		settings,
+		signal,
+		sourcePath,
+	});
+	const outputDirectory = await mkdtemp(
+		path.join(os.tmpdir(), "qcut-person-cutout-")
+	);
+	const outputPath = path.join(outputDirectory, "person-cutout.webm");
+	try {
+		onProgress?.({ progress: 8, status: "正在检查人物蒙版缓存..." });
+		const pipelineAttempt = await executePersonCutoutInferencePipeline({
+			executeInference: async (candidateRuntime) =>
+				preparePersonCutoutInference({
+					ffmpegPath,
+					metadata,
+					onProgress,
+					runtime: candidateRuntime,
+					settings,
+					signal,
+					sourcePath,
+				}),
+			fallbackRuntimes: selection.fallbackRuntimes,
+			finalize: async ({ inferenceResult, runtime }) => {
+				await runTransparentEncoder({
+					alphaCache: inferenceResult.alphaCache,
+					blendImplementation: inferenceResult.completedImplementation,
+					ffmpegPath,
+					metadata,
+					nativeMetalCanary: inferenceResult.nativeMetalCanary,
+					onProgress,
+					outputPath,
+					runtime,
+					signal,
+					sourcePath,
+					workingDirectory: outputDirectory,
+				});
+				return inferenceResult.alphaCache.frameCount;
+			},
+			onFallback: ({ error, failedRuntime, nextRuntime }) => {
+				const videoObjectCandidate = failedRuntime.videoObject;
+				if (
+					failedRuntime.modelRoute === "video-object" &&
+					videoObjectCandidate
+				) {
+					const circuitOpened = videoObjectRuntimeCircuitBreaker.reject({
+						capabilitySha256: videoObjectCandidate.capabilitySha256,
+						error,
+					});
+					if (circuitOpened) {
+						console.warn(
+							"QCut rejected the video-object candidate after its confirmed hostless Alpha signature.",
+							{
+								capabilitySha256: videoObjectCandidate.capabilitySha256,
+								providerCapability: videoObjectCandidate.providerCapability,
+							}
+						);
+					}
+				}
+				if (nextRuntime.modelRoute === "video-object") {
+					console.warn(
+						"Video-object provider failed; retrying the next pinned provider.",
+						error
+					);
+					onProgress?.({
+						progress: 8,
+						status: "主体分析引擎不可用，正在切换备用引擎...",
+					});
+					return;
+				}
+				console.warn(
+					"Advanced person-cutout route failed; retrying portrait GRU.",
+					error
+				);
+				onProgress?.({
+					progress: 8,
+					status: "主体分析不可用，正在切换精细人物抠像...",
+				});
+			},
+			portraitRuntime,
+			selectedRuntime: selection.runtime,
+		});
+		if (signal?.aborted) throw createPersonCutoutAbortError();
+		const { inferenceAttempt } = pipelineAttempt;
+		const actualRuntime = inferenceAttempt.runtime;
+		return {
+			blendImplementation: inferenceAttempt.result.blendImplementation,
+			didModelRouteFallback:
+				selection.didSelectionFallback || inferenceAttempt.didFallback,
+			modelRoute: actualRuntime.modelRoute,
+			nativeMetalCanary: inferenceAttempt.result.nativeMetalCanary,
+			pipelineId: actualRuntime.pipelineDescriptor.pipelineId,
+			provider: actualRuntime.pipelineDescriptor.providerId,
+			refinementProvider: actualRuntime.pipelineDescriptor.refinementProvider,
+			requestedModelRoute: selection.requestedModelRoute,
+			outputPath,
+			width: metadata.width,
+			height: metadata.height,
+			duration: metadata.duration,
+			frameRate: metadata.frameRate,
+			frameCount: pipelineAttempt.finalResult,
+			hasAudio: metadata.hasAudio,
+			codec: "vp9",
+		};
+	} catch (error) {
+		await rm(outputDirectory, { recursive: true, force: true });
+		throw error;
+	}
 }
 
 export async function releaseJianyingPersonCutout({
-  outputPath,
+	outputPath,
 }: {
-  outputPath: string;
+	outputPath: string;
 }) {
-  const outputDirectory = path.dirname(outputPath);
-  if (!path.basename(outputDirectory).startsWith("qcut-person-cutout-")) return;
-  await rm(outputDirectory, { recursive: true, force: true });
+	const outputDirectory = path.dirname(outputPath);
+	if (!path.basename(outputDirectory).startsWith("qcut-person-cutout-")) return;
+	await rm(outputDirectory, { recursive: true, force: true });
 }

--- a/qcut/electron/jianying-person-cutout/saliency-bridge-resolver.ts
+++ b/qcut/electron/jianying-person-cutout/saliency-bridge-resolver.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants, existsSync } from "node:fs";
-import { access, mkdir, readFile } from "node:fs/promises";
+import { access, mkdir, readFile, rename, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -10,12 +10,7 @@ const execFileAsync = promisify(execFile);
 export const JIANYING_SALIENCY_BRIDGE_FILE_NAME =
 	"jianying-saliency-script-bridge";
 const SOURCE_RELATIVE_PATHS = [
-	path.join(
-		"electron",
-		"jianying-person-cutout",
-		"native",
-		"alpha-resize.cpp"
-	),
+	path.join("electron", "jianying-person-cutout", "native", "alpha-resize.cpp"),
 	path.join(
 		"electron",
 		"jianying-person-cutout",
@@ -49,12 +44,7 @@ const SOURCE_RELATIVE_PATHS = [
 ] as const;
 const FINGERPRINT_RELATIVE_PATHS = [
 	...SOURCE_RELATIVE_PATHS,
-	path.join(
-		"electron",
-		"jianying-person-cutout",
-		"native",
-		"alpha-resize.hpp"
-	),
+	path.join("electron", "jianying-person-cutout", "native", "alpha-resize.hpp"),
 	path.join(
 		"electron",
 		"jianying-person-cutout",
@@ -157,6 +147,7 @@ export async function compileJianyingSaliencyBridge({
 }) {
 	if (await isExecutable({ filePath: outputPath })) return outputPath;
 	await mkdir(path.dirname(outputPath), { recursive: true });
+	const stagingPath = `${outputPath}.${randomUUID()}.tmp`;
 	await execFileAsync(
 		"xcrun",
 		[
@@ -173,12 +164,14 @@ export async function compileJianyingSaliencyBridge({
 			"OpenGL",
 			"-ldl",
 			"-o",
-			outputPath,
+			stagingPath,
 		],
 		{ maxBuffer: 16 * 1024 * 1024 }
 	);
-	if (!(await isExecutable({ filePath: outputPath }))) {
+	if (!(await isExecutable({ filePath: stagingPath }))) {
+		await rm(stagingPath, { force: true });
 		throw new Error("剪映显著性抠像本机桥构建后不可执行");
 	}
+	await rename(stagingPath, outputPath);
 	return outputPath;
 }

--- a/qcut/electron/jianying-person-cutout/saliency-bridge-resolver.ts
+++ b/qcut/electron/jianying-person-cutout/saliency-bridge-resolver.ts
@@ -26,6 +26,12 @@ const SOURCE_RELATIVE_PATHS = [
 		"electron",
 		"jianying-person-cutout",
 		"native",
+		"effect-input-probe.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
 		"effect-texture-context.cpp"
 	),
 	path.join(
@@ -48,6 +54,12 @@ const FINGERPRINT_RELATIVE_PATHS = [
 		"jianying-person-cutout",
 		"native",
 		"alpha-resize.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"effect-input-probe.hpp"
 	),
 	path.join(
 		"electron",

--- a/qcut/electron/jianying-person-cutout/saliency-bridge-resolver.ts
+++ b/qcut/electron/jianying-person-cutout/saliency-bridge-resolver.ts
@@ -1,0 +1,172 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants, existsSync } from "node:fs";
+import { access, mkdir, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+export const JIANYING_SALIENCY_BRIDGE_FILE_NAME =
+	"jianying-saliency-script-bridge";
+const SOURCE_RELATIVE_PATHS = [
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-resize.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-refinement.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"effect-texture-context.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"video-object-alpha-quality.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"saliency-script-bridge.cpp"
+	),
+] as const;
+const FINGERPRINT_RELATIVE_PATHS = [
+	...SOURCE_RELATIVE_PATHS,
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-resize.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"effect-texture-context.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"video-object-alpha-quality.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-refinement.hpp"
+	),
+] as const;
+
+async function isExecutable({ filePath }: { filePath: string }) {
+	try {
+		await access(filePath, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function findProjectRoot() {
+	const candidates = [
+		process.cwd(),
+		path.resolve(__dirname, "..", ".."),
+		path.resolve(__dirname, "..", "..", ".."),
+	];
+	return (
+		candidates.find((candidate) =>
+			FINGERPRINT_RELATIVE_PATHS.every((relativePath) =>
+				existsSync(path.join(candidate, relativePath))
+			)
+		) ?? null
+	);
+}
+
+function packagedBridgePath() {
+	const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string })
+		.resourcesPath;
+	return resourcesPath
+		? path.join(resourcesPath, "bin", JIANYING_SALIENCY_BRIDGE_FILE_NAME)
+		: null;
+}
+
+export async function resolveJianyingSaliencyBridge() {
+	if (process.platform !== "darwin") return null;
+	const configured = process.env.QCUT_JIANYING_SALIENCY_BRIDGE;
+	const packaged = packagedBridgePath();
+	for (const candidate of [configured, packaged]) {
+		if (candidate && (await isExecutable({ filePath: candidate }))) {
+			return candidate;
+		}
+	}
+	const projectRoot = findProjectRoot();
+	if (!projectRoot) return null;
+	const sourceContents = await Promise.all(
+		FINGERPRINT_RELATIVE_PATHS.map((relativePath) =>
+			readFile(path.join(projectRoot, relativePath))
+		)
+	);
+	const sourceHash = createHash("sha256");
+	for (const contents of sourceContents) sourceHash.update(contents);
+	const fingerprint = sourceHash
+		.update(process.arch)
+		.digest("hex")
+		.slice(0, 16);
+	const outputPath = path.join(
+		os.homedir(),
+		"Library",
+		"Caches",
+		"QCut",
+		"jianying-saliency-script-bridge",
+		fingerprint,
+		JIANYING_SALIENCY_BRIDGE_FILE_NAME
+	);
+	if (await isExecutable({ filePath: outputPath })) return outputPath;
+	return compileJianyingSaliencyBridge({ projectRoot, outputPath });
+}
+
+export async function compileJianyingSaliencyBridge({
+	projectRoot,
+	outputPath,
+}: {
+	projectRoot: string;
+	outputPath: string;
+}) {
+	if (await isExecutable({ filePath: outputPath })) return outputPath;
+	await mkdir(path.dirname(outputPath), { recursive: true });
+	await execFileAsync(
+		"xcrun",
+		[
+			"clang++",
+			"-DGL_SILENCE_DEPRECATION",
+			"-std=c++20",
+			"-Wall",
+			"-Wextra",
+			"-Werror",
+			...SOURCE_RELATIVE_PATHS.map((relativePath) =>
+				path.join(projectRoot, relativePath)
+			),
+			"-framework",
+			"OpenGL",
+			"-ldl",
+			"-o",
+			outputPath,
+		],
+		{ maxBuffer: 16 * 1024 * 1024 }
+	);
+	if (!(await isExecutable({ filePath: outputPath }))) {
+		throw new Error("剪映显著性抠像本机桥构建后不可执行");
+	}
+	return outputPath;
+}

--- a/qcut/electron/jianying-person-cutout/saliency-runtime.ts
+++ b/qcut/electron/jianying-person-cutout/saliency-runtime.ts
@@ -1,0 +1,143 @@
+import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import { resolveJianyingSaliencyBridge } from "./saliency-bridge-resolver.js";
+import {
+	firstMatchingDirectory,
+	firstMatchingFile,
+	sha256File,
+	VIDEO_FUSION_LIBRARY_SHA256,
+} from "./runtime-assets.js";
+const MODEL_FILES = [
+	{
+		name: "saliency_matting_v1.0_size0_md55882cbfb5e9c1f205cd599d3c5d0833a.model",
+		sha256:
+			"ac2ae6badafc6a94641dc59b5844762676eee71b218785bfad37169eea380341",
+	},
+	{
+		name: "saliency_script_for_cc_v1.2_size0_md57b5c3cdeb513b9e4d65f0e3fd5909100.model",
+		sha256:
+			"4d7fbc2ec820f28f3d0c8531a63d53a338d091a989109f20ee67377c4f594c01",
+	},
+	{
+		name: "video_saliency_seg_bce_v1.0_size100_md57b601afc96d910a40a4dd17c0c43c96a.model",
+		sha256:
+			"346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+	},
+] as const;
+const EFFECT_FILES = [
+	{
+		name: "algorithmConfig.json",
+		sha256:
+			"58ae549c87d82c487e546732ab4e4f91de6b7db8773b3048bf1753b4871788ef",
+	},
+	{
+		name: "config.json",
+		sha256:
+			"652ad89364eeaf614d6e98c180ad3403420ff641e8f8b8e9d9209c07880453f0",
+	},
+] as const;
+
+export interface JianyingSaliencyRuntime {
+	bridgePath: string;
+	effectDirectory: string;
+	frameworkDirectory: string;
+	libraryPath: string;
+	modelDirectory: string;
+	modelSha256: string;
+	processorSha256: string;
+}
+
+export async function resolveJianyingSaliencyRuntime(): Promise<JianyingSaliencyRuntime | null> {
+	if (process.platform !== "darwin") return null;
+	const privateRuntimeRoot = path.join(
+		os.homedir(),
+		"Library",
+		"Application Support",
+		"QCut",
+		"PrivateRuntimes"
+	);
+	const jianyingCacheRoot = path.join(
+		os.homedir(),
+		"Movies",
+		"JianyingPro",
+		"User Data",
+		"Cache",
+		"effect"
+	);
+	const configuredRoot = process.env.QCUT_JIANYING_SALIENCY_RUNTIME;
+	const modelDirectory = await firstMatchingDirectory({
+		candidates: [
+			...(configuredRoot ? [path.join(configuredRoot, "Models")] : []),
+			path.join(privateRuntimeRoot, "JianyingSaliency", "current", "Models"),
+			path.join(privateRuntimeRoot, "JianyingFilter", "current", "Models"),
+			path.join(jianyingCacheRoot, "model"),
+		],
+		files: MODEL_FILES,
+	});
+	const effectDirectory = await firstMatchingDirectory({
+		candidates: [
+			...(configuredRoot ? [path.join(configuredRoot, "Effect")] : []),
+			path.join(privateRuntimeRoot, "JianyingSaliency", "current", "Effect"),
+			path.join(
+				jianyingCacheRoot,
+				"7366590389928595994",
+				"94715bdc841b34cd5451b4b9c181bde4",
+				"saliency_matting"
+			),
+		],
+		files: EFFECT_FILES,
+	});
+	const libraryCandidates = [
+		...(configuredRoot
+			? [path.join(configuredRoot, "Frameworks", "libcccreator.dylib")]
+			: []),
+		path.join(
+			privateRuntimeRoot,
+			"JianyingSaliency",
+			"current",
+			"Frameworks",
+			"libcccreator.dylib"
+		),
+		path.join(
+			"/Applications",
+			"VideoFusion-macOS.app",
+			"Contents",
+			"Frameworks",
+			"libcccreator.dylib"
+		),
+	];
+	const libraryPath = await firstMatchingFile({
+		candidates: libraryCandidates,
+		sha256: VIDEO_FUSION_LIBRARY_SHA256,
+	});
+	const bridgePath = await resolveJianyingSaliencyBridge();
+	if (!bridgePath || !libraryPath || !modelDirectory || !effectDirectory) {
+		return null;
+	}
+	const [bridgeHash, ...assetHashes] = await Promise.all([
+		sha256File({ filePath: bridgePath }),
+		...MODEL_FILES.map(({ name }) =>
+			sha256File({ filePath: path.join(modelDirectory, name) })
+		),
+		...EFFECT_FILES.map(({ name }) =>
+			sha256File({ filePath: path.join(effectDirectory, name) })
+		),
+	]);
+	if (!bridgeHash || assetHashes.some((hash) => hash === null)) return null;
+	const modelSha256 = createHash("sha256")
+		.update(assetHashes.join(""))
+		.digest("hex");
+	return {
+		bridgePath,
+		effectDirectory,
+		frameworkDirectory: path.dirname(libraryPath),
+		libraryPath,
+		modelDirectory,
+		modelSha256,
+		processorSha256: createHash("sha256")
+			.update(bridgeHash)
+			.update(VIDEO_FUSION_LIBRARY_SHA256)
+			.digest("hex"),
+	};
+}

--- a/qcut/electron/jianying-person-cutout/saliency-runtime.ts
+++ b/qcut/electron/jianying-person-cutout/saliency-runtime.ts
@@ -11,30 +11,25 @@ import {
 const MODEL_FILES = [
 	{
 		name: "saliency_matting_v1.0_size0_md55882cbfb5e9c1f205cd599d3c5d0833a.model",
-		sha256:
-			"ac2ae6badafc6a94641dc59b5844762676eee71b218785bfad37169eea380341",
+		sha256: "ac2ae6badafc6a94641dc59b5844762676eee71b218785bfad37169eea380341",
 	},
 	{
 		name: "saliency_script_for_cc_v1.2_size0_md57b5c3cdeb513b9e4d65f0e3fd5909100.model",
-		sha256:
-			"4d7fbc2ec820f28f3d0c8531a63d53a338d091a989109f20ee67377c4f594c01",
+		sha256: "4d7fbc2ec820f28f3d0c8531a63d53a338d091a989109f20ee67377c4f594c01",
 	},
 	{
 		name: "video_saliency_seg_bce_v1.0_size100_md57b601afc96d910a40a4dd17c0c43c96a.model",
-		sha256:
-			"346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+		sha256: "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
 	},
 ] as const;
 const EFFECT_FILES = [
 	{
 		name: "algorithmConfig.json",
-		sha256:
-			"58ae549c87d82c487e546732ab4e4f91de6b7db8773b3048bf1753b4871788ef",
+		sha256: "58ae549c87d82c487e546732ab4e4f91de6b7db8773b3048bf1753b4871788ef",
 	},
 	{
 		name: "config.json",
-		sha256:
-			"652ad89364eeaf614d6e98c180ad3403420ff641e8f8b8e9d9209c07880453f0",
+		sha256: "652ad89364eeaf614d6e98c180ad3403420ff641e8f8b8e9d9209c07880453f0",
 	},
 ] as const;
 

--- a/qcut/electron/jianying-person-cutout/tematting-blend.ts
+++ b/qcut/electron/jianying-person-cutout/tematting-blend.ts
@@ -1,106 +1,110 @@
 import type { PersonCutoutModelRoute } from "./mask-cache.js";
 import {
-  JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
-  type PersonCutoutPipelineDescriptor,
+	JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+	type PersonCutoutPipelineDescriptor,
 } from "./pipeline-descriptor.js";
 
 export const TEMATTING_COMPATIBLE_BLEND = "TEMattingBlendEffectV2-compatible";
 export const TEMATTING_NATIVE_METAL_CANARY =
-  "TEMattingBlendEffectV2-native-metal-canary";
+	"TEMattingBlendEffectV2-native-metal-canary";
 export const TEMATTING_VENDOR_V2_EXACT_BLEND =
-  "TEMattingBlendEffectV2-vendor-exact";
+	"TEMattingBlendEffectV2-vendor-exact";
 
 export type TemattingBlendImplementation =
-  typeof TEMATTING_NATIVE_METAL_CANARY | typeof TEMATTING_COMPATIBLE_BLEND;
+	| typeof TEMATTING_NATIVE_METAL_CANARY
+	| typeof TEMATTING_COMPATIBLE_BLEND;
 export type TemattingOutputBlendImplementation =
-  typeof TEMATTING_COMPATIBLE_BLEND | typeof TEMATTING_VENDOR_V2_EXACT_BLEND;
+	| typeof TEMATTING_COMPATIBLE_BLEND
+	| typeof TEMATTING_VENDOR_V2_EXACT_BLEND;
 
 export type TemattingNativeMetalCanaryStatus =
-  "failed-fallback" | "not-run" | "passed";
+	| "failed-fallback"
+	| "not-run"
+	| "passed";
 
 export function resolveTemattingOutputProvenance({
-  completedImplementation,
-  pipelineDescriptor,
-  preferredImplementation,
+	completedImplementation,
+	pipelineDescriptor,
+	preferredImplementation,
 }: {
-  completedImplementation: TemattingBlendImplementation;
-  pipelineDescriptor?: PersonCutoutPipelineDescriptor;
-  preferredImplementation: TemattingBlendImplementation;
+	completedImplementation: TemattingBlendImplementation;
+	pipelineDescriptor?: PersonCutoutPipelineDescriptor;
+	preferredImplementation: TemattingBlendImplementation;
 }) {
-  const blendImplementation = resolveTemattingOutputBlendImplementation({
-    pipelineDescriptor,
-  });
-  if (completedImplementation === TEMATTING_NATIVE_METAL_CANARY) {
-    return {
-      blendImplementation,
-      nativeMetalCanary: "passed" as const,
-    };
-  }
-  return {
-    blendImplementation,
-    nativeMetalCanary:
-      preferredImplementation === TEMATTING_NATIVE_METAL_CANARY
-        ? ("failed-fallback" as const)
-        : ("not-run" as const),
-  };
+	const blendImplementation = resolveTemattingOutputBlendImplementation({
+		pipelineDescriptor,
+	});
+	if (completedImplementation === TEMATTING_NATIVE_METAL_CANARY) {
+		return {
+			blendImplementation,
+			nativeMetalCanary: "passed" as const,
+		};
+	}
+	return {
+		blendImplementation,
+		nativeMetalCanary:
+			preferredImplementation === TEMATTING_NATIVE_METAL_CANARY
+				? ("failed-fallback" as const)
+				: ("not-run" as const),
+	};
 }
 
 export function resolveTemattingOutputBlendImplementation({
-  pipelineDescriptor,
+	pipelineDescriptor,
 }: {
-  pipelineDescriptor?: PersonCutoutPipelineDescriptor;
+	pipelineDescriptor?: PersonCutoutPipelineDescriptor;
 }): TemattingOutputBlendImplementation {
-  return pipelineDescriptor?.pipelineId ===
-    JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE.pipelineId
-    ? TEMATTING_VENDOR_V2_EXACT_BLEND
-    : TEMATTING_COMPATIBLE_BLEND;
+	return pipelineDescriptor?.pipelineId ===
+		JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE.pipelineId
+		? TEMATTING_VENDOR_V2_EXACT_BLEND
+		: TEMATTING_COMPATIBLE_BLEND;
 }
 
 export function buildTemattingTransparentBlendFilter() {
-  return "[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]";
+	return "[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]";
 }
 
 export function buildTemattingOutputMetadata({
-  implementation,
-  modelName = "tt_matting_video_gru_v1.0",
-  modelRoute = "portrait-gru",
-  nativeMetalCanary,
-  pipelineDescriptor,
+	implementation,
+	modelName = "tt_matting_video_gru_v1.0",
+	modelRoute = "portrait-gru",
+	nativeMetalCanary,
+	pipelineDescriptor,
 }: {
-  implementation: TemattingBlendImplementation;
-  modelName?: string;
-  modelRoute?: PersonCutoutModelRoute;
-  nativeMetalCanary?: TemattingNativeMetalCanaryStatus;
-  pipelineDescriptor?: PersonCutoutPipelineDescriptor;
+	implementation: TemattingBlendImplementation;
+	modelName?: string;
+	modelRoute?: PersonCutoutModelRoute;
+	nativeMetalCanary?: TemattingNativeMetalCanaryStatus;
+	pipelineDescriptor?: PersonCutoutPipelineDescriptor;
 }) {
-  const resolvedNativeMetalCanary =
-    nativeMetalCanary ??
-    (implementation === TEMATTING_NATIVE_METAL_CANARY ? "passed" : "not-run");
-  const outputBlendImplementation = resolveTemattingOutputBlendImplementation({
-    pipelineDescriptor,
-  });
-  const metadata = [
-    "-metadata:s:v:0",
-    `qcut_matting_blend=${outputBlendImplementation}`,
-    "-metadata:s:v:0",
-    `qcut_matting_model=${modelName}`,
-    "-metadata:s:v:0",
-    `qcut_matting_route=${modelRoute}`,
-  ];
-  if (resolvedNativeMetalCanary !== "not-run") {
-    metadata.push(
-      "-metadata:s:v:0",
-      `qcut_matting_native_canary=${resolvedNativeMetalCanary}`,
-    );
-  }
-  if (!pipelineDescriptor) return metadata;
-  return [
-    ...metadata,
-    "-metadata:s:v:0",
-    `qcut_matting_provider=${pipelineDescriptor.providerId}`,
-    "-metadata:s:v:0",
-    `qcut_matting_pipeline=${pipelineDescriptor.pipelineId}`,
-    "-metadata:s:v:0",
-    `qcut_matting_refinement=${pipelineDescriptor.refinementProvider}`,
-  ];
+	const resolvedNativeMetalCanary =
+		nativeMetalCanary ??
+		(implementation === TEMATTING_NATIVE_METAL_CANARY ? "passed" : "not-run");
+	const outputBlendImplementation = resolveTemattingOutputBlendImplementation({
+		pipelineDescriptor,
+	});
+	const metadata = [
+		"-metadata:s:v:0",
+		`qcut_matting_blend=${outputBlendImplementation}`,
+		"-metadata:s:v:0",
+		`qcut_matting_model=${modelName}`,
+		"-metadata:s:v:0",
+		`qcut_matting_route=${modelRoute}`,
+	];
+	if (resolvedNativeMetalCanary !== "not-run") {
+		metadata.push(
+			"-metadata:s:v:0",
+			`qcut_matting_native_canary=${resolvedNativeMetalCanary}`
+		);
+	}
+	if (!pipelineDescriptor) return metadata;
+	return [
+		...metadata,
+		"-metadata:s:v:0",
+		`qcut_matting_provider=${pipelineDescriptor.providerId}`,
+		"-metadata:s:v:0",
+		`qcut_matting_pipeline=${pipelineDescriptor.pipelineId}`,
+		"-metadata:s:v:0",
+		`qcut_matting_refinement=${pipelineDescriptor.refinementProvider}`,
+	];
 }

--- a/qcut/electron/jianying-person-cutout/tematting-blend.ts
+++ b/qcut/electron/jianying-person-cutout/tematting-blend.ts
@@ -1,0 +1,32 @@
+import type { PersonCutoutModelRoute } from "./mask-cache.js";
+
+export const TEMATTING_NATIVE_METAL_BLEND =
+	"TEMattingBlendEffectV2-native-metal";
+export const TEMATTING_COMPATIBLE_BLEND = "TEMattingBlendEffectV2-compatible";
+
+export type TemattingBlendImplementation =
+	| typeof TEMATTING_NATIVE_METAL_BLEND
+	| typeof TEMATTING_COMPATIBLE_BLEND;
+
+export function buildTemattingTransparentBlendFilter() {
+	return "[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]";
+}
+
+export function buildTemattingOutputMetadata({
+	implementation,
+	modelName = "tt_matting_video_gru_v1.0",
+	modelRoute = "portrait-gru",
+}: {
+	implementation: TemattingBlendImplementation;
+	modelName?: string;
+	modelRoute?: PersonCutoutModelRoute;
+}) {
+	return [
+		"-metadata:s:v:0",
+		`qcut_matting_blend=${implementation}`,
+		"-metadata:s:v:0",
+		`qcut_matting_model=${modelName}`,
+		"-metadata:s:v:0",
+		`qcut_matting_route=${modelRoute}`,
+	];
+}

--- a/qcut/electron/jianying-person-cutout/tematting-blend.ts
+++ b/qcut/electron/jianying-person-cutout/tematting-blend.ts
@@ -1,32 +1,106 @@
 import type { PersonCutoutModelRoute } from "./mask-cache.js";
+import {
+  JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE,
+  type PersonCutoutPipelineDescriptor,
+} from "./pipeline-descriptor.js";
 
-export const TEMATTING_NATIVE_METAL_BLEND =
-	"TEMattingBlendEffectV2-native-metal";
 export const TEMATTING_COMPATIBLE_BLEND = "TEMattingBlendEffectV2-compatible";
+export const TEMATTING_NATIVE_METAL_CANARY =
+  "TEMattingBlendEffectV2-native-metal-canary";
+export const TEMATTING_VENDOR_V2_EXACT_BLEND =
+  "TEMattingBlendEffectV2-vendor-exact";
 
 export type TemattingBlendImplementation =
-	| typeof TEMATTING_NATIVE_METAL_BLEND
-	| typeof TEMATTING_COMPATIBLE_BLEND;
+  typeof TEMATTING_NATIVE_METAL_CANARY | typeof TEMATTING_COMPATIBLE_BLEND;
+export type TemattingOutputBlendImplementation =
+  typeof TEMATTING_COMPATIBLE_BLEND | typeof TEMATTING_VENDOR_V2_EXACT_BLEND;
+
+export type TemattingNativeMetalCanaryStatus =
+  "failed-fallback" | "not-run" | "passed";
+
+export function resolveTemattingOutputProvenance({
+  completedImplementation,
+  pipelineDescriptor,
+  preferredImplementation,
+}: {
+  completedImplementation: TemattingBlendImplementation;
+  pipelineDescriptor?: PersonCutoutPipelineDescriptor;
+  preferredImplementation: TemattingBlendImplementation;
+}) {
+  const blendImplementation = resolveTemattingOutputBlendImplementation({
+    pipelineDescriptor,
+  });
+  if (completedImplementation === TEMATTING_NATIVE_METAL_CANARY) {
+    return {
+      blendImplementation,
+      nativeMetalCanary: "passed" as const,
+    };
+  }
+  return {
+    blendImplementation,
+    nativeMetalCanary:
+      preferredImplementation === TEMATTING_NATIVE_METAL_CANARY
+        ? ("failed-fallback" as const)
+        : ("not-run" as const),
+  };
+}
+
+export function resolveTemattingOutputBlendImplementation({
+  pipelineDescriptor,
+}: {
+  pipelineDescriptor?: PersonCutoutPipelineDescriptor;
+}): TemattingOutputBlendImplementation {
+  return pipelineDescriptor?.pipelineId ===
+    JIANYING_BACH_VIDEO_OBJECT_PERSON_CUTOUT_PIPELINE.pipelineId
+    ? TEMATTING_VENDOR_V2_EXACT_BLEND
+    : TEMATTING_COMPATIBLE_BLEND;
+}
 
 export function buildTemattingTransparentBlendFilter() {
-	return "[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]";
+  return "[0:v:0][1:v:0]alphamerge,format=yuva420p[cutout]";
 }
 
 export function buildTemattingOutputMetadata({
-	implementation,
-	modelName = "tt_matting_video_gru_v1.0",
-	modelRoute = "portrait-gru",
+  implementation,
+  modelName = "tt_matting_video_gru_v1.0",
+  modelRoute = "portrait-gru",
+  nativeMetalCanary,
+  pipelineDescriptor,
 }: {
-	implementation: TemattingBlendImplementation;
-	modelName?: string;
-	modelRoute?: PersonCutoutModelRoute;
+  implementation: TemattingBlendImplementation;
+  modelName?: string;
+  modelRoute?: PersonCutoutModelRoute;
+  nativeMetalCanary?: TemattingNativeMetalCanaryStatus;
+  pipelineDescriptor?: PersonCutoutPipelineDescriptor;
 }) {
-	return [
-		"-metadata:s:v:0",
-		`qcut_matting_blend=${implementation}`,
-		"-metadata:s:v:0",
-		`qcut_matting_model=${modelName}`,
-		"-metadata:s:v:0",
-		`qcut_matting_route=${modelRoute}`,
-	];
+  const resolvedNativeMetalCanary =
+    nativeMetalCanary ??
+    (implementation === TEMATTING_NATIVE_METAL_CANARY ? "passed" : "not-run");
+  const outputBlendImplementation = resolveTemattingOutputBlendImplementation({
+    pipelineDescriptor,
+  });
+  const metadata = [
+    "-metadata:s:v:0",
+    `qcut_matting_blend=${outputBlendImplementation}`,
+    "-metadata:s:v:0",
+    `qcut_matting_model=${modelName}`,
+    "-metadata:s:v:0",
+    `qcut_matting_route=${modelRoute}`,
+  ];
+  if (resolvedNativeMetalCanary !== "not-run") {
+    metadata.push(
+      "-metadata:s:v:0",
+      `qcut_matting_native_canary=${resolvedNativeMetalCanary}`,
+    );
+  }
+  if (!pipelineDescriptor) return metadata;
+  return [
+    ...metadata,
+    "-metadata:s:v:0",
+    `qcut_matting_provider=${pipelineDescriptor.providerId}`,
+    "-metadata:s:v:0",
+    `qcut_matting_pipeline=${pipelineDescriptor.pipelineId}`,
+    "-metadata:s:v:0",
+    `qcut_matting_refinement=${pipelineDescriptor.refinementProvider}`,
+  ];
 }

--- a/qcut/electron/jianying-person-cutout/video-display-dimensions.ts
+++ b/qcut/electron/jianying-person-cutout/video-display-dimensions.ts
@@ -1,0 +1,41 @@
+interface VideoDisplaySideData {
+	rotation?: unknown;
+}
+
+interface VideoDisplayTags {
+	rotate?: unknown;
+}
+
+function finiteRotation({ value }: { value: unknown }) {
+	if (typeof value !== "number" && typeof value !== "string") return null;
+	const rotation = Number(value);
+	return Number.isFinite(rotation) ? rotation : null;
+}
+
+function normalizedQuarterTurn({ rotation }: { rotation: number }) {
+	const quarterTurns = Math.round(rotation / 90);
+	if (Math.abs(rotation - quarterTurns * 90) > 0.01) return 0;
+	return ((quarterTurns % 4) + 4) % 4;
+}
+
+export function resolveAutorotatedVideoDimensions({
+	height,
+	sideDataList,
+	tags,
+	width,
+}: {
+	height: number;
+	sideDataList?: VideoDisplaySideData[];
+	tags?: VideoDisplayTags;
+	width: number;
+}) {
+	const displayMatrixRotation = sideDataList
+		?.map(({ rotation }) => finiteRotation({ value: rotation }))
+		.find((rotation) => rotation !== null);
+	const tagRotation = finiteRotation({ value: tags?.rotate });
+	const rotation = displayMatrixRotation ?? tagRotation ?? 0;
+	const quarterTurn = normalizedQuarterTurn({ rotation });
+	return quarterTurn % 2 === 1
+		? { height: width, width: height }
+		: { height, width };
+}

--- a/qcut/electron/jianying-person-cutout/video-object-bach-bridge-resolver.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-bach-bridge-resolver.ts
@@ -1,0 +1,229 @@
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { constants, existsSync } from "node:fs";
+import { access, mkdir, readFile, rename, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+  withAtomicPublishLock,
+  type AtomicPublishLockTiming,
+} from "./atomic-publish-lock.js";
+import { VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER } from "./video-object-runtime-closure.js";
+
+const execFileAsync = promisify(execFile);
+export const VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME =
+  "jianying-video-object-bach-bridge";
+const MINIMUM_BRIDGE_BYTES = 4096;
+const MACH_O_MAGICS = [
+  Buffer.from([0xcf, 0xfa, 0xed, 0xfe]),
+  Buffer.from([0xfe, 0xed, 0xfa, 0xcf]),
+  Buffer.from([0xca, 0xfe, 0xba, 0xbe]),
+  Buffer.from([0xca, 0xfe, 0xba, 0xbf]),
+] as const;
+export const VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS = [
+  "video-object-jianying-bach-v2-exact-d634-v1",
+  "TEMattingBlendEffectV2-vendor-exact",
+  "vendor-v2-exact-no-qcut-refinement-v1",
+  "qcut-alpha-refinement-after-vendor-v2-v1",
+  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+  "D6342ECD-5432-33F0-A2AD-0C28F5699994",
+  "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9",
+  "797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b",
+  "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+] as const;
+const SOURCE_RELATIVE_PATHS = [
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "alpha-refinement.cpp",
+  ),
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "metal-matting-blend.cpp",
+  ),
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "video-object-bach-bridge.mm",
+  ),
+] as const;
+const FINGERPRINT_RELATIVE_PATHS = [
+  ...SOURCE_RELATIVE_PATHS,
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "alpha-refinement.hpp",
+  ),
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "metal-matting-blend.hpp",
+  ),
+] as const;
+
+async function isExecutable({ filePath }: { filePath: string }) {
+  try {
+    await access(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isValidVideoObjectBachBridge({
+  filePath,
+}: {
+  filePath: string;
+}) {
+  if (!(await isExecutable({ filePath }))) return false;
+  try {
+    const image = await readFile(filePath);
+    return (
+      image.length >= MINIMUM_BRIDGE_BYTES &&
+      MACH_O_MAGICS.some((magic) =>
+        image.subarray(0, magic.length).equals(magic),
+      ) &&
+      VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.every((marker) =>
+        image.includes(marker),
+      )
+    );
+  } catch {
+    return false;
+  }
+}
+
+function findProjectRoot() {
+  const candidates = [
+    process.cwd(),
+    path.resolve(__dirname, "..", ".."),
+    path.resolve(__dirname, "..", "..", ".."),
+  ];
+  return (
+    candidates.find((candidate) =>
+      FINGERPRINT_RELATIVE_PATHS.every((relativePath) =>
+        existsSync(path.join(candidate, relativePath)),
+      ),
+    ) ?? null
+  );
+}
+
+function packagedBridgePath() {
+  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string })
+    .resourcesPath;
+  return resourcesPath
+    ? path.join(resourcesPath, "bin", VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME)
+    : null;
+}
+
+export async function resolveVideoObjectBachBridge() {
+  if (process.platform !== "darwin" || process.arch !== "arm64") return null;
+  for (const candidate of [
+    process.env.QCUT_VIDEO_OBJECT_BACH_BRIDGE,
+    packagedBridgePath(),
+  ]) {
+    if (
+      candidate &&
+      (await isValidVideoObjectBachBridge({ filePath: candidate }))
+    ) {
+      return candidate;
+    }
+  }
+  const projectRoot = findProjectRoot();
+  if (!projectRoot) return null;
+  const sourceHash = createHash("sha256");
+  const fingerprintContents = await Promise.all(
+    FINGERPRINT_RELATIVE_PATHS.map((relativePath) =>
+      readFile(path.join(projectRoot, relativePath)),
+    ),
+  );
+  for (const contents of fingerprintContents) {
+    sourceHash.update(contents);
+  }
+  const fingerprint = sourceHash
+    .update(process.arch)
+    .digest("hex")
+    .slice(0, 16);
+  const outputPath = path.join(
+    os.homedir(),
+    "Library",
+    "Caches",
+    "QCut",
+    "jianying-video-object-bach-bridge",
+    fingerprint,
+    VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+  );
+  if (await isValidVideoObjectBachBridge({ filePath: outputPath }))
+    return outputPath;
+  return compileVideoObjectBachBridge({ outputPath, projectRoot });
+}
+
+export async function compileVideoObjectBachBridge({
+  lockTiming,
+  outputPath,
+  projectRoot,
+}: {
+  lockTiming?: AtomicPublishLockTiming;
+  outputPath: string;
+  projectRoot: string;
+}) {
+  if (await isValidVideoObjectBachBridge({ filePath: outputPath }))
+    return outputPath;
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await execFileAsync(
+      "xcrun",
+      [
+        "clang++",
+        "-std=c++20",
+        "-fobjc-arc",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-Wno-deprecated-declarations",
+        ...SOURCE_RELATIVE_PATHS.map((relativePath) =>
+          path.join(projectRoot, relativePath),
+        ),
+        "-framework",
+        "AppKit",
+        "-framework",
+        "OpenGL",
+        "-framework",
+        "CoreVideo",
+        "-framework",
+        "CoreFoundation",
+        "-o",
+        temporaryPath,
+      ],
+      { maxBuffer: 16 * 1024 * 1024 },
+    );
+    if (!(await isValidVideoObjectBachBridge({ filePath: temporaryPath }))) {
+      throw new Error("剪映同图抠像本机桥构建产物无效");
+    }
+    return await withAtomicPublishLock({
+      lockPath: `${outputPath}.publish-lock`,
+      timing: lockTiming,
+      action: async () => {
+        if (await isValidVideoObjectBachBridge({ filePath: outputPath })) {
+          return outputPath;
+        }
+        await rm(outputPath, { force: true });
+        await rename(temporaryPath, outputPath);
+        if (!(await isValidVideoObjectBachBridge({ filePath: outputPath }))) {
+          await rm(outputPath, { force: true });
+          throw new Error("剪映同图抠像本机桥发布校验失败");
+        }
+        return outputPath;
+      },
+    });
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}

--- a/qcut/electron/jianying-person-cutout/video-object-bach-bridge-resolver.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-bach-bridge-resolver.ts
@@ -6,224 +6,224 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import {
-  withAtomicPublishLock,
-  type AtomicPublishLockTiming,
+	withAtomicPublishLock,
+	type AtomicPublishLockTiming,
 } from "./atomic-publish-lock.js";
 import { VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER } from "./video-object-runtime-closure.js";
 
 const execFileAsync = promisify(execFile);
 export const VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME =
-  "jianying-video-object-bach-bridge";
+	"jianying-video-object-bach-bridge";
 const MINIMUM_BRIDGE_BYTES = 4096;
 const MACH_O_MAGICS = [
-  Buffer.from([0xcf, 0xfa, 0xed, 0xfe]),
-  Buffer.from([0xfe, 0xed, 0xfa, 0xcf]),
-  Buffer.from([0xca, 0xfe, 0xba, 0xbe]),
-  Buffer.from([0xca, 0xfe, 0xba, 0xbf]),
+	Buffer.from([0xcf, 0xfa, 0xed, 0xfe]),
+	Buffer.from([0xfe, 0xed, 0xfa, 0xcf]),
+	Buffer.from([0xca, 0xfe, 0xba, 0xbe]),
+	Buffer.from([0xca, 0xfe, 0xba, 0xbf]),
 ] as const;
 export const VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS = [
-  "video-object-jianying-bach-v2-exact-d634-v1",
-  "TEMattingBlendEffectV2-vendor-exact",
-  "vendor-v2-exact-no-qcut-refinement-v1",
-  "qcut-alpha-refinement-after-vendor-v2-v1",
-  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-  "D6342ECD-5432-33F0-A2AD-0C28F5699994",
-  "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9",
-  "797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b",
-  "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+	"video-object-jianying-bach-v2-exact-d634-v1",
+	"TEMattingBlendEffectV2-vendor-exact",
+	"vendor-v2-exact-no-qcut-refinement-v1",
+	"qcut-alpha-refinement-after-vendor-v2-v1",
+	VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+	"D6342ECD-5432-33F0-A2AD-0C28F5699994",
+	"0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9",
+	"797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b",
+	"346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
 ] as const;
 const SOURCE_RELATIVE_PATHS = [
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "alpha-refinement.cpp",
-  ),
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "metal-matting-blend.cpp",
-  ),
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "video-object-bach-bridge.mm",
-  ),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-refinement.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"metal-matting-blend.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"video-object-bach-bridge.mm"
+	),
 ] as const;
 const FINGERPRINT_RELATIVE_PATHS = [
-  ...SOURCE_RELATIVE_PATHS,
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "alpha-refinement.hpp",
-  ),
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "metal-matting-blend.hpp",
-  ),
+	...SOURCE_RELATIVE_PATHS,
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-refinement.hpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"metal-matting-blend.hpp"
+	),
 ] as const;
 
 async function isExecutable({ filePath }: { filePath: string }) {
-  try {
-    await access(filePath, constants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
+	try {
+		await access(filePath, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export async function isValidVideoObjectBachBridge({
-  filePath,
+	filePath,
 }: {
-  filePath: string;
+	filePath: string;
 }) {
-  if (!(await isExecutable({ filePath }))) return false;
-  try {
-    const image = await readFile(filePath);
-    return (
-      image.length >= MINIMUM_BRIDGE_BYTES &&
-      MACH_O_MAGICS.some((magic) =>
-        image.subarray(0, magic.length).equals(magic),
-      ) &&
-      VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.every((marker) =>
-        image.includes(marker),
-      )
-    );
-  } catch {
-    return false;
-  }
+	if (!(await isExecutable({ filePath }))) return false;
+	try {
+		const image = await readFile(filePath);
+		return (
+			image.length >= MINIMUM_BRIDGE_BYTES &&
+			MACH_O_MAGICS.some((magic) =>
+				image.subarray(0, magic.length).equals(magic)
+			) &&
+			VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.every((marker) =>
+				image.includes(marker)
+			)
+		);
+	} catch {
+		return false;
+	}
 }
 
 function findProjectRoot() {
-  const candidates = [
-    process.cwd(),
-    path.resolve(__dirname, "..", ".."),
-    path.resolve(__dirname, "..", "..", ".."),
-  ];
-  return (
-    candidates.find((candidate) =>
-      FINGERPRINT_RELATIVE_PATHS.every((relativePath) =>
-        existsSync(path.join(candidate, relativePath)),
-      ),
-    ) ?? null
-  );
+	const candidates = [
+		process.cwd(),
+		path.resolve(__dirname, "..", ".."),
+		path.resolve(__dirname, "..", "..", ".."),
+	];
+	return (
+		candidates.find((candidate) =>
+			FINGERPRINT_RELATIVE_PATHS.every((relativePath) =>
+				existsSync(path.join(candidate, relativePath))
+			)
+		) ?? null
+	);
 }
 
 function packagedBridgePath() {
-  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string })
-    .resourcesPath;
-  return resourcesPath
-    ? path.join(resourcesPath, "bin", VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME)
-    : null;
+	const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string })
+		.resourcesPath;
+	return resourcesPath
+		? path.join(resourcesPath, "bin", VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME)
+		: null;
 }
 
 export async function resolveVideoObjectBachBridge() {
-  if (process.platform !== "darwin" || process.arch !== "arm64") return null;
-  for (const candidate of [
-    process.env.QCUT_VIDEO_OBJECT_BACH_BRIDGE,
-    packagedBridgePath(),
-  ]) {
-    if (
-      candidate &&
-      (await isValidVideoObjectBachBridge({ filePath: candidate }))
-    ) {
-      return candidate;
-    }
-  }
-  const projectRoot = findProjectRoot();
-  if (!projectRoot) return null;
-  const sourceHash = createHash("sha256");
-  const fingerprintContents = await Promise.all(
-    FINGERPRINT_RELATIVE_PATHS.map((relativePath) =>
-      readFile(path.join(projectRoot, relativePath)),
-    ),
-  );
-  for (const contents of fingerprintContents) {
-    sourceHash.update(contents);
-  }
-  const fingerprint = sourceHash
-    .update(process.arch)
-    .digest("hex")
-    .slice(0, 16);
-  const outputPath = path.join(
-    os.homedir(),
-    "Library",
-    "Caches",
-    "QCut",
-    "jianying-video-object-bach-bridge",
-    fingerprint,
-    VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
-  );
-  if (await isValidVideoObjectBachBridge({ filePath: outputPath }))
-    return outputPath;
-  return compileVideoObjectBachBridge({ outputPath, projectRoot });
+	if (process.platform !== "darwin" || process.arch !== "arm64") return null;
+	for (const candidate of [
+		process.env.QCUT_VIDEO_OBJECT_BACH_BRIDGE,
+		packagedBridgePath(),
+	]) {
+		if (
+			candidate &&
+			(await isValidVideoObjectBachBridge({ filePath: candidate }))
+		) {
+			return candidate;
+		}
+	}
+	const projectRoot = findProjectRoot();
+	if (!projectRoot) return null;
+	const sourceHash = createHash("sha256");
+	const fingerprintContents = await Promise.all(
+		FINGERPRINT_RELATIVE_PATHS.map((relativePath) =>
+			readFile(path.join(projectRoot, relativePath))
+		)
+	);
+	for (const contents of fingerprintContents) {
+		sourceHash.update(contents);
+	}
+	const fingerprint = sourceHash
+		.update(process.arch)
+		.digest("hex")
+		.slice(0, 16);
+	const outputPath = path.join(
+		os.homedir(),
+		"Library",
+		"Caches",
+		"QCut",
+		"jianying-video-object-bach-bridge",
+		fingerprint,
+		VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME
+	);
+	if (await isValidVideoObjectBachBridge({ filePath: outputPath }))
+		return outputPath;
+	return compileVideoObjectBachBridge({ outputPath, projectRoot });
 }
 
 export async function compileVideoObjectBachBridge({
-  lockTiming,
-  outputPath,
-  projectRoot,
+	lockTiming,
+	outputPath,
+	projectRoot,
 }: {
-  lockTiming?: AtomicPublishLockTiming;
-  outputPath: string;
-  projectRoot: string;
+	lockTiming?: AtomicPublishLockTiming;
+	outputPath: string;
+	projectRoot: string;
 }) {
-  if (await isValidVideoObjectBachBridge({ filePath: outputPath }))
-    return outputPath;
-  await mkdir(path.dirname(outputPath), { recursive: true });
-  const temporaryPath = `${outputPath}.${process.pid}.${randomUUID()}.tmp`;
-  try {
-    await execFileAsync(
-      "xcrun",
-      [
-        "clang++",
-        "-std=c++20",
-        "-fobjc-arc",
-        "-Wall",
-        "-Wextra",
-        "-Werror",
-        "-Wno-deprecated-declarations",
-        ...SOURCE_RELATIVE_PATHS.map((relativePath) =>
-          path.join(projectRoot, relativePath),
-        ),
-        "-framework",
-        "AppKit",
-        "-framework",
-        "OpenGL",
-        "-framework",
-        "CoreVideo",
-        "-framework",
-        "CoreFoundation",
-        "-o",
-        temporaryPath,
-      ],
-      { maxBuffer: 16 * 1024 * 1024 },
-    );
-    if (!(await isValidVideoObjectBachBridge({ filePath: temporaryPath }))) {
-      throw new Error("剪映同图抠像本机桥构建产物无效");
-    }
-    return await withAtomicPublishLock({
-      lockPath: `${outputPath}.publish-lock`,
-      timing: lockTiming,
-      action: async () => {
-        if (await isValidVideoObjectBachBridge({ filePath: outputPath })) {
-          return outputPath;
-        }
-        await rm(outputPath, { force: true });
-        await rename(temporaryPath, outputPath);
-        if (!(await isValidVideoObjectBachBridge({ filePath: outputPath }))) {
-          await rm(outputPath, { force: true });
-          throw new Error("剪映同图抠像本机桥发布校验失败");
-        }
-        return outputPath;
-      },
-    });
-  } finally {
-    await rm(temporaryPath, { force: true });
-  }
+	if (await isValidVideoObjectBachBridge({ filePath: outputPath }))
+		return outputPath;
+	await mkdir(path.dirname(outputPath), { recursive: true });
+	const temporaryPath = `${outputPath}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		await execFileAsync(
+			"xcrun",
+			[
+				"clang++",
+				"-std=c++20",
+				"-fobjc-arc",
+				"-Wall",
+				"-Wextra",
+				"-Werror",
+				"-Wno-deprecated-declarations",
+				...SOURCE_RELATIVE_PATHS.map((relativePath) =>
+					path.join(projectRoot, relativePath)
+				),
+				"-framework",
+				"AppKit",
+				"-framework",
+				"OpenGL",
+				"-framework",
+				"CoreVideo",
+				"-framework",
+				"CoreFoundation",
+				"-o",
+				temporaryPath,
+			],
+			{ maxBuffer: 16 * 1024 * 1024 }
+		);
+		if (!(await isValidVideoObjectBachBridge({ filePath: temporaryPath }))) {
+			throw new Error("剪映同图抠像本机桥构建产物无效");
+		}
+		return await withAtomicPublishLock({
+			lockPath: `${outputPath}.publish-lock`,
+			timing: lockTiming,
+			action: async () => {
+				if (await isValidVideoObjectBachBridge({ filePath: outputPath })) {
+					return outputPath;
+				}
+				await rm(outputPath, { force: true });
+				await rename(temporaryPath, outputPath);
+				if (!(await isValidVideoObjectBachBridge({ filePath: outputPath }))) {
+					await rm(outputPath, { force: true });
+					throw new Error("剪映同图抠像本机桥发布校验失败");
+				}
+				return outputPath;
+			},
+		});
+	} finally {
+		await rm(temporaryPath, { force: true });
+	}
 }

--- a/qcut/electron/jianying-person-cutout/video-object-bridge-arguments.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-bridge-arguments.ts
@@ -1,0 +1,74 @@
+import type { JianyingVideoObjectRuntimeCandidate } from "./video-object-runtime.js";
+
+export interface VideoObjectBridgeSettings {
+  edgeShift: number;
+  feather: number;
+  temporalSmoothing: number;
+  threshold: number;
+}
+
+export function createVideoObjectBridgeArguments({
+  height,
+  inputPath,
+  outputPath,
+  settings,
+  videoObject,
+  width,
+}: {
+  height: number;
+  inputPath: string;
+  outputPath: string;
+  settings: VideoObjectBridgeSettings;
+  videoObject: JianyingVideoObjectRuntimeCandidate;
+  width: number;
+}) {
+  const refinementArguments = [
+    String(settings.threshold),
+    String(settings.temporalSmoothing),
+    String(settings.edgeShift),
+    String(settings.feather),
+  ];
+  if (videoObject.executionBackend === "jianying-bach-v2-exact-d634-v1") {
+    if (!videoObject.libraryPath || !videoObject.graphDirectory) {
+      throw new Error("剪映 Bach 物体抠像运行时不完整");
+    }
+    return [
+      videoObject.libraryPath,
+      videoObject.graphDirectory,
+      videoObject.modelPath,
+      inputPath,
+      String(width),
+      String(height),
+      outputPath,
+      ...refinementArguments,
+    ];
+  }
+  if (videoObject.executionBackend === "same-model-coreml-v1") {
+    if (!videoObject.coreMLModelPath) {
+      throw new Error("同模型物体抠像运行时不完整");
+    }
+    return [
+      videoObject.coreMLModelPath,
+      inputPath,
+      String(width),
+      String(height),
+      outputPath,
+      ...refinementArguments,
+    ];
+  }
+  if (!videoObject.libraryPath || !videoObject.effectDirectory) {
+    throw new Error("剪映物体抠像宿主运行时不完整");
+  }
+  return [
+    videoObject.libraryPath,
+    videoObject.modelDirectory,
+    videoObject.effectDirectory,
+    inputPath,
+    String(width),
+    String(height),
+    outputPath,
+    ...refinementArguments,
+    "--route",
+    "video-object",
+  ];
+}

--- a/qcut/electron/jianying-person-cutout/video-object-bridge-arguments.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-bridge-arguments.ts
@@ -1,74 +1,74 @@
 import type { JianyingVideoObjectRuntimeCandidate } from "./video-object-runtime.js";
 
 export interface VideoObjectBridgeSettings {
-  edgeShift: number;
-  feather: number;
-  temporalSmoothing: number;
-  threshold: number;
+	edgeShift: number;
+	feather: number;
+	temporalSmoothing: number;
+	threshold: number;
 }
 
 export function createVideoObjectBridgeArguments({
-  height,
-  inputPath,
-  outputPath,
-  settings,
-  videoObject,
-  width,
+	height,
+	inputPath,
+	outputPath,
+	settings,
+	videoObject,
+	width,
 }: {
-  height: number;
-  inputPath: string;
-  outputPath: string;
-  settings: VideoObjectBridgeSettings;
-  videoObject: JianyingVideoObjectRuntimeCandidate;
-  width: number;
+	height: number;
+	inputPath: string;
+	outputPath: string;
+	settings: VideoObjectBridgeSettings;
+	videoObject: JianyingVideoObjectRuntimeCandidate;
+	width: number;
 }) {
-  const refinementArguments = [
-    String(settings.threshold),
-    String(settings.temporalSmoothing),
-    String(settings.edgeShift),
-    String(settings.feather),
-  ];
-  if (videoObject.executionBackend === "jianying-bach-v2-exact-d634-v1") {
-    if (!videoObject.libraryPath || !videoObject.graphDirectory) {
-      throw new Error("剪映 Bach 物体抠像运行时不完整");
-    }
-    return [
-      videoObject.libraryPath,
-      videoObject.graphDirectory,
-      videoObject.modelPath,
-      inputPath,
-      String(width),
-      String(height),
-      outputPath,
-      ...refinementArguments,
-    ];
-  }
-  if (videoObject.executionBackend === "same-model-coreml-v1") {
-    if (!videoObject.coreMLModelPath) {
-      throw new Error("同模型物体抠像运行时不完整");
-    }
-    return [
-      videoObject.coreMLModelPath,
-      inputPath,
-      String(width),
-      String(height),
-      outputPath,
-      ...refinementArguments,
-    ];
-  }
-  if (!videoObject.libraryPath || !videoObject.effectDirectory) {
-    throw new Error("剪映物体抠像宿主运行时不完整");
-  }
-  return [
-    videoObject.libraryPath,
-    videoObject.modelDirectory,
-    videoObject.effectDirectory,
-    inputPath,
-    String(width),
-    String(height),
-    outputPath,
-    ...refinementArguments,
-    "--route",
-    "video-object",
-  ];
+	const refinementArguments = [
+		String(settings.threshold),
+		String(settings.temporalSmoothing),
+		String(settings.edgeShift),
+		String(settings.feather),
+	];
+	if (videoObject.executionBackend === "jianying-bach-v2-exact-d634-v1") {
+		if (!videoObject.libraryPath || !videoObject.graphDirectory) {
+			throw new Error("剪映 Bach 物体抠像运行时不完整");
+		}
+		return [
+			videoObject.libraryPath,
+			videoObject.graphDirectory,
+			videoObject.modelPath,
+			inputPath,
+			String(width),
+			String(height),
+			outputPath,
+			...refinementArguments,
+		];
+	}
+	if (videoObject.executionBackend === "same-model-coreml-v1") {
+		if (!videoObject.coreMLModelPath) {
+			throw new Error("同模型物体抠像运行时不完整");
+		}
+		return [
+			videoObject.coreMLModelPath,
+			inputPath,
+			String(width),
+			String(height),
+			outputPath,
+			...refinementArguments,
+		];
+	}
+	if (!videoObject.libraryPath || !videoObject.effectDirectory) {
+		throw new Error("剪映物体抠像宿主运行时不完整");
+	}
+	return [
+		videoObject.libraryPath,
+		videoObject.modelDirectory,
+		videoObject.effectDirectory,
+		inputPath,
+		String(width),
+		String(height),
+		outputPath,
+		...refinementArguments,
+		"--route",
+		"video-object",
+	];
 }

--- a/qcut/electron/jianying-person-cutout/video-object-circuit-breaker.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-circuit-breaker.ts
@@ -1,0 +1,38 @@
+export const VIDEO_OBJECT_ALPHA_QUALITY_FAILURE =
+	"video-object-alpha-quality-v1";
+export const VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE =
+	"video-object graph returned only the hostless 0/1/2 Alpha signature for the complete stream";
+
+export function isConfirmedVideoObjectHostlessAlphaFailure({
+	error,
+}: {
+	error: unknown;
+}) {
+	return (
+		error instanceof Error &&
+		error.message.includes(VIDEO_OBJECT_ALPHA_QUALITY_FAILURE) &&
+		error.message.includes(VIDEO_OBJECT_HOSTLESS_ALPHA_SIGNATURE)
+	);
+}
+
+export class VideoObjectRuntimeCircuitBreaker {
+	readonly #rejectedCapabilities = new Set<string>();
+
+	isOpen({ capabilitySha256 }: { capabilitySha256: string }) {
+		return this.#rejectedCapabilities.has(capabilitySha256);
+	}
+
+	reject({
+		capabilitySha256,
+		error,
+	}: {
+		capabilitySha256: string;
+		error: unknown;
+	}) {
+		if (!isConfirmedVideoObjectHostlessAlphaFailure({ error })) {
+			return false;
+		}
+		this.#rejectedCapabilities.add(capabilitySha256);
+		return true;
+	}
+}

--- a/qcut/electron/jianying-person-cutout/video-object-coreml-bridge-resolver.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-coreml-bridge-resolver.ts
@@ -6,208 +6,208 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import {
-  withAtomicPublishLock,
-  type AtomicPublishLockTiming,
+	withAtomicPublishLock,
+	type AtomicPublishLockTiming,
 } from "./atomic-publish-lock.js";
 
 const execFileAsync = promisify(execFile);
 export const VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME =
-  "jianying-video-object-coreml-bridge";
+	"jianying-video-object-coreml-bridge";
 const MINIMUM_BRIDGE_BYTES = 4096;
 const MACH_O_MAGICS = [
-  Buffer.from([0xcf, 0xfa, 0xed, 0xfe]),
-  Buffer.from([0xfe, 0xed, 0xfa, 0xcf]),
-  Buffer.from([0xca, 0xfe, 0xba, 0xbe]),
-  Buffer.from([0xca, 0xfe, 0xba, 0xbf]),
+	Buffer.from([0xcf, 0xfa, 0xed, 0xfe]),
+	Buffer.from([0xfe, 0xed, 0xfa, 0xcf]),
+	Buffer.from([0xca, 0xfe, 0xba, 0xbe]),
+	Buffer.from([0xca, 0xfe, 0xba, 0xbf]),
 ] as const;
 const REQUIRED_BRIDGE_MARKERS = ["video-object-same-model-coreml-v1"] as const;
 const SOURCE_RELATIVE_PATHS = [
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "alpha-refinement.cpp",
-  ),
-  path.join("electron", "jianying-person-cutout", "native", "alpha-resize.cpp"),
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "video-object-coreml-preprocess.cpp",
-  ),
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "video-object-coreml-bridge.mm",
-  ),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-refinement.cpp"
+	),
+	path.join("electron", "jianying-person-cutout", "native", "alpha-resize.cpp"),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"video-object-coreml-preprocess.cpp"
+	),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"video-object-coreml-bridge.mm"
+	),
 ] as const;
 const FINGERPRINT_RELATIVE_PATHS = [
-  ...SOURCE_RELATIVE_PATHS,
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "alpha-refinement.hpp",
-  ),
-  path.join("electron", "jianying-person-cutout", "native", "alpha-resize.hpp"),
-  path.join(
-    "electron",
-    "jianying-person-cutout",
-    "native",
-    "video-object-coreml-preprocess.hpp",
-  ),
+	...SOURCE_RELATIVE_PATHS,
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"alpha-refinement.hpp"
+	),
+	path.join("electron", "jianying-person-cutout", "native", "alpha-resize.hpp"),
+	path.join(
+		"electron",
+		"jianying-person-cutout",
+		"native",
+		"video-object-coreml-preprocess.hpp"
+	),
 ] as const;
 
 async function isExecutable({ filePath }: { filePath: string }) {
-  try {
-    await access(filePath, constants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
+	try {
+		await access(filePath, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export async function isValidVideoObjectCoreMLBridge({
-  filePath,
+	filePath,
 }: {
-  filePath: string;
+	filePath: string;
 }) {
-  if (!(await isExecutable({ filePath }))) return false;
-  try {
-    const image = await readFile(filePath);
-    return (
-      image.length >= MINIMUM_BRIDGE_BYTES &&
-      MACH_O_MAGICS.some((magic) =>
-        image.subarray(0, magic.length).equals(magic),
-      ) &&
-      REQUIRED_BRIDGE_MARKERS.every((marker) => image.includes(marker))
-    );
-  } catch {
-    return false;
-  }
+	if (!(await isExecutable({ filePath }))) return false;
+	try {
+		const image = await readFile(filePath);
+		return (
+			image.length >= MINIMUM_BRIDGE_BYTES &&
+			MACH_O_MAGICS.some((magic) =>
+				image.subarray(0, magic.length).equals(magic)
+			) &&
+			REQUIRED_BRIDGE_MARKERS.every((marker) => image.includes(marker))
+		);
+	} catch {
+		return false;
+	}
 }
 
 function findProjectRoot() {
-  const candidates = [
-    process.cwd(),
-    path.resolve(__dirname, "..", ".."),
-    path.resolve(__dirname, "..", "..", ".."),
-  ];
-  return (
-    candidates.find((candidate) =>
-      FINGERPRINT_RELATIVE_PATHS.every((relativePath) =>
-        existsSync(path.join(candidate, relativePath)),
-      ),
-    ) ?? null
-  );
+	const candidates = [
+		process.cwd(),
+		path.resolve(__dirname, "..", ".."),
+		path.resolve(__dirname, "..", "..", ".."),
+	];
+	return (
+		candidates.find((candidate) =>
+			FINGERPRINT_RELATIVE_PATHS.every((relativePath) =>
+				existsSync(path.join(candidate, relativePath))
+			)
+		) ?? null
+	);
 }
 
 function packagedBridgePath() {
-  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string })
-    .resourcesPath;
-  return resourcesPath
-    ? path.join(resourcesPath, "bin", VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME)
-    : null;
+	const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string })
+		.resourcesPath;
+	return resourcesPath
+		? path.join(resourcesPath, "bin", VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME)
+		: null;
 }
 
 export async function resolveVideoObjectCoreMLBridge() {
-  if (process.platform !== "darwin") return null;
-  for (const candidate of [
-    process.env.QCUT_VIDEO_OBJECT_COREML_BRIDGE,
-    packagedBridgePath(),
-  ]) {
-    if (
-      candidate &&
-      (await isValidVideoObjectCoreMLBridge({ filePath: candidate }))
-    ) {
-      return candidate;
-    }
-  }
-  const projectRoot = findProjectRoot();
-  if (!projectRoot) return null;
-  const sourceHash = createHash("sha256");
-  const fingerprintContents = await Promise.all(
-    FINGERPRINT_RELATIVE_PATHS.map((relativePath) =>
-      readFile(path.join(projectRoot, relativePath)),
-    ),
-  );
-  for (const contents of fingerprintContents) {
-    sourceHash.update(contents);
-  }
-  const fingerprint = sourceHash
-    .update(process.arch)
-    .digest("hex")
-    .slice(0, 16);
-  const outputPath = path.join(
-    os.homedir(),
-    "Library",
-    "Caches",
-    "QCut",
-    "jianying-video-object-coreml-bridge",
-    fingerprint,
-    VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
-  );
-  if (await isValidVideoObjectCoreMLBridge({ filePath: outputPath }))
-    return outputPath;
-  return compileVideoObjectCoreMLBridge({ outputPath, projectRoot });
+	if (process.platform !== "darwin") return null;
+	for (const candidate of [
+		process.env.QCUT_VIDEO_OBJECT_COREML_BRIDGE,
+		packagedBridgePath(),
+	]) {
+		if (
+			candidate &&
+			(await isValidVideoObjectCoreMLBridge({ filePath: candidate }))
+		) {
+			return candidate;
+		}
+	}
+	const projectRoot = findProjectRoot();
+	if (!projectRoot) return null;
+	const sourceHash = createHash("sha256");
+	const fingerprintContents = await Promise.all(
+		FINGERPRINT_RELATIVE_PATHS.map((relativePath) =>
+			readFile(path.join(projectRoot, relativePath))
+		)
+	);
+	for (const contents of fingerprintContents) {
+		sourceHash.update(contents);
+	}
+	const fingerprint = sourceHash
+		.update(process.arch)
+		.digest("hex")
+		.slice(0, 16);
+	const outputPath = path.join(
+		os.homedir(),
+		"Library",
+		"Caches",
+		"QCut",
+		"jianying-video-object-coreml-bridge",
+		fingerprint,
+		VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME
+	);
+	if (await isValidVideoObjectCoreMLBridge({ filePath: outputPath }))
+		return outputPath;
+	return compileVideoObjectCoreMLBridge({ outputPath, projectRoot });
 }
 
 export async function compileVideoObjectCoreMLBridge({
-  lockTiming,
-  outputPath,
-  projectRoot,
+	lockTiming,
+	outputPath,
+	projectRoot,
 }: {
-  lockTiming?: AtomicPublishLockTiming;
-  outputPath: string;
-  projectRoot: string;
+	lockTiming?: AtomicPublishLockTiming;
+	outputPath: string;
+	projectRoot: string;
 }) {
-  if (await isValidVideoObjectCoreMLBridge({ filePath: outputPath }))
-    return outputPath;
-  await mkdir(path.dirname(outputPath), { recursive: true });
-  const temporaryPath = `${outputPath}.${process.pid}.${randomUUID()}.tmp`;
-  try {
-    await execFileAsync(
-      "xcrun",
-      [
-        "clang++",
-        "-std=c++20",
-        "-fobjc-arc",
-        "-Wall",
-        "-Wextra",
-        "-Werror",
-        ...SOURCE_RELATIVE_PATHS.map((relativePath) =>
-          path.join(projectRoot, relativePath),
-        ),
-        "-framework",
-        "CoreML",
-        "-framework",
-        "Foundation",
-        "-o",
-        temporaryPath,
-      ],
-      { maxBuffer: 16 * 1024 * 1024 },
-    );
-    if (!(await isValidVideoObjectCoreMLBridge({ filePath: temporaryPath }))) {
-      throw new Error("物体抠像 CoreML 本机桥构建产物无效");
-    }
-    return await withAtomicPublishLock({
-      lockPath: `${outputPath}.publish-lock`,
-      timing: lockTiming,
-      action: async () => {
-        if (await isValidVideoObjectCoreMLBridge({ filePath: outputPath })) {
-          return outputPath;
-        }
-        await rm(outputPath, { force: true });
-        await rename(temporaryPath, outputPath);
-        if (!(await isValidVideoObjectCoreMLBridge({ filePath: outputPath }))) {
-          await rm(outputPath, { force: true });
-          throw new Error("物体抠像 CoreML 本机桥发布校验失败");
-        }
-        return outputPath;
-      },
-    });
-  } finally {
-    await rm(temporaryPath, { force: true });
-  }
+	if (await isValidVideoObjectCoreMLBridge({ filePath: outputPath }))
+		return outputPath;
+	await mkdir(path.dirname(outputPath), { recursive: true });
+	const temporaryPath = `${outputPath}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		await execFileAsync(
+			"xcrun",
+			[
+				"clang++",
+				"-std=c++20",
+				"-fobjc-arc",
+				"-Wall",
+				"-Wextra",
+				"-Werror",
+				...SOURCE_RELATIVE_PATHS.map((relativePath) =>
+					path.join(projectRoot, relativePath)
+				),
+				"-framework",
+				"CoreML",
+				"-framework",
+				"Foundation",
+				"-o",
+				temporaryPath,
+			],
+			{ maxBuffer: 16 * 1024 * 1024 }
+		);
+		if (!(await isValidVideoObjectCoreMLBridge({ filePath: temporaryPath }))) {
+			throw new Error("物体抠像 CoreML 本机桥构建产物无效");
+		}
+		return await withAtomicPublishLock({
+			lockPath: `${outputPath}.publish-lock`,
+			timing: lockTiming,
+			action: async () => {
+				if (await isValidVideoObjectCoreMLBridge({ filePath: outputPath })) {
+					return outputPath;
+				}
+				await rm(outputPath, { force: true });
+				await rename(temporaryPath, outputPath);
+				if (!(await isValidVideoObjectCoreMLBridge({ filePath: outputPath }))) {
+					await rm(outputPath, { force: true });
+					throw new Error("物体抠像 CoreML 本机桥发布校验失败");
+				}
+				return outputPath;
+			},
+		});
+	} finally {
+		await rm(temporaryPath, { force: true });
+	}
 }

--- a/qcut/electron/jianying-person-cutout/video-object-coreml-bridge-resolver.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-coreml-bridge-resolver.ts
@@ -1,0 +1,213 @@
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { constants, existsSync } from "node:fs";
+import { access, mkdir, readFile, rename, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+  withAtomicPublishLock,
+  type AtomicPublishLockTiming,
+} from "./atomic-publish-lock.js";
+
+const execFileAsync = promisify(execFile);
+export const VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME =
+  "jianying-video-object-coreml-bridge";
+const MINIMUM_BRIDGE_BYTES = 4096;
+const MACH_O_MAGICS = [
+  Buffer.from([0xcf, 0xfa, 0xed, 0xfe]),
+  Buffer.from([0xfe, 0xed, 0xfa, 0xcf]),
+  Buffer.from([0xca, 0xfe, 0xba, 0xbe]),
+  Buffer.from([0xca, 0xfe, 0xba, 0xbf]),
+] as const;
+const REQUIRED_BRIDGE_MARKERS = ["video-object-same-model-coreml-v1"] as const;
+const SOURCE_RELATIVE_PATHS = [
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "alpha-refinement.cpp",
+  ),
+  path.join("electron", "jianying-person-cutout", "native", "alpha-resize.cpp"),
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "video-object-coreml-preprocess.cpp",
+  ),
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "video-object-coreml-bridge.mm",
+  ),
+] as const;
+const FINGERPRINT_RELATIVE_PATHS = [
+  ...SOURCE_RELATIVE_PATHS,
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "alpha-refinement.hpp",
+  ),
+  path.join("electron", "jianying-person-cutout", "native", "alpha-resize.hpp"),
+  path.join(
+    "electron",
+    "jianying-person-cutout",
+    "native",
+    "video-object-coreml-preprocess.hpp",
+  ),
+] as const;
+
+async function isExecutable({ filePath }: { filePath: string }) {
+  try {
+    await access(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isValidVideoObjectCoreMLBridge({
+  filePath,
+}: {
+  filePath: string;
+}) {
+  if (!(await isExecutable({ filePath }))) return false;
+  try {
+    const image = await readFile(filePath);
+    return (
+      image.length >= MINIMUM_BRIDGE_BYTES &&
+      MACH_O_MAGICS.some((magic) =>
+        image.subarray(0, magic.length).equals(magic),
+      ) &&
+      REQUIRED_BRIDGE_MARKERS.every((marker) => image.includes(marker))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function findProjectRoot() {
+  const candidates = [
+    process.cwd(),
+    path.resolve(__dirname, "..", ".."),
+    path.resolve(__dirname, "..", "..", ".."),
+  ];
+  return (
+    candidates.find((candidate) =>
+      FINGERPRINT_RELATIVE_PATHS.every((relativePath) =>
+        existsSync(path.join(candidate, relativePath)),
+      ),
+    ) ?? null
+  );
+}
+
+function packagedBridgePath() {
+  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string })
+    .resourcesPath;
+  return resourcesPath
+    ? path.join(resourcesPath, "bin", VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME)
+    : null;
+}
+
+export async function resolveVideoObjectCoreMLBridge() {
+  if (process.platform !== "darwin") return null;
+  for (const candidate of [
+    process.env.QCUT_VIDEO_OBJECT_COREML_BRIDGE,
+    packagedBridgePath(),
+  ]) {
+    if (
+      candidate &&
+      (await isValidVideoObjectCoreMLBridge({ filePath: candidate }))
+    ) {
+      return candidate;
+    }
+  }
+  const projectRoot = findProjectRoot();
+  if (!projectRoot) return null;
+  const sourceHash = createHash("sha256");
+  const fingerprintContents = await Promise.all(
+    FINGERPRINT_RELATIVE_PATHS.map((relativePath) =>
+      readFile(path.join(projectRoot, relativePath)),
+    ),
+  );
+  for (const contents of fingerprintContents) {
+    sourceHash.update(contents);
+  }
+  const fingerprint = sourceHash
+    .update(process.arch)
+    .digest("hex")
+    .slice(0, 16);
+  const outputPath = path.join(
+    os.homedir(),
+    "Library",
+    "Caches",
+    "QCut",
+    "jianying-video-object-coreml-bridge",
+    fingerprint,
+    VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+  );
+  if (await isValidVideoObjectCoreMLBridge({ filePath: outputPath }))
+    return outputPath;
+  return compileVideoObjectCoreMLBridge({ outputPath, projectRoot });
+}
+
+export async function compileVideoObjectCoreMLBridge({
+  lockTiming,
+  outputPath,
+  projectRoot,
+}: {
+  lockTiming?: AtomicPublishLockTiming;
+  outputPath: string;
+  projectRoot: string;
+}) {
+  if (await isValidVideoObjectCoreMLBridge({ filePath: outputPath }))
+    return outputPath;
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await execFileAsync(
+      "xcrun",
+      [
+        "clang++",
+        "-std=c++20",
+        "-fobjc-arc",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        ...SOURCE_RELATIVE_PATHS.map((relativePath) =>
+          path.join(projectRoot, relativePath),
+        ),
+        "-framework",
+        "CoreML",
+        "-framework",
+        "Foundation",
+        "-o",
+        temporaryPath,
+      ],
+      { maxBuffer: 16 * 1024 * 1024 },
+    );
+    if (!(await isValidVideoObjectCoreMLBridge({ filePath: temporaryPath }))) {
+      throw new Error("物体抠像 CoreML 本机桥构建产物无效");
+    }
+    return await withAtomicPublishLock({
+      lockPath: `${outputPath}.publish-lock`,
+      timing: lockTiming,
+      action: async () => {
+        if (await isValidVideoObjectCoreMLBridge({ filePath: outputPath })) {
+          return outputPath;
+        }
+        await rm(outputPath, { force: true });
+        await rename(temporaryPath, outputPath);
+        if (!(await isValidVideoObjectCoreMLBridge({ filePath: outputPath }))) {
+          await rm(outputPath, { force: true });
+          throw new Error("物体抠像 CoreML 本机桥发布校验失败");
+        }
+        return outputPath;
+      },
+    });
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}

--- a/qcut/electron/jianying-person-cutout/video-object-coreml-runtime.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-coreml-runtime.ts
@@ -1,0 +1,399 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+  withAtomicPublishLock,
+  type AtomicPublishLockTiming,
+} from "./atomic-publish-lock.js";
+
+const execFileAsync = promisify(execFile);
+const COREML_BUNDLE_NAME = "20440.3_sod_fp16.mlmodelc";
+export const COREML_BUNDLE_MANIFEST_FILE_NAME =
+  "qcut-coreml-bundle-manifest.json";
+const COREML_INPUTS = new Map([
+  ["data", "[1, 3, 256, 256]"],
+  ["prev_img", "[1, 3, 256, 256]"],
+  ["prev_mask", "[1, 1, 256, 256]"],
+]);
+const COREML_OUTPUTS = new Map([["nn_3", "[]"]]);
+const ZIP_LOCAL_FILE_HEADER = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+export interface CoreMLBundleManifest {
+  bundleName: string;
+  files: Array<{
+    path: string;
+    sha256: string;
+    size: number;
+  }>;
+  packedModelSha256: string;
+  version: 1;
+}
+
+const VERIFIED_VIDEO_OBJECT_BUNDLE_MANIFEST: CoreMLBundleManifest = {
+  bundleName: COREML_BUNDLE_NAME,
+  packedModelSha256:
+    "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+  version: 1,
+  files: [
+    {
+      path: "analytics/coremldata.bin",
+      sha256:
+        "cd9a772b591e4c19aabbfc76457913d3061313ead4db4ef2ede1aa1d4f92ed3d",
+      size: 448,
+    },
+    {
+      path: "coremldata.bin",
+      sha256:
+        "a04a8dd8a953d4292f6d65c4972e14859712d20388194ba455615986801d3530",
+      size: 312,
+    },
+    {
+      path: "metadata.json",
+      sha256:
+        "1e30c88154a65badfe0a44b4eca0f0080c2e191d9dbad30beb1185ea95402356",
+      size: 2340,
+    },
+    {
+      path: "model.espresso.net",
+      sha256:
+        "56e3131e2cca1fd653e77d10bf898e35be812352a7d751cf5c5cb7ce1324b4e4",
+      size: 150_812,
+    },
+    {
+      path: "model.espresso.shape",
+      sha256:
+        "0f435dac861c71d03274741a827a56be2325c981c5f11a92e677f2e34e2c8d48",
+      size: 33_134,
+    },
+    {
+      path: "model.espresso.weights",
+      sha256:
+        "1f7c0984c6500a8024ffde3989b3eadc44d6c4377b9ac650bea46a44789d9402",
+      size: 10_826_016,
+    },
+    {
+      path: "model/coremldata.bin",
+      sha256:
+        "f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b",
+      size: 64,
+    },
+    {
+      path: "neural_network_optionals/coremldata.bin",
+      sha256:
+        "5931bd536c4550294a212c6fc8d3c1bee75da817980ba0b671c8603dafb36238",
+      size: 40,
+    },
+  ],
+};
+
+interface CoreMLFeatureSchema {
+  name?: unknown;
+  shape?: unknown;
+}
+
+interface CoreMLMetadata {
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+}
+
+function matchesSchema({
+  expected,
+  value,
+}: {
+  expected: ReadonlyMap<string, string>;
+  value: unknown;
+}) {
+  if (!Array.isArray(value) || value.length !== expected.size) return false;
+  const schemas = value as CoreMLFeatureSchema[];
+  return schemas.every(
+    (schema) =>
+      typeof schema.name === "string" &&
+      typeof schema.shape === "string" &&
+      expected.get(schema.name) === schema.shape,
+  );
+}
+
+function normalizedManifest({
+  manifest,
+}: {
+  manifest: CoreMLBundleManifest;
+}): CoreMLBundleManifest {
+  return {
+    ...manifest,
+    files: [...manifest.files].sort((left, right) =>
+      left.path.localeCompare(right.path),
+    ),
+  };
+}
+
+function manifestContents({ manifest }: { manifest: CoreMLBundleManifest }) {
+  return `${JSON.stringify(normalizedManifest({ manifest }), null, 2)}\n`;
+}
+
+async function hasExpectedTensorSchema({ bundlePath }: { bundlePath: string }) {
+  try {
+    const metadataValue: unknown = JSON.parse(
+      await readFile(path.join(bundlePath, "metadata.json"), "utf8"),
+    );
+    if (!Array.isArray(metadataValue) || metadataValue.length !== 1)
+      return false;
+    const metadata = metadataValue[0] as CoreMLMetadata;
+    return (
+      matchesSchema({ expected: COREML_INPUTS, value: metadata.inputSchema }) &&
+      matchesSchema({ expected: COREML_OUTPUTS, value: metadata.outputSchema })
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function listBundleFiles({
+  bundlePath,
+  directory = bundlePath,
+}: {
+  bundlePath: string;
+  directory?: string;
+}): Promise<string[] | null> {
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const nestedFiles = await Promise.all(
+      entries.map(async (entry): Promise<string[] | null> => {
+        const absolutePath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          return listBundleFiles({ bundlePath, directory: absolutePath });
+        }
+        if (!entry.isFile()) return null;
+        return [
+          path.relative(bundlePath, absolutePath).split(path.sep).join("/"),
+        ];
+      }),
+    );
+    if (nestedFiles.some((files) => files === null)) return null;
+    return nestedFiles.flatMap((files) => files ?? []).sort();
+  } catch {
+    return null;
+  }
+}
+
+async function hasExpectedBundleContents({
+  bundlePath,
+  manifest,
+}: {
+  bundlePath: string;
+  manifest: CoreMLBundleManifest;
+}) {
+  if (path.basename(bundlePath) !== manifest.bundleName) return false;
+  const expectedFiles = normalizedManifest({ manifest }).files;
+  const actualPaths = await listBundleFiles({ bundlePath });
+  if (
+    actualPaths === null ||
+    actualPaths.length !== expectedFiles.length ||
+    actualPaths.some(
+      (actualPath, index) => actualPath !== expectedFiles[index].path,
+    )
+  ) {
+    return false;
+  }
+  try {
+    const matches = await Promise.all(
+      expectedFiles.map(async (expectedFile) => {
+        const contents = await readFile(
+          path.join(bundlePath, ...expectedFile.path.split("/")),
+        );
+        return (
+          contents.length === expectedFile.size &&
+          createHash("sha256").update(contents).digest("hex") ===
+            expectedFile.sha256
+        );
+      }),
+    );
+    return (
+      matches.every(Boolean) && (await hasExpectedTensorSchema({ bundlePath }))
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function isPublishedBundleValid({
+  bundlePath,
+  cacheDirectory,
+  manifest,
+}: {
+  bundlePath: string;
+  cacheDirectory: string;
+  manifest: CoreMLBundleManifest;
+}) {
+  try {
+    const publishedManifest = await readFile(
+      path.join(cacheDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
+      "utf8",
+    );
+    if (publishedManifest !== manifestContents({ manifest })) return false;
+    return hasExpectedBundleContents({ bundlePath, manifest });
+  } catch {
+    return false;
+  }
+}
+
+export function findPackedCoreMLArchiveOffset({
+  modelContents,
+}: {
+  modelContents: Buffer;
+}) {
+  const offset = modelContents.indexOf(ZIP_LOCAL_FILE_HEADER);
+  if (offset <= 0) {
+    throw new Error("物体抠像模型不包含可读取的 CoreML 网络");
+  }
+  return offset;
+}
+
+function coreMLCacheRoot() {
+  return (
+    process.env.QCUT_VIDEO_OBJECT_COREML_CACHE_ROOT ??
+    path.join(
+      os.homedir(),
+      "Library",
+      "Caches",
+      "QCut",
+      "jianying-video-object-coreml",
+    )
+  );
+}
+
+export function createVideoObjectCoreMLCache({
+  expectedManifest,
+  lockTiming,
+}: {
+  expectedManifest: CoreMLBundleManifest;
+  lockTiming?: AtomicPublishLockTiming;
+}) {
+  const manifest = normalizedManifest({ manifest: expectedManifest });
+
+  async function isReadable({ modelPath }: { modelPath: string }) {
+    try {
+      await access(modelPath, constants.R_OK);
+      return isPublishedBundleValid({
+        bundlePath: modelPath,
+        cacheDirectory: path.dirname(modelPath),
+        manifest,
+      });
+    } catch {
+      return false;
+    }
+  }
+
+  async function prepare({
+    modelPath,
+    modelSha256,
+  }: {
+    modelPath: string;
+    modelSha256: string;
+  }) {
+    if (modelSha256 !== manifest.packedModelSha256) {
+      throw new Error("物体抠像 packed model 与 CoreML 内容清单不匹配");
+    }
+    const cacheRoot = coreMLCacheRoot();
+    const cacheDirectory = path.join(cacheRoot, modelSha256);
+    const cachedBundle = path.join(cacheDirectory, manifest.bundleName);
+    if (
+      await isPublishedBundleValid({
+        bundlePath: cachedBundle,
+        cacheDirectory,
+        manifest,
+      })
+    ) {
+      return cachedBundle;
+    }
+
+    await mkdir(cacheRoot, { recursive: true });
+    return withAtomicPublishLock({
+      lockPath: path.join(cacheRoot, `${modelSha256}.publish-lock`),
+      timing: lockTiming,
+      action: async () => {
+        if (
+          await isPublishedBundleValid({
+            bundlePath: cachedBundle,
+            cacheDirectory,
+            manifest,
+          })
+        ) {
+          return cachedBundle;
+        }
+
+        const temporaryDirectory = await mkdtemp(
+          path.join(cacheRoot, `${modelSha256}.extracting-`),
+        );
+        try {
+          const modelContents = await readFile(modelPath);
+          const archiveOffset = findPackedCoreMLArchiveOffset({
+            modelContents,
+          });
+          const archivePath = path.join(temporaryDirectory, "model.zip");
+          await writeFile(archivePath, modelContents.subarray(archiveOffset));
+          await execFileAsync("/usr/bin/ditto", [
+            "-x",
+            "-k",
+            archivePath,
+            temporaryDirectory,
+          ]);
+          await rm(archivePath, { force: true });
+          const extractedBundle = path.join(
+            temporaryDirectory,
+            manifest.bundleName,
+          );
+          if (
+            !(await hasExpectedBundleContents({
+              bundlePath: extractedBundle,
+              manifest,
+            }))
+          ) {
+            throw new Error("物体抠像 CoreML 网络内容不符合已验证模型");
+          }
+          await writeFile(
+            path.join(temporaryDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
+            manifestContents({ manifest }),
+            "utf8",
+          );
+          if (
+            !(await isPublishedBundleValid({
+              bundlePath: extractedBundle,
+              cacheDirectory: temporaryDirectory,
+              manifest,
+            }))
+          ) {
+            throw new Error("物体抠像 CoreML 缓存发布校验失败");
+          }
+          await rm(cacheDirectory, { force: true, recursive: true });
+          await rename(temporaryDirectory, cacheDirectory);
+          return cachedBundle;
+        } finally {
+          await rm(temporaryDirectory, { force: true, recursive: true });
+        }
+      },
+    });
+  }
+
+  return { isReadable, prepare };
+}
+
+const verifiedVideoObjectCoreMLCache = createVideoObjectCoreMLCache({
+  expectedManifest: VERIFIED_VIDEO_OBJECT_BUNDLE_MANIFEST,
+});
+
+export const prepareVideoObjectCoreMLModel =
+  verifiedVideoObjectCoreMLCache.prepare;
+export const isReadableCoreMLModel = verifiedVideoObjectCoreMLCache.isReadable;

--- a/qcut/electron/jianying-person-cutout/video-object-coreml-runtime.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-coreml-runtime.ts
@@ -2,398 +2,398 @@ import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import {
-  access,
-  mkdir,
-  mkdtemp,
-  readFile,
-  readdir,
-  rename,
-  rm,
-  writeFile,
+	access,
+	mkdir,
+	mkdtemp,
+	readFile,
+	readdir,
+	rename,
+	rm,
+	writeFile,
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import {
-  withAtomicPublishLock,
-  type AtomicPublishLockTiming,
+	withAtomicPublishLock,
+	type AtomicPublishLockTiming,
 } from "./atomic-publish-lock.js";
 
 const execFileAsync = promisify(execFile);
 const COREML_BUNDLE_NAME = "20440.3_sod_fp16.mlmodelc";
 export const COREML_BUNDLE_MANIFEST_FILE_NAME =
-  "qcut-coreml-bundle-manifest.json";
+	"qcut-coreml-bundle-manifest.json";
 const COREML_INPUTS = new Map([
-  ["data", "[1, 3, 256, 256]"],
-  ["prev_img", "[1, 3, 256, 256]"],
-  ["prev_mask", "[1, 1, 256, 256]"],
+	["data", "[1, 3, 256, 256]"],
+	["prev_img", "[1, 3, 256, 256]"],
+	["prev_mask", "[1, 1, 256, 256]"],
 ]);
 const COREML_OUTPUTS = new Map([["nn_3", "[]"]]);
 const ZIP_LOCAL_FILE_HEADER = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
 
 export interface CoreMLBundleManifest {
-  bundleName: string;
-  files: Array<{
-    path: string;
-    sha256: string;
-    size: number;
-  }>;
-  packedModelSha256: string;
-  version: 1;
+	bundleName: string;
+	files: Array<{
+		path: string;
+		sha256: string;
+		size: number;
+	}>;
+	packedModelSha256: string;
+	version: 1;
 }
 
 const VERIFIED_VIDEO_OBJECT_BUNDLE_MANIFEST: CoreMLBundleManifest = {
-  bundleName: COREML_BUNDLE_NAME,
-  packedModelSha256:
-    "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
-  version: 1,
-  files: [
-    {
-      path: "analytics/coremldata.bin",
-      sha256:
-        "cd9a772b591e4c19aabbfc76457913d3061313ead4db4ef2ede1aa1d4f92ed3d",
-      size: 448,
-    },
-    {
-      path: "coremldata.bin",
-      sha256:
-        "a04a8dd8a953d4292f6d65c4972e14859712d20388194ba455615986801d3530",
-      size: 312,
-    },
-    {
-      path: "metadata.json",
-      sha256:
-        "1e30c88154a65badfe0a44b4eca0f0080c2e191d9dbad30beb1185ea95402356",
-      size: 2340,
-    },
-    {
-      path: "model.espresso.net",
-      sha256:
-        "56e3131e2cca1fd653e77d10bf898e35be812352a7d751cf5c5cb7ce1324b4e4",
-      size: 150_812,
-    },
-    {
-      path: "model.espresso.shape",
-      sha256:
-        "0f435dac861c71d03274741a827a56be2325c981c5f11a92e677f2e34e2c8d48",
-      size: 33_134,
-    },
-    {
-      path: "model.espresso.weights",
-      sha256:
-        "1f7c0984c6500a8024ffde3989b3eadc44d6c4377b9ac650bea46a44789d9402",
-      size: 10_826_016,
-    },
-    {
-      path: "model/coremldata.bin",
-      sha256:
-        "f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b",
-      size: 64,
-    },
-    {
-      path: "neural_network_optionals/coremldata.bin",
-      sha256:
-        "5931bd536c4550294a212c6fc8d3c1bee75da817980ba0b671c8603dafb36238",
-      size: 40,
-    },
-  ],
+	bundleName: COREML_BUNDLE_NAME,
+	packedModelSha256:
+		"346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+	version: 1,
+	files: [
+		{
+			path: "analytics/coremldata.bin",
+			sha256:
+				"cd9a772b591e4c19aabbfc76457913d3061313ead4db4ef2ede1aa1d4f92ed3d",
+			size: 448,
+		},
+		{
+			path: "coremldata.bin",
+			sha256:
+				"a04a8dd8a953d4292f6d65c4972e14859712d20388194ba455615986801d3530",
+			size: 312,
+		},
+		{
+			path: "metadata.json",
+			sha256:
+				"1e30c88154a65badfe0a44b4eca0f0080c2e191d9dbad30beb1185ea95402356",
+			size: 2340,
+		},
+		{
+			path: "model.espresso.net",
+			sha256:
+				"56e3131e2cca1fd653e77d10bf898e35be812352a7d751cf5c5cb7ce1324b4e4",
+			size: 150_812,
+		},
+		{
+			path: "model.espresso.shape",
+			sha256:
+				"0f435dac861c71d03274741a827a56be2325c981c5f11a92e677f2e34e2c8d48",
+			size: 33_134,
+		},
+		{
+			path: "model.espresso.weights",
+			sha256:
+				"1f7c0984c6500a8024ffde3989b3eadc44d6c4377b9ac650bea46a44789d9402",
+			size: 10_826_016,
+		},
+		{
+			path: "model/coremldata.bin",
+			sha256:
+				"f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b",
+			size: 64,
+		},
+		{
+			path: "neural_network_optionals/coremldata.bin",
+			sha256:
+				"5931bd536c4550294a212c6fc8d3c1bee75da817980ba0b671c8603dafb36238",
+			size: 40,
+		},
+	],
 };
 
 interface CoreMLFeatureSchema {
-  name?: unknown;
-  shape?: unknown;
+	name?: unknown;
+	shape?: unknown;
 }
 
 interface CoreMLMetadata {
-  inputSchema?: unknown;
-  outputSchema?: unknown;
+	inputSchema?: unknown;
+	outputSchema?: unknown;
 }
 
 function matchesSchema({
-  expected,
-  value,
+	expected,
+	value,
 }: {
-  expected: ReadonlyMap<string, string>;
-  value: unknown;
+	expected: ReadonlyMap<string, string>;
+	value: unknown;
 }) {
-  if (!Array.isArray(value) || value.length !== expected.size) return false;
-  const schemas = value as CoreMLFeatureSchema[];
-  return schemas.every(
-    (schema) =>
-      typeof schema.name === "string" &&
-      typeof schema.shape === "string" &&
-      expected.get(schema.name) === schema.shape,
-  );
+	if (!Array.isArray(value) || value.length !== expected.size) return false;
+	const schemas = value as CoreMLFeatureSchema[];
+	return schemas.every(
+		(schema) =>
+			typeof schema.name === "string" &&
+			typeof schema.shape === "string" &&
+			expected.get(schema.name) === schema.shape
+	);
 }
 
 function normalizedManifest({
-  manifest,
+	manifest,
 }: {
-  manifest: CoreMLBundleManifest;
+	manifest: CoreMLBundleManifest;
 }): CoreMLBundleManifest {
-  return {
-    ...manifest,
-    files: [...manifest.files].sort((left, right) =>
-      left.path.localeCompare(right.path),
-    ),
-  };
+	return {
+		...manifest,
+		files: [...manifest.files].sort((left, right) =>
+			left.path.localeCompare(right.path)
+		),
+	};
 }
 
 function manifestContents({ manifest }: { manifest: CoreMLBundleManifest }) {
-  return `${JSON.stringify(normalizedManifest({ manifest }), null, 2)}\n`;
+	return `${JSON.stringify(normalizedManifest({ manifest }), null, 2)}\n`;
 }
 
 async function hasExpectedTensorSchema({ bundlePath }: { bundlePath: string }) {
-  try {
-    const metadataValue: unknown = JSON.parse(
-      await readFile(path.join(bundlePath, "metadata.json"), "utf8"),
-    );
-    if (!Array.isArray(metadataValue) || metadataValue.length !== 1)
-      return false;
-    const metadata = metadataValue[0] as CoreMLMetadata;
-    return (
-      matchesSchema({ expected: COREML_INPUTS, value: metadata.inputSchema }) &&
-      matchesSchema({ expected: COREML_OUTPUTS, value: metadata.outputSchema })
-    );
-  } catch {
-    return false;
-  }
+	try {
+		const metadataValue: unknown = JSON.parse(
+			await readFile(path.join(bundlePath, "metadata.json"), "utf8")
+		);
+		if (!Array.isArray(metadataValue) || metadataValue.length !== 1)
+			return false;
+		const metadata = metadataValue[0] as CoreMLMetadata;
+		return (
+			matchesSchema({ expected: COREML_INPUTS, value: metadata.inputSchema }) &&
+			matchesSchema({ expected: COREML_OUTPUTS, value: metadata.outputSchema })
+		);
+	} catch {
+		return false;
+	}
 }
 
 async function listBundleFiles({
-  bundlePath,
-  directory = bundlePath,
+	bundlePath,
+	directory = bundlePath,
 }: {
-  bundlePath: string;
-  directory?: string;
+	bundlePath: string;
+	directory?: string;
 }): Promise<string[] | null> {
-  try {
-    const entries = await readdir(directory, { withFileTypes: true });
-    const nestedFiles = await Promise.all(
-      entries.map(async (entry): Promise<string[] | null> => {
-        const absolutePath = path.join(directory, entry.name);
-        if (entry.isDirectory()) {
-          return listBundleFiles({ bundlePath, directory: absolutePath });
-        }
-        if (!entry.isFile()) return null;
-        return [
-          path.relative(bundlePath, absolutePath).split(path.sep).join("/"),
-        ];
-      }),
-    );
-    if (nestedFiles.some((files) => files === null)) return null;
-    return nestedFiles.flatMap((files) => files ?? []).sort();
-  } catch {
-    return null;
-  }
+	try {
+		const entries = await readdir(directory, { withFileTypes: true });
+		const nestedFiles = await Promise.all(
+			entries.map(async (entry): Promise<string[] | null> => {
+				const absolutePath = path.join(directory, entry.name);
+				if (entry.isDirectory()) {
+					return listBundleFiles({ bundlePath, directory: absolutePath });
+				}
+				if (!entry.isFile()) return null;
+				return [
+					path.relative(bundlePath, absolutePath).split(path.sep).join("/"),
+				];
+			})
+		);
+		if (nestedFiles.some((files) => files === null)) return null;
+		return nestedFiles.flatMap((files) => files ?? []).sort();
+	} catch {
+		return null;
+	}
 }
 
 async function hasExpectedBundleContents({
-  bundlePath,
-  manifest,
+	bundlePath,
+	manifest,
 }: {
-  bundlePath: string;
-  manifest: CoreMLBundleManifest;
+	bundlePath: string;
+	manifest: CoreMLBundleManifest;
 }) {
-  if (path.basename(bundlePath) !== manifest.bundleName) return false;
-  const expectedFiles = normalizedManifest({ manifest }).files;
-  const actualPaths = await listBundleFiles({ bundlePath });
-  if (
-    actualPaths === null ||
-    actualPaths.length !== expectedFiles.length ||
-    actualPaths.some(
-      (actualPath, index) => actualPath !== expectedFiles[index].path,
-    )
-  ) {
-    return false;
-  }
-  try {
-    const matches = await Promise.all(
-      expectedFiles.map(async (expectedFile) => {
-        const contents = await readFile(
-          path.join(bundlePath, ...expectedFile.path.split("/")),
-        );
-        return (
-          contents.length === expectedFile.size &&
-          createHash("sha256").update(contents).digest("hex") ===
-            expectedFile.sha256
-        );
-      }),
-    );
-    return (
-      matches.every(Boolean) && (await hasExpectedTensorSchema({ bundlePath }))
-    );
-  } catch {
-    return false;
-  }
+	if (path.basename(bundlePath) !== manifest.bundleName) return false;
+	const expectedFiles = normalizedManifest({ manifest }).files;
+	const actualPaths = await listBundleFiles({ bundlePath });
+	if (
+		actualPaths === null ||
+		actualPaths.length !== expectedFiles.length ||
+		actualPaths.some(
+			(actualPath, index) => actualPath !== expectedFiles[index].path
+		)
+	) {
+		return false;
+	}
+	try {
+		const matches = await Promise.all(
+			expectedFiles.map(async (expectedFile) => {
+				const contents = await readFile(
+					path.join(bundlePath, ...expectedFile.path.split("/"))
+				);
+				return (
+					contents.length === expectedFile.size &&
+					createHash("sha256").update(contents).digest("hex") ===
+						expectedFile.sha256
+				);
+			})
+		);
+		return (
+			matches.every(Boolean) && (await hasExpectedTensorSchema({ bundlePath }))
+		);
+	} catch {
+		return false;
+	}
 }
 
 async function isPublishedBundleValid({
-  bundlePath,
-  cacheDirectory,
-  manifest,
+	bundlePath,
+	cacheDirectory,
+	manifest,
 }: {
-  bundlePath: string;
-  cacheDirectory: string;
-  manifest: CoreMLBundleManifest;
+	bundlePath: string;
+	cacheDirectory: string;
+	manifest: CoreMLBundleManifest;
 }) {
-  try {
-    const publishedManifest = await readFile(
-      path.join(cacheDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
-      "utf8",
-    );
-    if (publishedManifest !== manifestContents({ manifest })) return false;
-    return hasExpectedBundleContents({ bundlePath, manifest });
-  } catch {
-    return false;
-  }
+	try {
+		const publishedManifest = await readFile(
+			path.join(cacheDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
+			"utf8"
+		);
+		if (publishedManifest !== manifestContents({ manifest })) return false;
+		return hasExpectedBundleContents({ bundlePath, manifest });
+	} catch {
+		return false;
+	}
 }
 
 export function findPackedCoreMLArchiveOffset({
-  modelContents,
+	modelContents,
 }: {
-  modelContents: Buffer;
+	modelContents: Buffer;
 }) {
-  const offset = modelContents.indexOf(ZIP_LOCAL_FILE_HEADER);
-  if (offset <= 0) {
-    throw new Error("物体抠像模型不包含可读取的 CoreML 网络");
-  }
-  return offset;
+	const offset = modelContents.indexOf(ZIP_LOCAL_FILE_HEADER);
+	if (offset <= 0) {
+		throw new Error("物体抠像模型不包含可读取的 CoreML 网络");
+	}
+	return offset;
 }
 
 function coreMLCacheRoot() {
-  return (
-    process.env.QCUT_VIDEO_OBJECT_COREML_CACHE_ROOT ??
-    path.join(
-      os.homedir(),
-      "Library",
-      "Caches",
-      "QCut",
-      "jianying-video-object-coreml",
-    )
-  );
+	return (
+		process.env.QCUT_VIDEO_OBJECT_COREML_CACHE_ROOT ??
+		path.join(
+			os.homedir(),
+			"Library",
+			"Caches",
+			"QCut",
+			"jianying-video-object-coreml"
+		)
+	);
 }
 
 export function createVideoObjectCoreMLCache({
-  expectedManifest,
-  lockTiming,
+	expectedManifest,
+	lockTiming,
 }: {
-  expectedManifest: CoreMLBundleManifest;
-  lockTiming?: AtomicPublishLockTiming;
+	expectedManifest: CoreMLBundleManifest;
+	lockTiming?: AtomicPublishLockTiming;
 }) {
-  const manifest = normalizedManifest({ manifest: expectedManifest });
+	const manifest = normalizedManifest({ manifest: expectedManifest });
 
-  async function isReadable({ modelPath }: { modelPath: string }) {
-    try {
-      await access(modelPath, constants.R_OK);
-      return isPublishedBundleValid({
-        bundlePath: modelPath,
-        cacheDirectory: path.dirname(modelPath),
-        manifest,
-      });
-    } catch {
-      return false;
-    }
-  }
+	async function isReadable({ modelPath }: { modelPath: string }) {
+		try {
+			await access(modelPath, constants.R_OK);
+			return isPublishedBundleValid({
+				bundlePath: modelPath,
+				cacheDirectory: path.dirname(modelPath),
+				manifest,
+			});
+		} catch {
+			return false;
+		}
+	}
 
-  async function prepare({
-    modelPath,
-    modelSha256,
-  }: {
-    modelPath: string;
-    modelSha256: string;
-  }) {
-    if (modelSha256 !== manifest.packedModelSha256) {
-      throw new Error("物体抠像 packed model 与 CoreML 内容清单不匹配");
-    }
-    const cacheRoot = coreMLCacheRoot();
-    const cacheDirectory = path.join(cacheRoot, modelSha256);
-    const cachedBundle = path.join(cacheDirectory, manifest.bundleName);
-    if (
-      await isPublishedBundleValid({
-        bundlePath: cachedBundle,
-        cacheDirectory,
-        manifest,
-      })
-    ) {
-      return cachedBundle;
-    }
+	async function prepare({
+		modelPath,
+		modelSha256,
+	}: {
+		modelPath: string;
+		modelSha256: string;
+	}) {
+		if (modelSha256 !== manifest.packedModelSha256) {
+			throw new Error("物体抠像 packed model 与 CoreML 内容清单不匹配");
+		}
+		const cacheRoot = coreMLCacheRoot();
+		const cacheDirectory = path.join(cacheRoot, modelSha256);
+		const cachedBundle = path.join(cacheDirectory, manifest.bundleName);
+		if (
+			await isPublishedBundleValid({
+				bundlePath: cachedBundle,
+				cacheDirectory,
+				manifest,
+			})
+		) {
+			return cachedBundle;
+		}
 
-    await mkdir(cacheRoot, { recursive: true });
-    return withAtomicPublishLock({
-      lockPath: path.join(cacheRoot, `${modelSha256}.publish-lock`),
-      timing: lockTiming,
-      action: async () => {
-        if (
-          await isPublishedBundleValid({
-            bundlePath: cachedBundle,
-            cacheDirectory,
-            manifest,
-          })
-        ) {
-          return cachedBundle;
-        }
+		await mkdir(cacheRoot, { recursive: true });
+		return withAtomicPublishLock({
+			lockPath: path.join(cacheRoot, `${modelSha256}.publish-lock`),
+			timing: lockTiming,
+			action: async () => {
+				if (
+					await isPublishedBundleValid({
+						bundlePath: cachedBundle,
+						cacheDirectory,
+						manifest,
+					})
+				) {
+					return cachedBundle;
+				}
 
-        const temporaryDirectory = await mkdtemp(
-          path.join(cacheRoot, `${modelSha256}.extracting-`),
-        );
-        try {
-          const modelContents = await readFile(modelPath);
-          const archiveOffset = findPackedCoreMLArchiveOffset({
-            modelContents,
-          });
-          const archivePath = path.join(temporaryDirectory, "model.zip");
-          await writeFile(archivePath, modelContents.subarray(archiveOffset));
-          await execFileAsync("/usr/bin/ditto", [
-            "-x",
-            "-k",
-            archivePath,
-            temporaryDirectory,
-          ]);
-          await rm(archivePath, { force: true });
-          const extractedBundle = path.join(
-            temporaryDirectory,
-            manifest.bundleName,
-          );
-          if (
-            !(await hasExpectedBundleContents({
-              bundlePath: extractedBundle,
-              manifest,
-            }))
-          ) {
-            throw new Error("物体抠像 CoreML 网络内容不符合已验证模型");
-          }
-          await writeFile(
-            path.join(temporaryDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
-            manifestContents({ manifest }),
-            "utf8",
-          );
-          if (
-            !(await isPublishedBundleValid({
-              bundlePath: extractedBundle,
-              cacheDirectory: temporaryDirectory,
-              manifest,
-            }))
-          ) {
-            throw new Error("物体抠像 CoreML 缓存发布校验失败");
-          }
-          await rm(cacheDirectory, { force: true, recursive: true });
-          await rename(temporaryDirectory, cacheDirectory);
-          return cachedBundle;
-        } finally {
-          await rm(temporaryDirectory, { force: true, recursive: true });
-        }
-      },
-    });
-  }
+				const temporaryDirectory = await mkdtemp(
+					path.join(cacheRoot, `${modelSha256}.extracting-`)
+				);
+				try {
+					const modelContents = await readFile(modelPath);
+					const archiveOffset = findPackedCoreMLArchiveOffset({
+						modelContents,
+					});
+					const archivePath = path.join(temporaryDirectory, "model.zip");
+					await writeFile(archivePath, modelContents.subarray(archiveOffset));
+					await execFileAsync("/usr/bin/ditto", [
+						"-x",
+						"-k",
+						archivePath,
+						temporaryDirectory,
+					]);
+					await rm(archivePath, { force: true });
+					const extractedBundle = path.join(
+						temporaryDirectory,
+						manifest.bundleName
+					);
+					if (
+						!(await hasExpectedBundleContents({
+							bundlePath: extractedBundle,
+							manifest,
+						}))
+					) {
+						throw new Error("物体抠像 CoreML 网络内容不符合已验证模型");
+					}
+					await writeFile(
+						path.join(temporaryDirectory, COREML_BUNDLE_MANIFEST_FILE_NAME),
+						manifestContents({ manifest }),
+						"utf8"
+					);
+					if (
+						!(await isPublishedBundleValid({
+							bundlePath: extractedBundle,
+							cacheDirectory: temporaryDirectory,
+							manifest,
+						}))
+					) {
+						throw new Error("物体抠像 CoreML 缓存发布校验失败");
+					}
+					await rm(cacheDirectory, { force: true, recursive: true });
+					await rename(temporaryDirectory, cacheDirectory);
+					return cachedBundle;
+				} finally {
+					await rm(temporaryDirectory, { force: true, recursive: true });
+				}
+			},
+		});
+	}
 
-  return { isReadable, prepare };
+	return { isReadable, prepare };
 }
 
 const verifiedVideoObjectCoreMLCache = createVideoObjectCoreMLCache({
-  expectedManifest: VERIFIED_VIDEO_OBJECT_BUNDLE_MANIFEST,
+	expectedManifest: VERIFIED_VIDEO_OBJECT_BUNDLE_MANIFEST,
 });
 
 export const prepareVideoObjectCoreMLModel =
-  verifiedVideoObjectCoreMLCache.prepare;
+	verifiedVideoObjectCoreMLCache.prepare;
 export const isReadableCoreMLModel = verifiedVideoObjectCoreMLCache.isReadable;

--- a/qcut/electron/jianying-person-cutout/video-object-runtime-closure.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-runtime-closure.ts
@@ -1,0 +1,297 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { mapWithConcurrency } from "../lib/map-with-concurrency.js";
+
+const RUNTIME_MANIFEST_FILE_NAME = "qcut-effect-runtime.json";
+const HASH_CONCURRENCY = 4;
+export const VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES = [
+  [
+    "Frameworks/libAGFX.dylib",
+    "1b9493940eebda3b79d72b7308adf8abfbff56c9cfce9d7d73b31cd080453eee",
+  ],
+  [
+    "Frameworks/libByteVC1_dec.dylib",
+    "1934d8af041763669bf671ae4bc36920b50a671112eee97e238d59e2c6f4f80a",
+  ],
+  [
+    "Frameworks/libEGL.dylib",
+    "9b47714f4e4db6a99567a361df7d68fe3f1ba1ce0f2277a7c2d13f8df144cedc",
+  ],
+  [
+    "Frameworks/libGLESv2.dylib",
+    "6553b3bf3900e51c31d81d1734b689410aec7eedd48e199b8909e6824763842f",
+  ],
+  [
+    "Frameworks/libIESAppLogger.dylib",
+    "90e6e7b203d42c3315c704e4912288e9a6e9fab7db310e404a48657b1c662687",
+  ],
+  [
+    "Frameworks/libLumiGeneRuntime.dylib",
+    "2ef804016a7e3c359c9cbb430a33d15eee37b6a9c274e27d00246dfdadb907ab",
+  ],
+  [
+    "Frameworks/libavcodec.dylib",
+    "83dcaf3834b561ef9cb7dfe23979053932ae075e33bae60c1c1ffccdb2f3c831",
+  ],
+  [
+    "Frameworks/libavdevice.dylib",
+    "e50acfe1423795507e0e8a8beec6a22504e4b3484961d617700cc1389f33e0c9",
+  ],
+  [
+    "Frameworks/libavfilter.dylib",
+    "04bca9d6227f80b916fa149f2f786e6ccfaa264e58d3903d3eccc347eb6e6ea0",
+  ],
+  [
+    "Frameworks/libavformat.dylib",
+    "e3e123b6f6efdfebbd20fbd554006a6da8348671150eaa8ff27999edad00dc04",
+  ],
+  [
+    "Frameworks/libavutil.dylib",
+    "647f031c96f4e75506c8a663970e06594f15ac76196b1d0d82e1f2c1273b8fd1",
+  ],
+  [
+    "Frameworks/libbytenn.dylib",
+    "febfce4549cd6337c232c22ed00463a54cda7b255c4961426a33bfc78542b863",
+  ],
+  [
+    "Frameworks/libcccreator.dylib",
+    "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9",
+  ],
+  [
+    "Frameworks/libdav1d.dylib",
+    "08f14e26884aa68653471bf737d1e619def2376d256c57265dc443bdf8fc3751",
+  ],
+  [
+    "Frameworks/libfastcv.dylib",
+    "679fc0665d9e24a6130f1bf53cc04d7a54edde4fcba6d9607e4559b627ae066f",
+  ],
+  [
+    "Frameworks/libffmpeg.dylib",
+    "f9d7e2346b80bb14265ee274bb69cadaa5e7d8b86ab14339290f9fa6cb2231e5",
+  ],
+  [
+    "Frameworks/liblens.dylib",
+    "fdf576dd066a11db7b54d815621893ed62a8ed223e22834d5753738dc66df161",
+  ],
+  [
+    "Frameworks/libmp3lame.0.dylib",
+    "7e94d5e4ac4f9bba67399b3f161fb4f6297ed9a56e7772ca805ebbd2e8905294",
+  ],
+  [
+    "Frameworks/libsamicore.dylib",
+    "79494a89151fbf4b11ac8093e993a58ca075b2f379d17b4ccba309ec1aca6214",
+  ],
+  [
+    "Frameworks/libsscronet.dylib",
+    "0f9f0b5adfd2128dc12b1885c60b5f4a0099fb0cddf0fbc5f8eef108a0f2428c",
+  ],
+  [
+    "Frameworks/libswresample.dylib",
+    "b87bdbb71fb77ebe00a25709fc47ffaf2edbd9850aff698ba8e6e0fa2e4db53d",
+  ],
+  [
+    "Frameworks/libswscale.dylib",
+    "114efa544ceced50e59d24956ae4bb8d0b42679389f0e251b6da43fde1b918bd",
+  ],
+  [
+    "Frameworks/libvecryptor.dylib",
+    "8cc1f5cf094ee0dd8673a3c626f51892d6bd37ea15a178e3c80246c939a3a81e",
+  ],
+] as const;
+
+export const VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256 =
+  "e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e";
+export const VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER = `jianying-runtime-framework-closure-d634-v1-${VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256}`;
+
+interface RuntimeManifestFile {
+  bytes: number;
+  path: string;
+  sha256: string;
+}
+
+interface RuntimeManifest {
+  cloudUpload: false;
+  coreUuid: string;
+  files: RuntimeManifestFile[];
+  localOnly: true;
+  schemaVersion: 1;
+}
+
+interface DependencyInspection {
+  bytes: number;
+  sha256: string | null;
+}
+
+type InspectDependency = (input: {
+  filePath: string;
+}) => Promise<DependencyInspection>;
+
+function isSafeRelativePath({ value }: { value: string }) {
+  return (
+    value.length > 0 &&
+    !path.isAbsolute(value) &&
+    !value.split(/[\\/]/).includes("..")
+  );
+}
+
+function parseRuntimeManifest({ value }: { value: unknown }) {
+  if (!value || typeof value !== "object") return null;
+  const manifest = value as Partial<RuntimeManifest>;
+  if (
+    manifest.schemaVersion !== 1 ||
+    manifest.localOnly !== true ||
+    manifest.cloudUpload !== false ||
+    typeof manifest.coreUuid !== "string" ||
+    !Array.isArray(manifest.files)
+  ) {
+    return null;
+  }
+  const filesAreValid = manifest.files.every((file) => {
+    if (!file || typeof file !== "object") return false;
+    return (
+      typeof file.path === "string" &&
+      isSafeRelativePath({ value: file.path }) &&
+      Number.isSafeInteger(file.bytes) &&
+      file.bytes >= 0 &&
+      typeof file.sha256 === "string" &&
+      /^[a-f0-9]{64}$/.test(file.sha256)
+    );
+  });
+  if (!filesAreValid) return null;
+  const paths = manifest.files.map((file) => file.path);
+  if (new Set(paths).size !== paths.length) return null;
+  return manifest as RuntimeManifest;
+}
+
+function dependencyClosureSha256({
+  dependencies,
+}: {
+  dependencies: ReadonlyArray<readonly [string, string]>;
+}) {
+  const canonical = [...dependencies]
+    .sort(([leftPath], [rightPath]) =>
+      leftPath < rightPath ? -1 : leftPath > rightPath ? 1 : 0,
+    )
+    .map(
+      ([dependencyPath, sha256]) =>
+        `${path.posix.basename(dependencyPath)}=${sha256}\n`,
+    )
+    .join("");
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+async function sha256Stream({ filePath }: { filePath: string }) {
+  const hash = createHash("sha256");
+  await pipeline(
+    createReadStream(filePath),
+    new Writable({
+      write(chunk: Buffer, _encoding, callback) {
+        hash.update(chunk);
+        callback();
+      },
+    }),
+  );
+  return hash.digest("hex");
+}
+
+async function inspectDependency({
+  filePath,
+}: {
+  filePath: string;
+}): Promise<DependencyInspection> {
+  const [metadata, sha256] = await Promise.all([
+    stat(filePath),
+    sha256Stream({ filePath }),
+  ]);
+  return {
+    bytes: metadata.isFile() ? metadata.size : -1,
+    sha256,
+  };
+}
+
+export async function verifyVideoObjectBachDependencyClosure({
+  expectedCoreUuid,
+  expectedRuntimeSha256,
+  inspect = inspectDependency,
+  runtimeRoot,
+}: {
+  expectedCoreUuid: string;
+  expectedRuntimeSha256: string;
+  inspect?: InspectDependency;
+  runtimeRoot: string;
+}) {
+  const manifest = parseRuntimeManifest({
+    value: JSON.parse(
+      await readFile(
+        path.join(runtimeRoot, RUNTIME_MANIFEST_FILE_NAME),
+        "utf8",
+      ),
+    ) as unknown,
+  });
+  if (!manifest || manifest.coreUuid !== expectedCoreUuid) {
+    throw new Error(
+      "Jianying runtime manifest does not match the audited UUID",
+    );
+  }
+  const manifestByPath = new Map(
+    manifest.files.map((file) => [file.path, file]),
+  );
+  const runtimeEntry = manifestByPath.get("Frameworks/libcccreator.dylib");
+  if (!runtimeEntry || runtimeEntry.sha256 !== expectedRuntimeSha256) {
+    throw new Error("Jianying runtime manifest does not pin libcccreator");
+  }
+  const manifestFrameworkPaths = manifest.files
+    .filter(
+      (file) =>
+        file.path.startsWith("Frameworks/") && file.path.endsWith(".dylib"),
+    )
+    .map((file) => file.path)
+    .sort();
+  const auditedFrameworkPaths =
+    VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.map(
+      ([dependencyPath]) => dependencyPath,
+    ).sort();
+  if (
+    JSON.stringify(manifestFrameworkPaths) !==
+    JSON.stringify(auditedFrameworkPaths)
+  ) {
+    throw new Error("Jianying runtime dependency inventory is incomplete");
+  }
+  await mapWithConcurrency({
+    items: VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
+    limit: HASH_CONCURRENCY,
+    task: async ({ item: [dependencyPath, expectedSha256] }) => {
+      const manifestEntry = manifestByPath.get(dependencyPath);
+      if (!manifestEntry || manifestEntry.sha256 !== expectedSha256) {
+        throw new Error(
+          `Jianying runtime manifest has a mixed dependency: ${dependencyPath}`,
+        );
+      }
+      const actual = await inspect({
+        filePath: path.join(runtimeRoot, ...dependencyPath.split("/")),
+      });
+      if (
+        actual.sha256 !== expectedSha256 ||
+        actual.bytes !== manifestEntry.bytes
+      ) {
+        throw new Error(
+          `Jianying runtime dependency checksum mismatch: ${dependencyPath}`,
+        );
+      }
+    },
+  });
+  const actualClosureSha256 = dependencyClosureSha256({
+    dependencies: VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
+  });
+  if (actualClosureSha256 !== VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256) {
+    throw new Error("Jianying runtime dependency closure identity is stale");
+  }
+  return {
+    dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+    dependencyClosureSha256: actualClosureSha256,
+  };
+}

--- a/qcut/electron/jianying-person-cutout/video-object-runtime-closure.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-runtime-closure.ts
@@ -9,289 +9,286 @@ import { mapWithConcurrency } from "../lib/map-with-concurrency.js";
 const RUNTIME_MANIFEST_FILE_NAME = "qcut-effect-runtime.json";
 const HASH_CONCURRENCY = 4;
 export const VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES = [
-  [
-    "Frameworks/libAGFX.dylib",
-    "1b9493940eebda3b79d72b7308adf8abfbff56c9cfce9d7d73b31cd080453eee",
-  ],
-  [
-    "Frameworks/libByteVC1_dec.dylib",
-    "1934d8af041763669bf671ae4bc36920b50a671112eee97e238d59e2c6f4f80a",
-  ],
-  [
-    "Frameworks/libEGL.dylib",
-    "9b47714f4e4db6a99567a361df7d68fe3f1ba1ce0f2277a7c2d13f8df144cedc",
-  ],
-  [
-    "Frameworks/libGLESv2.dylib",
-    "6553b3bf3900e51c31d81d1734b689410aec7eedd48e199b8909e6824763842f",
-  ],
-  [
-    "Frameworks/libIESAppLogger.dylib",
-    "90e6e7b203d42c3315c704e4912288e9a6e9fab7db310e404a48657b1c662687",
-  ],
-  [
-    "Frameworks/libLumiGeneRuntime.dylib",
-    "2ef804016a7e3c359c9cbb430a33d15eee37b6a9c274e27d00246dfdadb907ab",
-  ],
-  [
-    "Frameworks/libavcodec.dylib",
-    "83dcaf3834b561ef9cb7dfe23979053932ae075e33bae60c1c1ffccdb2f3c831",
-  ],
-  [
-    "Frameworks/libavdevice.dylib",
-    "e50acfe1423795507e0e8a8beec6a22504e4b3484961d617700cc1389f33e0c9",
-  ],
-  [
-    "Frameworks/libavfilter.dylib",
-    "04bca9d6227f80b916fa149f2f786e6ccfaa264e58d3903d3eccc347eb6e6ea0",
-  ],
-  [
-    "Frameworks/libavformat.dylib",
-    "e3e123b6f6efdfebbd20fbd554006a6da8348671150eaa8ff27999edad00dc04",
-  ],
-  [
-    "Frameworks/libavutil.dylib",
-    "647f031c96f4e75506c8a663970e06594f15ac76196b1d0d82e1f2c1273b8fd1",
-  ],
-  [
-    "Frameworks/libbytenn.dylib",
-    "febfce4549cd6337c232c22ed00463a54cda7b255c4961426a33bfc78542b863",
-  ],
-  [
-    "Frameworks/libcccreator.dylib",
-    "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9",
-  ],
-  [
-    "Frameworks/libdav1d.dylib",
-    "08f14e26884aa68653471bf737d1e619def2376d256c57265dc443bdf8fc3751",
-  ],
-  [
-    "Frameworks/libfastcv.dylib",
-    "679fc0665d9e24a6130f1bf53cc04d7a54edde4fcba6d9607e4559b627ae066f",
-  ],
-  [
-    "Frameworks/libffmpeg.dylib",
-    "f9d7e2346b80bb14265ee274bb69cadaa5e7d8b86ab14339290f9fa6cb2231e5",
-  ],
-  [
-    "Frameworks/liblens.dylib",
-    "fdf576dd066a11db7b54d815621893ed62a8ed223e22834d5753738dc66df161",
-  ],
-  [
-    "Frameworks/libmp3lame.0.dylib",
-    "7e94d5e4ac4f9bba67399b3f161fb4f6297ed9a56e7772ca805ebbd2e8905294",
-  ],
-  [
-    "Frameworks/libsamicore.dylib",
-    "79494a89151fbf4b11ac8093e993a58ca075b2f379d17b4ccba309ec1aca6214",
-  ],
-  [
-    "Frameworks/libsscronet.dylib",
-    "0f9f0b5adfd2128dc12b1885c60b5f4a0099fb0cddf0fbc5f8eef108a0f2428c",
-  ],
-  [
-    "Frameworks/libswresample.dylib",
-    "b87bdbb71fb77ebe00a25709fc47ffaf2edbd9850aff698ba8e6e0fa2e4db53d",
-  ],
-  [
-    "Frameworks/libswscale.dylib",
-    "114efa544ceced50e59d24956ae4bb8d0b42679389f0e251b6da43fde1b918bd",
-  ],
-  [
-    "Frameworks/libvecryptor.dylib",
-    "8cc1f5cf094ee0dd8673a3c626f51892d6bd37ea15a178e3c80246c939a3a81e",
-  ],
+	[
+		"Frameworks/libAGFX.dylib",
+		"1b9493940eebda3b79d72b7308adf8abfbff56c9cfce9d7d73b31cd080453eee",
+	],
+	[
+		"Frameworks/libByteVC1_dec.dylib",
+		"1934d8af041763669bf671ae4bc36920b50a671112eee97e238d59e2c6f4f80a",
+	],
+	[
+		"Frameworks/libEGL.dylib",
+		"9b47714f4e4db6a99567a361df7d68fe3f1ba1ce0f2277a7c2d13f8df144cedc",
+	],
+	[
+		"Frameworks/libGLESv2.dylib",
+		"6553b3bf3900e51c31d81d1734b689410aec7eedd48e199b8909e6824763842f",
+	],
+	[
+		"Frameworks/libIESAppLogger.dylib",
+		"90e6e7b203d42c3315c704e4912288e9a6e9fab7db310e404a48657b1c662687",
+	],
+	[
+		"Frameworks/libLumiGeneRuntime.dylib",
+		"2ef804016a7e3c359c9cbb430a33d15eee37b6a9c274e27d00246dfdadb907ab",
+	],
+	[
+		"Frameworks/libavcodec.dylib",
+		"83dcaf3834b561ef9cb7dfe23979053932ae075e33bae60c1c1ffccdb2f3c831",
+	],
+	[
+		"Frameworks/libavdevice.dylib",
+		"e50acfe1423795507e0e8a8beec6a22504e4b3484961d617700cc1389f33e0c9",
+	],
+	[
+		"Frameworks/libavfilter.dylib",
+		"04bca9d6227f80b916fa149f2f786e6ccfaa264e58d3903d3eccc347eb6e6ea0",
+	],
+	[
+		"Frameworks/libavformat.dylib",
+		"e3e123b6f6efdfebbd20fbd554006a6da8348671150eaa8ff27999edad00dc04",
+	],
+	[
+		"Frameworks/libavutil.dylib",
+		"647f031c96f4e75506c8a663970e06594f15ac76196b1d0d82e1f2c1273b8fd1",
+	],
+	[
+		"Frameworks/libbytenn.dylib",
+		"febfce4549cd6337c232c22ed00463a54cda7b255c4961426a33bfc78542b863",
+	],
+	[
+		"Frameworks/libcccreator.dylib",
+		"0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9",
+	],
+	[
+		"Frameworks/libdav1d.dylib",
+		"08f14e26884aa68653471bf737d1e619def2376d256c57265dc443bdf8fc3751",
+	],
+	[
+		"Frameworks/libfastcv.dylib",
+		"679fc0665d9e24a6130f1bf53cc04d7a54edde4fcba6d9607e4559b627ae066f",
+	],
+	[
+		"Frameworks/libffmpeg.dylib",
+		"f9d7e2346b80bb14265ee274bb69cadaa5e7d8b86ab14339290f9fa6cb2231e5",
+	],
+	[
+		"Frameworks/liblens.dylib",
+		"fdf576dd066a11db7b54d815621893ed62a8ed223e22834d5753738dc66df161",
+	],
+	[
+		"Frameworks/libmp3lame.0.dylib",
+		"7e94d5e4ac4f9bba67399b3f161fb4f6297ed9a56e7772ca805ebbd2e8905294",
+	],
+	[
+		"Frameworks/libsamicore.dylib",
+		"79494a89151fbf4b11ac8093e993a58ca075b2f379d17b4ccba309ec1aca6214",
+	],
+	[
+		"Frameworks/libsscronet.dylib",
+		"0f9f0b5adfd2128dc12b1885c60b5f4a0099fb0cddf0fbc5f8eef108a0f2428c",
+	],
+	[
+		"Frameworks/libswresample.dylib",
+		"b87bdbb71fb77ebe00a25709fc47ffaf2edbd9850aff698ba8e6e0fa2e4db53d",
+	],
+	[
+		"Frameworks/libswscale.dylib",
+		"114efa544ceced50e59d24956ae4bb8d0b42679389f0e251b6da43fde1b918bd",
+	],
+	[
+		"Frameworks/libvecryptor.dylib",
+		"8cc1f5cf094ee0dd8673a3c626f51892d6bd37ea15a178e3c80246c939a3a81e",
+	],
 ] as const;
 
 export const VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256 =
-  "e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e";
+	"e462db26eb23dc6b21829912dd97010b9dde33ee6659f22a481c11690c0f7c2e";
 export const VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER = `jianying-runtime-framework-closure-d634-v1-${VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256}`;
 
 interface RuntimeManifestFile {
-  bytes: number;
-  path: string;
-  sha256: string;
+	bytes: number;
+	path: string;
+	sha256: string;
 }
 
 interface RuntimeManifest {
-  cloudUpload: false;
-  coreUuid: string;
-  files: RuntimeManifestFile[];
-  localOnly: true;
-  schemaVersion: 1;
+	cloudUpload: false;
+	coreUuid: string;
+	files: RuntimeManifestFile[];
+	localOnly: true;
+	schemaVersion: 1;
 }
 
 interface DependencyInspection {
-  bytes: number;
-  sha256: string | null;
+	bytes: number;
+	sha256: string | null;
 }
 
 type InspectDependency = (input: {
-  filePath: string;
+	filePath: string;
 }) => Promise<DependencyInspection>;
 
 function isSafeRelativePath({ value }: { value: string }) {
-  return (
-    value.length > 0 &&
-    !path.isAbsolute(value) &&
-    !value.split(/[\\/]/).includes("..")
-  );
+	return (
+		value.length > 0 &&
+		!path.isAbsolute(value) &&
+		!value.split(/[\\/]/).includes("..")
+	);
 }
 
 function parseRuntimeManifest({ value }: { value: unknown }) {
-  if (!value || typeof value !== "object") return null;
-  const manifest = value as Partial<RuntimeManifest>;
-  if (
-    manifest.schemaVersion !== 1 ||
-    manifest.localOnly !== true ||
-    manifest.cloudUpload !== false ||
-    typeof manifest.coreUuid !== "string" ||
-    !Array.isArray(manifest.files)
-  ) {
-    return null;
-  }
-  const filesAreValid = manifest.files.every((file) => {
-    if (!file || typeof file !== "object") return false;
-    return (
-      typeof file.path === "string" &&
-      isSafeRelativePath({ value: file.path }) &&
-      Number.isSafeInteger(file.bytes) &&
-      file.bytes >= 0 &&
-      typeof file.sha256 === "string" &&
-      /^[a-f0-9]{64}$/.test(file.sha256)
-    );
-  });
-  if (!filesAreValid) return null;
-  const paths = manifest.files.map((file) => file.path);
-  if (new Set(paths).size !== paths.length) return null;
-  return manifest as RuntimeManifest;
+	if (!value || typeof value !== "object") return null;
+	const manifest = value as Partial<RuntimeManifest>;
+	if (
+		manifest.schemaVersion !== 1 ||
+		manifest.localOnly !== true ||
+		manifest.cloudUpload !== false ||
+		typeof manifest.coreUuid !== "string" ||
+		!Array.isArray(manifest.files)
+	) {
+		return null;
+	}
+	const filesAreValid = manifest.files.every((file) => {
+		if (!file || typeof file !== "object") return false;
+		return (
+			typeof file.path === "string" &&
+			isSafeRelativePath({ value: file.path }) &&
+			Number.isSafeInteger(file.bytes) &&
+			file.bytes >= 0 &&
+			typeof file.sha256 === "string" &&
+			/^[a-f0-9]{64}$/.test(file.sha256)
+		);
+	});
+	if (!filesAreValid) return null;
+	const paths = manifest.files.map((file) => file.path);
+	if (new Set(paths).size !== paths.length) return null;
+	return manifest as RuntimeManifest;
 }
 
 function dependencyClosureSha256({
-  dependencies,
+	dependencies,
 }: {
-  dependencies: ReadonlyArray<readonly [string, string]>;
+	dependencies: ReadonlyArray<readonly [string, string]>;
 }) {
-  const canonical = [...dependencies]
-    .sort(([leftPath], [rightPath]) =>
-      leftPath < rightPath ? -1 : leftPath > rightPath ? 1 : 0,
-    )
-    .map(
-      ([dependencyPath, sha256]) =>
-        `${path.posix.basename(dependencyPath)}=${sha256}\n`,
-    )
-    .join("");
-  return createHash("sha256").update(canonical).digest("hex");
+	const canonical = [...dependencies]
+		.sort(([leftPath], [rightPath]) =>
+			leftPath < rightPath ? -1 : leftPath > rightPath ? 1 : 0
+		)
+		.map(
+			([dependencyPath, sha256]) =>
+				`${path.posix.basename(dependencyPath)}=${sha256}\n`
+		)
+		.join("");
+	return createHash("sha256").update(canonical).digest("hex");
 }
 
 async function sha256Stream({ filePath }: { filePath: string }) {
-  const hash = createHash("sha256");
-  await pipeline(
-    createReadStream(filePath),
-    new Writable({
-      write(chunk: Buffer, _encoding, callback) {
-        hash.update(chunk);
-        callback();
-      },
-    }),
-  );
-  return hash.digest("hex");
+	const hash = createHash("sha256");
+	await pipeline(
+		createReadStream(filePath),
+		new Writable({
+			write(chunk: Buffer, _encoding, callback) {
+				hash.update(chunk);
+				callback();
+			},
+		})
+	);
+	return hash.digest("hex");
 }
 
 async function inspectDependency({
-  filePath,
+	filePath,
 }: {
-  filePath: string;
+	filePath: string;
 }): Promise<DependencyInspection> {
-  const [metadata, sha256] = await Promise.all([
-    stat(filePath),
-    sha256Stream({ filePath }),
-  ]);
-  return {
-    bytes: metadata.isFile() ? metadata.size : -1,
-    sha256,
-  };
+	const [metadata, sha256] = await Promise.all([
+		stat(filePath),
+		sha256Stream({ filePath }),
+	]);
+	return {
+		bytes: metadata.isFile() ? metadata.size : -1,
+		sha256,
+	};
 }
 
 export async function verifyVideoObjectBachDependencyClosure({
-  expectedCoreUuid,
-  expectedRuntimeSha256,
-  inspect = inspectDependency,
-  runtimeRoot,
+	expectedCoreUuid,
+	expectedRuntimeSha256,
+	inspect = inspectDependency,
+	runtimeRoot,
 }: {
-  expectedCoreUuid: string;
-  expectedRuntimeSha256: string;
-  inspect?: InspectDependency;
-  runtimeRoot: string;
+	expectedCoreUuid: string;
+	expectedRuntimeSha256: string;
+	inspect?: InspectDependency;
+	runtimeRoot: string;
 }) {
-  const manifest = parseRuntimeManifest({
-    value: JSON.parse(
-      await readFile(
-        path.join(runtimeRoot, RUNTIME_MANIFEST_FILE_NAME),
-        "utf8",
-      ),
-    ) as unknown,
-  });
-  if (!manifest || manifest.coreUuid !== expectedCoreUuid) {
-    throw new Error(
-      "Jianying runtime manifest does not match the audited UUID",
-    );
-  }
-  const manifestByPath = new Map(
-    manifest.files.map((file) => [file.path, file]),
-  );
-  const runtimeEntry = manifestByPath.get("Frameworks/libcccreator.dylib");
-  if (!runtimeEntry || runtimeEntry.sha256 !== expectedRuntimeSha256) {
-    throw new Error("Jianying runtime manifest does not pin libcccreator");
-  }
-  const manifestFrameworkPaths = manifest.files
-    .filter(
-      (file) =>
-        file.path.startsWith("Frameworks/") && file.path.endsWith(".dylib"),
-    )
-    .map((file) => file.path)
-    .sort();
-  const auditedFrameworkPaths =
-    VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.map(
-      ([dependencyPath]) => dependencyPath,
-    ).sort();
-  if (
-    JSON.stringify(manifestFrameworkPaths) !==
-    JSON.stringify(auditedFrameworkPaths)
-  ) {
-    throw new Error("Jianying runtime dependency inventory is incomplete");
-  }
-  await mapWithConcurrency({
-    items: VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
-    limit: HASH_CONCURRENCY,
-    task: async ({ item: [dependencyPath, expectedSha256] }) => {
-      const manifestEntry = manifestByPath.get(dependencyPath);
-      if (!manifestEntry || manifestEntry.sha256 !== expectedSha256) {
-        throw new Error(
-          `Jianying runtime manifest has a mixed dependency: ${dependencyPath}`,
-        );
-      }
-      const actual = await inspect({
-        filePath: path.join(runtimeRoot, ...dependencyPath.split("/")),
-      });
-      if (
-        actual.sha256 !== expectedSha256 ||
-        actual.bytes !== manifestEntry.bytes
-      ) {
-        throw new Error(
-          `Jianying runtime dependency checksum mismatch: ${dependencyPath}`,
-        );
-      }
-    },
-  });
-  const actualClosureSha256 = dependencyClosureSha256({
-    dependencies: VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
-  });
-  if (actualClosureSha256 !== VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256) {
-    throw new Error("Jianying runtime dependency closure identity is stale");
-  }
-  return {
-    dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-    dependencyClosureSha256: actualClosureSha256,
-  };
+	const manifest = parseRuntimeManifest({
+		value: JSON.parse(
+			await readFile(path.join(runtimeRoot, RUNTIME_MANIFEST_FILE_NAME), "utf8")
+		) as unknown,
+	});
+	if (!manifest || manifest.coreUuid !== expectedCoreUuid) {
+		throw new Error(
+			"Jianying runtime manifest does not match the audited UUID"
+		);
+	}
+	const manifestByPath = new Map(
+		manifest.files.map((file) => [file.path, file])
+	);
+	const runtimeEntry = manifestByPath.get("Frameworks/libcccreator.dylib");
+	if (!runtimeEntry || runtimeEntry.sha256 !== expectedRuntimeSha256) {
+		throw new Error("Jianying runtime manifest does not pin libcccreator");
+	}
+	const manifestFrameworkPaths = manifest.files
+		.filter(
+			(file) =>
+				file.path.startsWith("Frameworks/") && file.path.endsWith(".dylib")
+		)
+		.map((file) => file.path)
+		.sort();
+	const auditedFrameworkPaths =
+		VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES.map(
+			([dependencyPath]) => dependencyPath
+		).sort();
+	if (
+		JSON.stringify(manifestFrameworkPaths) !==
+		JSON.stringify(auditedFrameworkPaths)
+	) {
+		throw new Error("Jianying runtime dependency inventory is incomplete");
+	}
+	await mapWithConcurrency({
+		items: VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
+		limit: HASH_CONCURRENCY,
+		task: async ({ item: [dependencyPath, expectedSha256] }) => {
+			const manifestEntry = manifestByPath.get(dependencyPath);
+			if (!manifestEntry || manifestEntry.sha256 !== expectedSha256) {
+				throw new Error(
+					`Jianying runtime manifest has a mixed dependency: ${dependencyPath}`
+				);
+			}
+			const actual = await inspect({
+				filePath: path.join(runtimeRoot, ...dependencyPath.split("/")),
+			});
+			if (
+				actual.sha256 !== expectedSha256 ||
+				actual.bytes !== manifestEntry.bytes
+			) {
+				throw new Error(
+					`Jianying runtime dependency checksum mismatch: ${dependencyPath}`
+				);
+			}
+		},
+	});
+	const actualClosureSha256 = dependencyClosureSha256({
+		dependencies: VIDEO_OBJECT_BACH_AUDITED_FRAMEWORK_DEPENDENCIES,
+	});
+	if (actualClosureSha256 !== VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256) {
+		throw new Error("Jianying runtime dependency closure identity is stale");
+	}
+	return {
+		dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+		dependencyClosureSha256: actualClosureSha256,
+	};
 }

--- a/qcut/electron/jianying-person-cutout/video-object-runtime.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-runtime.ts
@@ -3,10 +3,10 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
-  firstMatchingDirectory,
-  firstMatchingFile,
-  sha256File,
-  VIDEO_FUSION_LIBRARY_SHA256,
+	firstMatchingDirectory,
+	firstMatchingFile,
+	sha256File,
+	VIDEO_FUSION_LIBRARY_SHA256,
 } from "./runtime-assets.js";
 import { resolveJianyingSaliencyBridge } from "./saliency-bridge-resolver.js";
 import type { VideoObjectExecutionBackend } from "./pipeline-descriptor.js";
@@ -15,659 +15,659 @@ import { resolveVideoObjectBachBridge } from "./video-object-bach-bridge-resolve
 import { resolveVideoObjectCoreMLBridge } from "./video-object-coreml-bridge-resolver.js";
 import { prepareVideoObjectCoreMLModel } from "./video-object-coreml-runtime.js";
 import {
-  verifyVideoObjectBachDependencyClosure,
-  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+	verifyVideoObjectBachDependencyClosure,
+	VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+	VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
 } from "./video-object-runtime-closure.js";
 
 export const VIDEO_OBJECT_GRAPH_SHA256 =
-  "797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b";
+	"797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b";
 export const VIDEO_OBJECT_BACH_RUNTIME_UUID =
-  "D6342ECD-5432-33F0-A2AD-0C28F5699994";
+	"D6342ECD-5432-33F0-A2AD-0C28F5699994";
 export const VIDEO_OBJECT_BACH_RUNTIME_SHA256 =
-  "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9";
+	"0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9";
 const VIDEO_OBJECT_MODEL = {
-  name: "video_saliency_seg_bce_v1.0_size100_md57b601afc96d910a40a4dd17c0c43c96a.model",
-  sha256: "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+	name: "video_saliency_seg_bce_v1.0_size100_md57b601afc96d910a40a4dd17c0c43c96a.model",
+	sha256: "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
 } as const;
 const VIDEO_OBJECT_GRAPH_MAX_DIMENSION = 512;
 export const VIDEO_OBJECT_COREML_PROCESSOR_VERSION =
-  "source-rgba-direct-256-v2";
+	"source-rgba-direct-256-v2";
 export const VIDEO_OBJECT_BACH_PROCESSOR_VERSION =
-  "jianying-bach-d634-tematting-blend-v2-source-alpha-v1";
+	"jianying-bach-d634-tematting-blend-v2-source-alpha-v1";
 export const VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY = {
-  dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
-  dependencyClosureSha256: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
-  effectRegistration: "jianying-bach-algorithm-plus-tematting-blend-v2",
-  graphSha256: VIDEO_OBJECT_GRAPH_SHA256,
-  hostEffectRegistry: "not-required-bach-direct",
-  implementationRole: "audited-jianying-runtime",
-  inputTransport: "ite-video-frame-cvpixelbuffer-bgra-v1",
-  modelSha256: VIDEO_OBJECT_MODEL.sha256,
-  outputContract: "tematting-blend-effect-v2-source-alpha-u8-v1",
-  postprocess: "TEMattingBlendEffectV2-vendor-exact",
-  readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
-  refinement: "vendor-v2-exact-no-qcut-refinement-v1",
-  runtimeSha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
-  runtimeUuid: VIDEO_OBJECT_BACH_RUNTIME_UUID,
-  temporalState: "te-bach-matting-session-v1",
+	dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+	dependencyClosureSha256: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+	effectRegistration: "jianying-bach-algorithm-plus-tematting-blend-v2",
+	graphSha256: VIDEO_OBJECT_GRAPH_SHA256,
+	hostEffectRegistry: "not-required-bach-direct",
+	implementationRole: "audited-jianying-runtime",
+	inputTransport: "ite-video-frame-cvpixelbuffer-bgra-v1",
+	modelSha256: VIDEO_OBJECT_MODEL.sha256,
+	outputContract: "tematting-blend-effect-v2-source-alpha-u8-v1",
+	postprocess: "TEMattingBlendEffectV2-vendor-exact",
+	readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
+	refinement: "vendor-v2-exact-no-qcut-refinement-v1",
+	runtimeSha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+	runtimeUuid: VIDEO_OBJECT_BACH_RUNTIME_UUID,
+	temporalState: "te-bach-matting-session-v1",
 } as const;
 export const VIDEO_OBJECT_PROVIDER_CAPABILITY = {
-  effectRegistration: "not-required-direct-coreml",
-  hostEffectRegistry: "bypassed",
-  implementationRole: "private-host-independent-fallback",
-  inputTransport: "same-model-coreml-source-rgba-direct-256-v2",
-  inputTransportStatus: "bach-capture-close-not-bit-exact-frame0",
-  modelResolution: "resolved",
-  modelResolver: "packed-model-coreml-extractor-v1",
-  outputValidation: "coreml-tensor-contract-v1",
-  readiness: "same-model-coreml-validated",
-  temporalState: "previous-image-and-mask-v1",
+	effectRegistration: "not-required-direct-coreml",
+	hostEffectRegistry: "bypassed",
+	implementationRole: "private-host-independent-fallback",
+	inputTransport: "same-model-coreml-source-rgba-direct-256-v2",
+	inputTransportStatus: "bach-capture-close-not-bit-exact-frame0",
+	modelResolution: "resolved",
+	modelResolver: "packed-model-coreml-extractor-v1",
+	outputValidation: "coreml-tensor-contract-v1",
+	readiness: "same-model-coreml-validated",
+	temporalState: "previous-image-and-mask-v1",
 } as const;
 export const VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY = {
-  effectRegistration: "qcut-generated-standalone-effect-v1",
-  hostEffectRegistry: "not-reproduced",
-  inputTransport: "effect-c-api-texture-v1",
-  inputTransportStatus: "host-context-unverified",
-  modelResolution: "resolved",
-  modelResolver: "effect-c-api-file-resource-finder-v1",
-  outputValidation: VIDEO_OBJECT_ALPHA_QUALITY_FAILURE,
-  readiness: "output-gated-candidate",
+	effectRegistration: "qcut-generated-standalone-effect-v1",
+	hostEffectRegistry: "not-reproduced",
+	inputTransport: "effect-c-api-texture-v1",
+	inputTransportStatus: "host-context-unverified",
+	modelResolution: "resolved",
+	modelResolver: "effect-c-api-file-resource-finder-v1",
+	outputValidation: VIDEO_OBJECT_ALPHA_QUALITY_FAILURE,
+	readiness: "output-gated-candidate",
 } as const;
 const EFFECT_CONFIG = `${JSON.stringify(
-  {
-    bALG_BACH_CONFIG: true,
-    effect: {
-      Link: [],
-      model_names: { matting: ["video_saliency_seg_bce"] },
-    },
-    name: "ai_matting_video_object",
-    version: "16.5.0",
-  },
-  null,
-  2,
+	{
+		bALG_BACH_CONFIG: true,
+		effect: {
+			Link: [],
+			model_names: { matting: ["video_saliency_seg_bce"] },
+		},
+		name: "ai_matting_video_object",
+		version: "16.5.0",
+	},
+	null,
+	2
 )}\n`;
 
 function roundToEven({ value }: { value: number }) {
-  return Math.max(2, Math.round(value / 2) * 2);
+	return Math.max(2, Math.round(value / 2) * 2);
 }
 
 export function calculateVideoObjectGraphSize({
-  height,
-  width,
+	height,
+	width,
 }: {
-  height: number;
-  width: number;
+	height: number;
+	width: number;
 }) {
-  if (
-    !Number.isFinite(width) ||
-    !Number.isFinite(height) ||
-    width <= 0 ||
-    height <= 0
-  ) {
-    throw new Error("视频尺寸无效");
-  }
-  const scale = VIDEO_OBJECT_GRAPH_MAX_DIMENSION / Math.max(width, height);
-  return {
-    width: roundToEven({ value: width * scale }),
-    height: roundToEven({ value: height * scale }),
-  };
+	if (
+		!Number.isFinite(width) ||
+		!Number.isFinite(height) ||
+		width <= 0 ||
+		height <= 0
+	) {
+		throw new Error("视频尺寸无效");
+	}
+	const scale = VIDEO_OBJECT_GRAPH_MAX_DIMENSION / Math.max(width, height);
+	return {
+		width: roundToEven({ value: width * scale }),
+		height: roundToEven({ value: height * scale }),
+	};
 }
 
 function createAlgorithmConfig({
-  height,
-  width,
+	height,
+	width,
 }: {
-  height: number;
-  width: number;
+	height: number;
+	width: number;
 }) {
-  const graphSize = calculateVideoObjectGraphSize({ height, width });
-  return `${JSON.stringify(
-    {
-      version: "1.0",
-      mode: 2,
-      name: "AlgorithmGraph_9bpck63bYbqbZAcfdUcjcAbNdWcf",
-      nodes: [
-        {
-          name: "video_saliency_seg_0",
-          type: "general_seg",
-          config: {
-            keyMaps: {
-              intParam: {},
-              floatParam: {},
-              stringParam: { model_name: "video_saliency_seg_bce" },
-              pathParam: {},
-            },
-          },
-        },
-        {
-          name: "textureBlitter",
-          type: "texture_blit",
-          config: {
-            size: graphSize,
-            keyMaps: { intParam: {}, floatParam: {}, stringParam: {} },
-          },
-        },
-      ],
-      links: [
-        {
-          fromNode: "textureBlitter",
-          fromIndex: 0,
-          toNode: "video_saliency_seg_0",
-          toIndex: 0,
-        },
-      ],
-    },
-    null,
-    2,
-  )}\n`;
+	const graphSize = calculateVideoObjectGraphSize({ height, width });
+	return `${JSON.stringify(
+		{
+			version: "1.0",
+			mode: 2,
+			name: "AlgorithmGraph_9bpck63bYbqbZAcfdUcjcAbNdWcf",
+			nodes: [
+				{
+					name: "video_saliency_seg_0",
+					type: "general_seg",
+					config: {
+						keyMaps: {
+							intParam: {},
+							floatParam: {},
+							stringParam: { model_name: "video_saliency_seg_bce" },
+							pathParam: {},
+						},
+					},
+				},
+				{
+					name: "textureBlitter",
+					type: "texture_blit",
+					config: {
+						size: graphSize,
+						keyMaps: { intParam: {}, floatParam: {}, stringParam: {} },
+					},
+				},
+			],
+			links: [
+				{
+					fromNode: "textureBlitter",
+					fromIndex: 0,
+					toNode: "video_saliency_seg_0",
+					toIndex: 0,
+				},
+			],
+		},
+		null,
+		2
+	)}\n`;
 }
 
 export interface JianyingVideoObjectRuntimeCandidate {
-  bridgePath: string;
-  capabilitySha256: string;
-  coreMLModelPath: string | null;
-  dependencyClosureSha256: string | null;
-  effectDirectory: string | null;
-  executionBackend: VideoObjectExecutionBackend;
-  frameworkDirectory: string | null;
-  graphDirectory: string | null;
-  libraryPath: string | null;
-  modelDirectory: string;
-  modelPath: string;
-  modelSha256: string;
-  processorSha256: string;
-  providerCapability:
-    | typeof VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY
-    | typeof VIDEO_OBJECT_PROVIDER_CAPABILITY
-    | typeof VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY;
-  readiness:
-    | typeof VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY.readiness
-    | typeof VIDEO_OBJECT_PROVIDER_CAPABILITY.readiness
-    | typeof VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY.readiness;
+	bridgePath: string;
+	capabilitySha256: string;
+	coreMLModelPath: string | null;
+	dependencyClosureSha256: string | null;
+	effectDirectory: string | null;
+	executionBackend: VideoObjectExecutionBackend;
+	frameworkDirectory: string | null;
+	graphDirectory: string | null;
+	libraryPath: string | null;
+	modelDirectory: string;
+	modelPath: string;
+	modelSha256: string;
+	processorSha256: string;
+	providerCapability:
+		| typeof VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY
+		| typeof VIDEO_OBJECT_PROVIDER_CAPABILITY
+		| typeof VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY;
+	readiness:
+		| typeof VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY.readiness
+		| typeof VIDEO_OBJECT_PROVIDER_CAPABILITY.readiness
+		| typeof VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY.readiness;
 }
 
 export function createVideoObjectRuntimeFingerprints({
-  backend = "same-model-coreml-v1",
-  bridgeSha256,
-  height,
-  width,
+	backend = "same-model-coreml-v1",
+	bridgeSha256,
+	height,
+	width,
 }: {
-  backend?: VideoObjectExecutionBackend;
-  bridgeSha256: string;
-  height: number;
-  width: number;
+	backend?: VideoObjectExecutionBackend;
+	bridgeSha256: string;
+	height: number;
+	width: number;
 }) {
-  const providerCapability =
-    backend === "jianying-bach-v2-exact-d634-v1"
-      ? VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY
-      : backend === "same-model-coreml-v1"
-        ? VIDEO_OBJECT_PROVIDER_CAPABILITY
-        : VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY;
-  const runtimeFingerprint =
-    backend === "jianying-bach-v2-exact-d634-v1"
-      ? `${VIDEO_OBJECT_BACH_RUNTIME_SHA256}:${VIDEO_OBJECT_BACH_RUNTIME_UUID}:${VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256}`
-      : backend === "same-model-coreml-v1"
-        ? "coreml-system-runtime-v1"
-        : VIDEO_FUSION_LIBRARY_SHA256;
-  const capabilitySha256 = createHash("sha256")
-    .update(bridgeSha256)
-    .update(runtimeFingerprint)
-    .update(VIDEO_OBJECT_GRAPH_SHA256)
-    .update(VIDEO_OBJECT_MODEL.sha256)
-    .update(EFFECT_CONFIG)
-    .update(JSON.stringify(providerCapability))
-    .digest("hex");
-  return {
-    capabilitySha256,
-    processorSha256: createHash("sha256")
-      .update(capabilitySha256)
-      .update(
-        backend === "jianying-bach-v2-exact-d634-v1"
-          ? VIDEO_OBJECT_BACH_PROCESSOR_VERSION
-          : VIDEO_OBJECT_COREML_PROCESSOR_VERSION,
-      )
-      .update(
-        backend === "effect-host-interop-v1"
-          ? createAlgorithmConfig({ height, width })
-          : JSON.stringify({ height, width, system: os.release() }),
-      )
-      .digest("hex"),
-  };
+	const providerCapability =
+		backend === "jianying-bach-v2-exact-d634-v1"
+			? VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY
+			: backend === "same-model-coreml-v1"
+				? VIDEO_OBJECT_PROVIDER_CAPABILITY
+				: VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY;
+	const runtimeFingerprint =
+		backend === "jianying-bach-v2-exact-d634-v1"
+			? `${VIDEO_OBJECT_BACH_RUNTIME_SHA256}:${VIDEO_OBJECT_BACH_RUNTIME_UUID}:${VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256}`
+			: backend === "same-model-coreml-v1"
+				? "coreml-system-runtime-v1"
+				: VIDEO_FUSION_LIBRARY_SHA256;
+	const capabilitySha256 = createHash("sha256")
+		.update(bridgeSha256)
+		.update(runtimeFingerprint)
+		.update(VIDEO_OBJECT_GRAPH_SHA256)
+		.update(VIDEO_OBJECT_MODEL.sha256)
+		.update(EFFECT_CONFIG)
+		.update(JSON.stringify(providerCapability))
+		.digest("hex");
+	return {
+		capabilitySha256,
+		processorSha256: createHash("sha256")
+			.update(capabilitySha256)
+			.update(
+				backend === "jianying-bach-v2-exact-d634-v1"
+					? VIDEO_OBJECT_BACH_PROCESSOR_VERSION
+					: VIDEO_OBJECT_COREML_PROCESSOR_VERSION
+			)
+			.update(
+				backend === "effect-host-interop-v1"
+					? createAlgorithmConfig({ height, width })
+					: JSON.stringify({ height, width, system: os.release() })
+			)
+			.digest("hex"),
+	};
 }
 
 async function writeGeneratedFile({
-  contents,
-  filePath,
+	contents,
+	filePath,
 }: {
-  contents: string;
-  filePath: string;
+	contents: string;
+	filePath: string;
 }) {
-  try {
-    if ((await readFile(filePath, "utf8")) === contents) return;
-  } catch {
-    // Missing or partial cache files are repaired atomically below.
-  }
-  const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
-  await writeFile(temporaryPath, contents, "utf8");
-  await rename(temporaryPath, filePath);
+	try {
+		if ((await readFile(filePath, "utf8")) === contents) return;
+	} catch {
+		// Missing or partial cache files are repaired atomically below.
+	}
+	const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+	await writeFile(temporaryPath, contents, "utf8");
+	await rename(temporaryPath, filePath);
 }
 
 async function prepareEffectDirectory({
-  graphSha256,
-  height,
-  width,
+	graphSha256,
+	height,
+	width,
 }: {
-  graphSha256: string;
-  height: number;
-  width: number;
+	graphSha256: string;
+	height: number;
+	width: number;
 }) {
-  const algorithmConfig = createAlgorithmConfig({ height, width });
-  const fingerprint = createHash("sha256")
-    .update(graphSha256)
-    .update(EFFECT_CONFIG)
-    .update(algorithmConfig)
-    .digest("hex")
-    .slice(0, 16);
-  const directory = path.join(
-    os.homedir(),
-    "Library",
-    "Caches",
-    "QCut",
-    "jianying-video-object-effect",
-    fingerprint,
-  );
-  await mkdir(directory, { recursive: true });
-  await Promise.all([
-    writeGeneratedFile({
-      contents: algorithmConfig,
-      filePath: path.join(directory, "algorithmConfig.json"),
-    }),
-    writeGeneratedFile({
-      contents: EFFECT_CONFIG,
-      filePath: path.join(directory, "config.json"),
-    }),
-  ]);
-  return directory;
+	const algorithmConfig = createAlgorithmConfig({ height, width });
+	const fingerprint = createHash("sha256")
+		.update(graphSha256)
+		.update(EFFECT_CONFIG)
+		.update(algorithmConfig)
+		.digest("hex")
+		.slice(0, 16);
+	const directory = path.join(
+		os.homedir(),
+		"Library",
+		"Caches",
+		"QCut",
+		"jianying-video-object-effect",
+		fingerprint
+	);
+	await mkdir(directory, { recursive: true });
+	await Promise.all([
+		writeGeneratedFile({
+			contents: algorithmConfig,
+			filePath: path.join(directory, "algorithmConfig.json"),
+		}),
+		writeGeneratedFile({
+			contents: EFFECT_CONFIG,
+			filePath: path.join(directory, "config.json"),
+		}),
+	]);
+	return directory;
 }
 
 interface VideoObjectRuntimeAssetRoots {
-  configuredRoot: string | undefined;
-  jianyingEffectRoot: string;
-  privateRuntimeRoot: string;
+	configuredRoot: string | undefined;
+	jianyingEffectRoot: string;
+	privateRuntimeRoot: string;
 }
 
 function videoObjectRuntimeAssetRoots(): VideoObjectRuntimeAssetRoots {
-  const home = os.homedir();
-  return {
-    configuredRoot: process.env.QCUT_JIANYING_VIDEO_OBJECT_RUNTIME,
-    jianyingEffectRoot: path.join(
-      home,
-      "Movies",
-      "JianyingPro",
-      "User Data",
-      "Cache",
-      "effect",
-    ),
-    privateRuntimeRoot: path.join(
-      home,
-      "Library",
-      "Application Support",
-      "QCut",
-      "PrivateRuntimes",
-    ),
-  };
+	const home = os.homedir();
+	return {
+		configuredRoot: process.env.QCUT_JIANYING_VIDEO_OBJECT_RUNTIME,
+		jianyingEffectRoot: path.join(
+			home,
+			"Movies",
+			"JianyingPro",
+			"User Data",
+			"Cache",
+			"effect"
+		),
+		privateRuntimeRoot: path.join(
+			home,
+			"Library",
+			"Application Support",
+			"QCut",
+			"PrivateRuntimes"
+		),
+	};
 }
 
 async function resolveVideoObjectModelDirectory({
-  roots,
+	roots,
 }: {
-  roots: VideoObjectRuntimeAssetRoots;
+	roots: VideoObjectRuntimeAssetRoots;
 }) {
-  const { configuredRoot, jianyingEffectRoot, privateRuntimeRoot } = roots;
-  return firstMatchingDirectory({
-    candidates: [
-      ...(configuredRoot
-        ? [
-            path.join(configuredRoot, "Models"),
-            path.join(configuredRoot, "Models", "user-cache"),
-          ]
-        : []),
-      path.join(
-        privateRuntimeRoot,
-        "JianyingTransition",
-        "current",
-        "Models",
-        "user-cache",
-      ),
-      path.join(privateRuntimeRoot, "JianyingSaliency", "current", "Models"),
-      path.join(privateRuntimeRoot, "JianyingFilter", "current", "Models"),
-      path.join(jianyingEffectRoot, "model"),
-    ],
-    files: [VIDEO_OBJECT_MODEL],
-  });
+	const { configuredRoot, jianyingEffectRoot, privateRuntimeRoot } = roots;
+	return firstMatchingDirectory({
+		candidates: [
+			...(configuredRoot
+				? [
+						path.join(configuredRoot, "Models"),
+						path.join(configuredRoot, "Models", "user-cache"),
+					]
+				: []),
+			path.join(
+				privateRuntimeRoot,
+				"JianyingTransition",
+				"current",
+				"Models",
+				"user-cache"
+			),
+			path.join(privateRuntimeRoot, "JianyingSaliency", "current", "Models"),
+			path.join(privateRuntimeRoot, "JianyingFilter", "current", "Models"),
+			path.join(jianyingEffectRoot, "model"),
+		],
+		files: [VIDEO_OBJECT_MODEL],
+	});
 }
 
 function videoObjectGraphCandidates({
-  roots,
+	roots,
 }: {
-  roots: VideoObjectRuntimeAssetRoots;
+	roots: VideoObjectRuntimeAssetRoots;
 }) {
-  const { configuredRoot, jianyingEffectRoot, privateRuntimeRoot } = roots;
-  return [
-    ...(configuredRoot
-      ? [
-          path.join(configuredRoot, "SourceEffect", "algorithmConfig.json"),
-          path.join(
-            configuredRoot,
-            "Models",
-            "app-bundle",
-            "matting_config",
-            "ai_matting_video_object",
-            "algorithmConfig.json",
-          ),
-        ]
-      : []),
-    path.join(
-      privateRuntimeRoot,
-      "JianyingTransition",
-      "current",
-      "Models",
-      "app-bundle",
-      "matting_config",
-      "ai_matting_video_object",
-      "algorithmConfig.json",
-    ),
-    path.join(
-      privateRuntimeRoot,
-      "JianyingVideoObject",
-      "current",
-      "SourceEffect",
-      "algorithmConfig.json",
-    ),
-    path.join(
-      jianyingEffectRoot,
-      "7366590389928595994",
-      "94715bdc841b34cd5451b4b9c181bde4",
-      "ai_matting_video_object",
-      "algorithmConfig.json",
-    ),
-  ];
+	const { configuredRoot, jianyingEffectRoot, privateRuntimeRoot } = roots;
+	return [
+		...(configuredRoot
+			? [
+					path.join(configuredRoot, "SourceEffect", "algorithmConfig.json"),
+					path.join(
+						configuredRoot,
+						"Models",
+						"app-bundle",
+						"matting_config",
+						"ai_matting_video_object",
+						"algorithmConfig.json"
+					),
+				]
+			: []),
+		path.join(
+			privateRuntimeRoot,
+			"JianyingTransition",
+			"current",
+			"Models",
+			"app-bundle",
+			"matting_config",
+			"ai_matting_video_object",
+			"algorithmConfig.json"
+		),
+		path.join(
+			privateRuntimeRoot,
+			"JianyingVideoObject",
+			"current",
+			"SourceEffect",
+			"algorithmConfig.json"
+		),
+		path.join(
+			jianyingEffectRoot,
+			"7366590389928595994",
+			"94715bdc841b34cd5451b4b9c181bde4",
+			"ai_matting_video_object",
+			"algorithmConfig.json"
+		),
+	];
 }
 
 async function resolveBachVideoObjectCandidate({
-  height,
-  modelDirectory,
-  modelPath,
-  roots,
-  width,
+	height,
+	modelDirectory,
+	modelPath,
+	roots,
+	width,
 }: {
-  height: number;
-  modelDirectory: string;
-  modelPath: string;
-  roots: VideoObjectRuntimeAssetRoots;
-  width: number;
+	height: number;
+	modelDirectory: string;
+	modelPath: string;
+	roots: VideoObjectRuntimeAssetRoots;
+	width: number;
 }): Promise<JianyingVideoObjectRuntimeCandidate | null> {
-  try {
-    const { configuredRoot, privateRuntimeRoot } = roots;
-    const [bridgePath, graphPath, libraryPath] = await Promise.all([
-      resolveVideoObjectBachBridge(),
-      firstMatchingFile({
-        candidates: videoObjectGraphCandidates({ roots }),
-        sha256: VIDEO_OBJECT_GRAPH_SHA256,
-      }),
-      firstMatchingFile({
-        candidates: [
-          ...(configuredRoot
-            ? [path.join(configuredRoot, "Frameworks", "libcccreator.dylib")]
-            : []),
-          path.join(
-            privateRuntimeRoot,
-            "JianyingTransition",
-            "current",
-            "Frameworks",
-            "libcccreator.dylib",
-          ),
-          path.join(
-            privateRuntimeRoot,
-            "JianyingFilter",
-            "current",
-            "Frameworks",
-            "libcccreator.dylib",
-          ),
-        ],
-        sha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
-      }),
-    ]);
-    if (!bridgePath || !graphPath || !libraryPath) return null;
-    const dependencyClosure = await verifyVideoObjectBachDependencyClosure({
-      expectedCoreUuid: VIDEO_OBJECT_BACH_RUNTIME_UUID,
-      expectedRuntimeSha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
-      runtimeRoot: path.dirname(path.dirname(libraryPath)),
-    });
-    const bridgeSha256 = await sha256File({ filePath: bridgePath });
-    if (!bridgeSha256) return null;
-    const fingerprints = createVideoObjectRuntimeFingerprints({
-      backend: "jianying-bach-v2-exact-d634-v1",
-      bridgeSha256,
-      height,
-      width,
-    });
-    return {
-      bridgePath,
-      capabilitySha256: fingerprints.capabilitySha256,
-      coreMLModelPath: null,
-      dependencyClosureSha256: dependencyClosure.dependencyClosureSha256,
-      effectDirectory: null,
-      executionBackend: "jianying-bach-v2-exact-d634-v1",
-      frameworkDirectory: path.dirname(libraryPath),
-      graphDirectory: path.dirname(graphPath),
-      libraryPath,
-      modelDirectory,
-      modelPath,
-      modelSha256: VIDEO_OBJECT_MODEL.sha256,
-      processorSha256: fingerprints.processorSha256,
-      providerCapability: VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY,
-      readiness: VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY.readiness,
-    };
-  } catch (error) {
-    console.warn(
-      "QCut could not prepare the audited Jianying Bach runtime.",
-      error,
-    );
-    return null;
-  }
+	try {
+		const { configuredRoot, privateRuntimeRoot } = roots;
+		const [bridgePath, graphPath, libraryPath] = await Promise.all([
+			resolveVideoObjectBachBridge(),
+			firstMatchingFile({
+				candidates: videoObjectGraphCandidates({ roots }),
+				sha256: VIDEO_OBJECT_GRAPH_SHA256,
+			}),
+			firstMatchingFile({
+				candidates: [
+					...(configuredRoot
+						? [path.join(configuredRoot, "Frameworks", "libcccreator.dylib")]
+						: []),
+					path.join(
+						privateRuntimeRoot,
+						"JianyingTransition",
+						"current",
+						"Frameworks",
+						"libcccreator.dylib"
+					),
+					path.join(
+						privateRuntimeRoot,
+						"JianyingFilter",
+						"current",
+						"Frameworks",
+						"libcccreator.dylib"
+					),
+				],
+				sha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+			}),
+		]);
+		if (!bridgePath || !graphPath || !libraryPath) return null;
+		const dependencyClosure = await verifyVideoObjectBachDependencyClosure({
+			expectedCoreUuid: VIDEO_OBJECT_BACH_RUNTIME_UUID,
+			expectedRuntimeSha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+			runtimeRoot: path.dirname(path.dirname(libraryPath)),
+		});
+		const bridgeSha256 = await sha256File({ filePath: bridgePath });
+		if (!bridgeSha256) return null;
+		const fingerprints = createVideoObjectRuntimeFingerprints({
+			backend: "jianying-bach-v2-exact-d634-v1",
+			bridgeSha256,
+			height,
+			width,
+		});
+		return {
+			bridgePath,
+			capabilitySha256: fingerprints.capabilitySha256,
+			coreMLModelPath: null,
+			dependencyClosureSha256: dependencyClosure.dependencyClosureSha256,
+			effectDirectory: null,
+			executionBackend: "jianying-bach-v2-exact-d634-v1",
+			frameworkDirectory: path.dirname(libraryPath),
+			graphDirectory: path.dirname(graphPath),
+			libraryPath,
+			modelDirectory,
+			modelPath,
+			modelSha256: VIDEO_OBJECT_MODEL.sha256,
+			processorSha256: fingerprints.processorSha256,
+			providerCapability: VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY,
+			readiness: VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY.readiness,
+		};
+	} catch (error) {
+		console.warn(
+			"QCut could not prepare the audited Jianying Bach runtime.",
+			error
+		);
+		return null;
+	}
 }
 
 async function resolveCoreMLVideoObjectCandidate({
-  height,
-  modelDirectory,
-  modelPath,
-  width,
+	height,
+	modelDirectory,
+	modelPath,
+	width,
 }: {
-  height: number;
-  modelDirectory: string;
-  modelPath: string;
-  width: number;
+	height: number;
+	modelDirectory: string;
+	modelPath: string;
+	width: number;
 }): Promise<JianyingVideoObjectRuntimeCandidate | null> {
-  try {
-    const bridgePath = await resolveVideoObjectCoreMLBridge();
-    if (!bridgePath) return null;
-    const coreMLModelPath = await prepareVideoObjectCoreMLModel({
-      modelPath,
-      modelSha256: VIDEO_OBJECT_MODEL.sha256,
-    });
-    const bridgeSha256 = await sha256File({ filePath: bridgePath });
-    if (!bridgeSha256) return null;
-    const fingerprints = createVideoObjectRuntimeFingerprints({
-      bridgeSha256,
-      height,
-      width,
-    });
-    return {
-      bridgePath,
-      capabilitySha256: fingerprints.capabilitySha256,
-      coreMLModelPath,
-      dependencyClosureSha256: null,
-      effectDirectory: null,
-      executionBackend: "same-model-coreml-v1",
-      frameworkDirectory: null,
-      graphDirectory: null,
-      libraryPath: null,
-      modelDirectory,
-      modelPath,
-      modelSha256: VIDEO_OBJECT_MODEL.sha256,
-      processorSha256: fingerprints.processorSha256,
-      providerCapability: VIDEO_OBJECT_PROVIDER_CAPABILITY,
-      readiness: VIDEO_OBJECT_PROVIDER_CAPABILITY.readiness,
-    };
-  } catch (error) {
-    console.warn(
-      "QCut could not prepare the same-model CoreML video-object runtime.",
-      error,
-    );
-    return null;
-  }
+	try {
+		const bridgePath = await resolveVideoObjectCoreMLBridge();
+		if (!bridgePath) return null;
+		const coreMLModelPath = await prepareVideoObjectCoreMLModel({
+			modelPath,
+			modelSha256: VIDEO_OBJECT_MODEL.sha256,
+		});
+		const bridgeSha256 = await sha256File({ filePath: bridgePath });
+		if (!bridgeSha256) return null;
+		const fingerprints = createVideoObjectRuntimeFingerprints({
+			bridgeSha256,
+			height,
+			width,
+		});
+		return {
+			bridgePath,
+			capabilitySha256: fingerprints.capabilitySha256,
+			coreMLModelPath,
+			dependencyClosureSha256: null,
+			effectDirectory: null,
+			executionBackend: "same-model-coreml-v1",
+			frameworkDirectory: null,
+			graphDirectory: null,
+			libraryPath: null,
+			modelDirectory,
+			modelPath,
+			modelSha256: VIDEO_OBJECT_MODEL.sha256,
+			processorSha256: fingerprints.processorSha256,
+			providerCapability: VIDEO_OBJECT_PROVIDER_CAPABILITY,
+			readiness: VIDEO_OBJECT_PROVIDER_CAPABILITY.readiness,
+		};
+	} catch (error) {
+		console.warn(
+			"QCut could not prepare the same-model CoreML video-object runtime.",
+			error
+		);
+		return null;
+	}
 }
 
 async function resolveLegacyHostVideoObjectCandidate({
-  height,
-  modelDirectory,
-  modelPath,
-  roots,
-  width,
+	height,
+	modelDirectory,
+	modelPath,
+	roots,
+	width,
 }: {
-  height: number;
-  modelDirectory: string;
-  modelPath: string;
-  roots: VideoObjectRuntimeAssetRoots;
-  width: number;
+	height: number;
+	modelDirectory: string;
+	modelPath: string;
+	roots: VideoObjectRuntimeAssetRoots;
+	width: number;
 }): Promise<JianyingVideoObjectRuntimeCandidate | null> {
-  try {
-    const { configuredRoot, privateRuntimeRoot } = roots;
-    const [graphPath, libraryPath] = await Promise.all([
-      firstMatchingFile({
-        candidates: videoObjectGraphCandidates({ roots }),
-        sha256: VIDEO_OBJECT_GRAPH_SHA256,
-      }),
-      firstMatchingFile({
-        candidates: [
-          ...(configuredRoot
-            ? [path.join(configuredRoot, "Frameworks", "libcccreator.dylib")]
-            : []),
-          path.join(
-            privateRuntimeRoot,
-            "JianyingVideoObject",
-            "current",
-            "Frameworks",
-            "libcccreator.dylib",
-          ),
-          path.join(
-            "/Applications",
-            "VideoFusion-macOS.app",
-            "Contents",
-            "Frameworks",
-            "libcccreator.dylib",
-          ),
-        ],
-        sha256: VIDEO_FUSION_LIBRARY_SHA256,
-      }),
-    ]);
-    if (!graphPath || !libraryPath) return null;
-    const bridgePath = await resolveJianyingSaliencyBridge();
-    if (!bridgePath) return null;
-    const bridgeSha256 = await sha256File({ filePath: bridgePath });
-    if (!bridgeSha256) return null;
-    const effectDirectory = await prepareEffectDirectory({
-      graphSha256: VIDEO_OBJECT_GRAPH_SHA256,
-      height,
-      width,
-    });
-    const fingerprints = createVideoObjectRuntimeFingerprints({
-      backend: "effect-host-interop-v1",
-      bridgeSha256,
-      height,
-      width,
-    });
-    return {
-      bridgePath,
-      capabilitySha256: fingerprints.capabilitySha256,
-      coreMLModelPath: null,
-      dependencyClosureSha256: null,
-      effectDirectory,
-      executionBackend: "effect-host-interop-v1",
-      frameworkDirectory: path.dirname(libraryPath),
-      graphDirectory: null,
-      libraryPath,
-      modelDirectory,
-      modelPath,
-      modelSha256: VIDEO_OBJECT_MODEL.sha256,
-      providerCapability: VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
-      readiness: VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY.readiness,
-      processorSha256: fingerprints.processorSha256,
-    };
-  } catch (error) {
-    console.warn(
-      "QCut could not prepare the host video-object runtime.",
-      error,
-    );
-    return null;
-  }
+	try {
+		const { configuredRoot, privateRuntimeRoot } = roots;
+		const [graphPath, libraryPath] = await Promise.all([
+			firstMatchingFile({
+				candidates: videoObjectGraphCandidates({ roots }),
+				sha256: VIDEO_OBJECT_GRAPH_SHA256,
+			}),
+			firstMatchingFile({
+				candidates: [
+					...(configuredRoot
+						? [path.join(configuredRoot, "Frameworks", "libcccreator.dylib")]
+						: []),
+					path.join(
+						privateRuntimeRoot,
+						"JianyingVideoObject",
+						"current",
+						"Frameworks",
+						"libcccreator.dylib"
+					),
+					path.join(
+						"/Applications",
+						"VideoFusion-macOS.app",
+						"Contents",
+						"Frameworks",
+						"libcccreator.dylib"
+					),
+				],
+				sha256: VIDEO_FUSION_LIBRARY_SHA256,
+			}),
+		]);
+		if (!graphPath || !libraryPath) return null;
+		const bridgePath = await resolveJianyingSaliencyBridge();
+		if (!bridgePath) return null;
+		const bridgeSha256 = await sha256File({ filePath: bridgePath });
+		if (!bridgeSha256) return null;
+		const effectDirectory = await prepareEffectDirectory({
+			graphSha256: VIDEO_OBJECT_GRAPH_SHA256,
+			height,
+			width,
+		});
+		const fingerprints = createVideoObjectRuntimeFingerprints({
+			backend: "effect-host-interop-v1",
+			bridgeSha256,
+			height,
+			width,
+		});
+		return {
+			bridgePath,
+			capabilitySha256: fingerprints.capabilitySha256,
+			coreMLModelPath: null,
+			dependencyClosureSha256: null,
+			effectDirectory,
+			executionBackend: "effect-host-interop-v1",
+			frameworkDirectory: path.dirname(libraryPath),
+			graphDirectory: null,
+			libraryPath,
+			modelDirectory,
+			modelPath,
+			modelSha256: VIDEO_OBJECT_MODEL.sha256,
+			providerCapability: VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
+			readiness: VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY.readiness,
+			processorSha256: fingerprints.processorSha256,
+		};
+	} catch (error) {
+		console.warn(
+			"QCut could not prepare the host video-object runtime.",
+			error
+		);
+		return null;
+	}
 }
 
 export async function resolveJianyingVideoObjectRuntimeCandidates({
-  height,
-  width,
+	height,
+	width,
 }: {
-  height: number;
-  width: number;
+	height: number;
+	width: number;
 }): Promise<JianyingVideoObjectRuntimeCandidate[]> {
-  if (process.platform !== "darwin") return [];
-  const roots = videoObjectRuntimeAssetRoots();
-  let modelDirectory: string | null;
-  try {
-    modelDirectory = await resolveVideoObjectModelDirectory({ roots });
-  } catch (error) {
-    console.warn("QCut could not locate the video-object model.", error);
-    return [];
-  }
-  if (!modelDirectory) return [];
-  const modelPath = path.join(modelDirectory, VIDEO_OBJECT_MODEL.name);
-  const bach = await resolveBachVideoObjectCandidate({
-    height,
-    modelDirectory,
-    modelPath,
-    roots,
-    width,
-  });
-  const coreML = await resolveCoreMLVideoObjectCandidate({
-    height,
-    modelDirectory,
-    modelPath,
-    width,
-  });
-  const legacyHost = await resolveLegacyHostVideoObjectCandidate({
-    height,
-    modelDirectory,
-    modelPath,
-    roots,
-    width,
-  });
-  return [bach, coreML, legacyHost].filter(
-    (candidate): candidate is JianyingVideoObjectRuntimeCandidate =>
-      candidate !== null,
-  );
+	if (process.platform !== "darwin") return [];
+	const roots = videoObjectRuntimeAssetRoots();
+	let modelDirectory: string | null;
+	try {
+		modelDirectory = await resolveVideoObjectModelDirectory({ roots });
+	} catch (error) {
+		console.warn("QCut could not locate the video-object model.", error);
+		return [];
+	}
+	if (!modelDirectory) return [];
+	const modelPath = path.join(modelDirectory, VIDEO_OBJECT_MODEL.name);
+	const bach = await resolveBachVideoObjectCandidate({
+		height,
+		modelDirectory,
+		modelPath,
+		roots,
+		width,
+	});
+	const coreML = await resolveCoreMLVideoObjectCandidate({
+		height,
+		modelDirectory,
+		modelPath,
+		width,
+	});
+	const legacyHost = await resolveLegacyHostVideoObjectCandidate({
+		height,
+		modelDirectory,
+		modelPath,
+		roots,
+		width,
+	});
+	return [bach, coreML, legacyHost].filter(
+		(candidate): candidate is JianyingVideoObjectRuntimeCandidate =>
+			candidate !== null
+	);
 }
 
 export async function resolveJianyingVideoObjectRuntimeCandidate({
-  height,
-  width,
+	height,
+	width,
 }: {
-  height: number;
-  width: number;
+	height: number;
+	width: number;
 }): Promise<JianyingVideoObjectRuntimeCandidate | null> {
-  return (
-    (await resolveJianyingVideoObjectRuntimeCandidates({ height, width }))[0] ??
-    null
-  );
+	return (
+		(await resolveJianyingVideoObjectRuntimeCandidates({ height, width }))[0] ??
+		null
+	);
 }

--- a/qcut/electron/jianying-person-cutout/video-object-runtime.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-runtime.ts
@@ -1,0 +1,280 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+	firstMatchingDirectory,
+	firstMatchingFile,
+	sha256File,
+	VIDEO_FUSION_LIBRARY_SHA256,
+} from "./runtime-assets.js";
+import { resolveJianyingSaliencyBridge } from "./saliency-bridge-resolver.js";
+
+const VIDEO_OBJECT_GRAPH_SHA256 =
+	"797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b";
+const VIDEO_OBJECT_MODEL = {
+	name: "video_saliency_seg_bce_v1.0_size100_md57b601afc96d910a40a4dd17c0c43c96a.model",
+	sha256: "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+} as const;
+const VIDEO_OBJECT_GRAPH_MAX_DIMENSION = 512;
+const EFFECT_CONFIG = `${JSON.stringify(
+	{
+		bALG_BACH_CONFIG: true,
+		effect: {
+			Link: [],
+			model_names: { matting: ["video_saliency_seg_bce"] },
+		},
+		name: "ai_matting_video_object",
+		version: "16.5.0",
+	},
+	null,
+	2
+)}\n`;
+
+function roundToEven({ value }: { value: number }) {
+	return Math.max(2, Math.round(value / 2) * 2);
+}
+
+export function calculateVideoObjectGraphSize({
+	height,
+	width,
+}: {
+	height: number;
+	width: number;
+}) {
+	if (
+		!Number.isFinite(width) ||
+		!Number.isFinite(height) ||
+		width <= 0 ||
+		height <= 0
+	) {
+		throw new Error("视频尺寸无效");
+	}
+	const scale = VIDEO_OBJECT_GRAPH_MAX_DIMENSION / Math.max(width, height);
+	return {
+		width: roundToEven({ value: width * scale }),
+		height: roundToEven({ value: height * scale }),
+	};
+}
+
+function createAlgorithmConfig({
+	height,
+	width,
+}: {
+	height: number;
+	width: number;
+}) {
+	const graphSize = calculateVideoObjectGraphSize({ height, width });
+	return `${JSON.stringify(
+		{
+			version: "1.0",
+			mode: 2,
+			name: "AlgorithmGraph_9bpck63bYbqbZAcfdUcjcAbNdWcf",
+			nodes: [
+				{
+					name: "video_saliency_seg_0",
+					type: "general_seg",
+					config: {
+						keyMaps: {
+							intParam: {},
+							floatParam: {},
+							stringParam: { model_name: "video_saliency_seg_bce" },
+							pathParam: {},
+						},
+					},
+				},
+				{
+					name: "textureBlitter",
+					type: "texture_blit",
+					config: {
+						size: graphSize,
+						keyMaps: { intParam: {}, floatParam: {}, stringParam: {} },
+					},
+				},
+			],
+			links: [
+				{
+					fromNode: "textureBlitter",
+					fromIndex: 0,
+					toNode: "video_saliency_seg_0",
+					toIndex: 0,
+				},
+			],
+		},
+		null,
+		2
+	)}\n`;
+}
+
+export interface JianyingVideoObjectRuntime {
+	bridgePath: string;
+	effectDirectory: string;
+	frameworkDirectory: string;
+	libraryPath: string;
+	modelDirectory: string;
+	modelSha256: string;
+	processorSha256: string;
+	graphHeight: number;
+	graphWidth: number;
+}
+
+async function writeGeneratedFile({
+	contents,
+	filePath,
+}: {
+	contents: string;
+	filePath: string;
+}) {
+	try {
+		if ((await readFile(filePath, "utf8")) === contents) return;
+	} catch {
+		// Missing or partial cache files are repaired atomically below.
+	}
+	const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+	await writeFile(temporaryPath, contents, "utf8");
+	await rename(temporaryPath, filePath);
+}
+
+async function prepareEffectDirectory({
+	graphSha256,
+	height,
+	width,
+}: {
+	graphSha256: string;
+	height: number;
+	width: number;
+}) {
+	const algorithmConfig = createAlgorithmConfig({ height, width });
+	const fingerprint = createHash("sha256")
+		.update(graphSha256)
+		.update(EFFECT_CONFIG)
+		.update(algorithmConfig)
+		.digest("hex")
+		.slice(0, 16);
+	const directory = path.join(
+		os.homedir(),
+		"Library",
+		"Caches",
+		"QCut",
+		"jianying-video-object-effect",
+		fingerprint
+	);
+	await mkdir(directory, { recursive: true });
+	await Promise.all([
+		writeGeneratedFile({
+			contents: algorithmConfig,
+			filePath: path.join(directory, "algorithmConfig.json"),
+		}),
+		writeGeneratedFile({
+			contents: EFFECT_CONFIG,
+			filePath: path.join(directory, "config.json"),
+		}),
+	]);
+	return directory;
+}
+
+export async function resolveJianyingVideoObjectRuntime({
+	height,
+	width,
+}: {
+	height: number;
+	width: number;
+}): Promise<JianyingVideoObjectRuntime | null> {
+	if (process.platform !== "darwin") return null;
+	const privateRuntimeRoot = path.join(
+		os.homedir(),
+		"Library",
+		"Application Support",
+		"QCut",
+		"PrivateRuntimes"
+	);
+	const jianyingEffectRoot = path.join(
+		os.homedir(),
+		"Movies",
+		"JianyingPro",
+		"User Data",
+		"Cache",
+		"effect"
+	);
+	const configuredRoot = process.env.QCUT_JIANYING_VIDEO_OBJECT_RUNTIME;
+	const modelDirectory = await firstMatchingDirectory({
+		candidates: [
+			...(configuredRoot ? [path.join(configuredRoot, "Models")] : []),
+			path.join(privateRuntimeRoot, "JianyingSaliency", "current", "Models"),
+			path.join(privateRuntimeRoot, "JianyingFilter", "current", "Models"),
+			path.join(jianyingEffectRoot, "model"),
+		],
+		files: [VIDEO_OBJECT_MODEL],
+	});
+	const graphPath = await firstMatchingFile({
+		candidates: [
+			...(configuredRoot
+				? [path.join(configuredRoot, "SourceEffect", "algorithmConfig.json")]
+				: []),
+			path.join(
+				privateRuntimeRoot,
+				"JianyingVideoObject",
+				"current",
+				"SourceEffect",
+				"algorithmConfig.json"
+			),
+			path.join(
+				jianyingEffectRoot,
+				"7366590389928595994",
+				"94715bdc841b34cd5451b4b9c181bde4",
+				"ai_matting_video_object",
+				"algorithmConfig.json"
+			),
+		],
+		sha256: VIDEO_OBJECT_GRAPH_SHA256,
+	});
+	const libraryPath = await firstMatchingFile({
+		candidates: [
+			...(configuredRoot
+				? [path.join(configuredRoot, "Frameworks", "libcccreator.dylib")]
+				: []),
+			path.join(
+				privateRuntimeRoot,
+				"JianyingVideoObject",
+				"current",
+				"Frameworks",
+				"libcccreator.dylib"
+			),
+			path.join(
+				"/Applications",
+				"VideoFusion-macOS.app",
+				"Contents",
+				"Frameworks",
+				"libcccreator.dylib"
+			),
+		],
+		sha256: VIDEO_FUSION_LIBRARY_SHA256,
+	});
+	const bridgePath = await resolveJianyingSaliencyBridge();
+	if (!bridgePath || !graphPath || !libraryPath || !modelDirectory) return null;
+	const bridgeSha256 = await sha256File({ filePath: bridgePath });
+	if (!bridgeSha256) return null;
+	const effectDirectory = await prepareEffectDirectory({
+		graphSha256: VIDEO_OBJECT_GRAPH_SHA256,
+		height,
+		width,
+	});
+	const graphSize = calculateVideoObjectGraphSize({ height, width });
+	return {
+		bridgePath,
+		effectDirectory,
+		frameworkDirectory: path.dirname(libraryPath),
+		libraryPath,
+		modelDirectory,
+		modelSha256: VIDEO_OBJECT_MODEL.sha256,
+		graphHeight: graphSize.height,
+		graphWidth: graphSize.width,
+		processorSha256: createHash("sha256")
+			.update(bridgeSha256)
+			.update(VIDEO_FUSION_LIBRARY_SHA256)
+			.update(VIDEO_OBJECT_GRAPH_SHA256)
+			.update(EFFECT_CONFIG)
+			.update(createAlgorithmConfig({ height, width }))
+			.digest("hex"),
+	};
+}

--- a/qcut/electron/jianying-person-cutout/video-object-runtime.ts
+++ b/qcut/electron/jianying-person-cutout/video-object-runtime.ts
@@ -3,278 +3,671 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
-	firstMatchingDirectory,
-	firstMatchingFile,
-	sha256File,
-	VIDEO_FUSION_LIBRARY_SHA256,
+  firstMatchingDirectory,
+  firstMatchingFile,
+  sha256File,
+  VIDEO_FUSION_LIBRARY_SHA256,
 } from "./runtime-assets.js";
 import { resolveJianyingSaliencyBridge } from "./saliency-bridge-resolver.js";
+import type { VideoObjectExecutionBackend } from "./pipeline-descriptor.js";
+import { VIDEO_OBJECT_ALPHA_QUALITY_FAILURE } from "./video-object-circuit-breaker.js";
+import { resolveVideoObjectBachBridge } from "./video-object-bach-bridge-resolver.js";
+import { resolveVideoObjectCoreMLBridge } from "./video-object-coreml-bridge-resolver.js";
+import { prepareVideoObjectCoreMLModel } from "./video-object-coreml-runtime.js";
+import {
+  verifyVideoObjectBachDependencyClosure,
+  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+  VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+} from "./video-object-runtime-closure.js";
 
-const VIDEO_OBJECT_GRAPH_SHA256 =
-	"797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b";
+export const VIDEO_OBJECT_GRAPH_SHA256 =
+  "797fab4d5b1f0118ae565d3f9128b6a5d550b6af559c6da764c3d7777e1f7f5b";
+export const VIDEO_OBJECT_BACH_RUNTIME_UUID =
+  "D6342ECD-5432-33F0-A2AD-0C28F5699994";
+export const VIDEO_OBJECT_BACH_RUNTIME_SHA256 =
+  "0c39324edc0d8997d7c998c6a0867803b667fd40969e231a90ea502cc1e815b9";
 const VIDEO_OBJECT_MODEL = {
-	name: "video_saliency_seg_bce_v1.0_size100_md57b601afc96d910a40a4dd17c0c43c96a.model",
-	sha256: "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
+  name: "video_saliency_seg_bce_v1.0_size100_md57b601afc96d910a40a4dd17c0c43c96a.model",
+  sha256: "346b64693e02775faff84b6506e6aa8fb399d1060ab7eb3448157eef741849ef",
 } as const;
 const VIDEO_OBJECT_GRAPH_MAX_DIMENSION = 512;
+export const VIDEO_OBJECT_COREML_PROCESSOR_VERSION =
+  "source-rgba-direct-256-v2";
+export const VIDEO_OBJECT_BACH_PROCESSOR_VERSION =
+  "jianying-bach-d634-tematting-blend-v2-source-alpha-v1";
+export const VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY = {
+  dependencyClosureMarker: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_MARKER,
+  dependencyClosureSha256: VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256,
+  effectRegistration: "jianying-bach-algorithm-plus-tematting-blend-v2",
+  graphSha256: VIDEO_OBJECT_GRAPH_SHA256,
+  hostEffectRegistry: "not-required-bach-direct",
+  implementationRole: "audited-jianying-runtime",
+  inputTransport: "ite-video-frame-cvpixelbuffer-bgra-v1",
+  modelSha256: VIDEO_OBJECT_MODEL.sha256,
+  outputContract: "tematting-blend-effect-v2-source-alpha-u8-v1",
+  postprocess: "TEMattingBlendEffectV2-vendor-exact",
+  readiness: "exact-runtime-model-graph-vendor-v2-closure-pinned",
+  refinement: "vendor-v2-exact-no-qcut-refinement-v1",
+  runtimeSha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+  runtimeUuid: VIDEO_OBJECT_BACH_RUNTIME_UUID,
+  temporalState: "te-bach-matting-session-v1",
+} as const;
+export const VIDEO_OBJECT_PROVIDER_CAPABILITY = {
+  effectRegistration: "not-required-direct-coreml",
+  hostEffectRegistry: "bypassed",
+  implementationRole: "private-host-independent-fallback",
+  inputTransport: "same-model-coreml-source-rgba-direct-256-v2",
+  inputTransportStatus: "bach-capture-close-not-bit-exact-frame0",
+  modelResolution: "resolved",
+  modelResolver: "packed-model-coreml-extractor-v1",
+  outputValidation: "coreml-tensor-contract-v1",
+  readiness: "same-model-coreml-validated",
+  temporalState: "previous-image-and-mask-v1",
+} as const;
+export const VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY = {
+  effectRegistration: "qcut-generated-standalone-effect-v1",
+  hostEffectRegistry: "not-reproduced",
+  inputTransport: "effect-c-api-texture-v1",
+  inputTransportStatus: "host-context-unverified",
+  modelResolution: "resolved",
+  modelResolver: "effect-c-api-file-resource-finder-v1",
+  outputValidation: VIDEO_OBJECT_ALPHA_QUALITY_FAILURE,
+  readiness: "output-gated-candidate",
+} as const;
 const EFFECT_CONFIG = `${JSON.stringify(
-	{
-		bALG_BACH_CONFIG: true,
-		effect: {
-			Link: [],
-			model_names: { matting: ["video_saliency_seg_bce"] },
-		},
-		name: "ai_matting_video_object",
-		version: "16.5.0",
-	},
-	null,
-	2
+  {
+    bALG_BACH_CONFIG: true,
+    effect: {
+      Link: [],
+      model_names: { matting: ["video_saliency_seg_bce"] },
+    },
+    name: "ai_matting_video_object",
+    version: "16.5.0",
+  },
+  null,
+  2,
 )}\n`;
 
 function roundToEven({ value }: { value: number }) {
-	return Math.max(2, Math.round(value / 2) * 2);
+  return Math.max(2, Math.round(value / 2) * 2);
 }
 
 export function calculateVideoObjectGraphSize({
-	height,
-	width,
+  height,
+  width,
 }: {
-	height: number;
-	width: number;
+  height: number;
+  width: number;
 }) {
-	if (
-		!Number.isFinite(width) ||
-		!Number.isFinite(height) ||
-		width <= 0 ||
-		height <= 0
-	) {
-		throw new Error("视频尺寸无效");
-	}
-	const scale = VIDEO_OBJECT_GRAPH_MAX_DIMENSION / Math.max(width, height);
-	return {
-		width: roundToEven({ value: width * scale }),
-		height: roundToEven({ value: height * scale }),
-	};
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw new Error("视频尺寸无效");
+  }
+  const scale = VIDEO_OBJECT_GRAPH_MAX_DIMENSION / Math.max(width, height);
+  return {
+    width: roundToEven({ value: width * scale }),
+    height: roundToEven({ value: height * scale }),
+  };
 }
 
 function createAlgorithmConfig({
-	height,
-	width,
+  height,
+  width,
 }: {
-	height: number;
-	width: number;
+  height: number;
+  width: number;
 }) {
-	const graphSize = calculateVideoObjectGraphSize({ height, width });
-	return `${JSON.stringify(
-		{
-			version: "1.0",
-			mode: 2,
-			name: "AlgorithmGraph_9bpck63bYbqbZAcfdUcjcAbNdWcf",
-			nodes: [
-				{
-					name: "video_saliency_seg_0",
-					type: "general_seg",
-					config: {
-						keyMaps: {
-							intParam: {},
-							floatParam: {},
-							stringParam: { model_name: "video_saliency_seg_bce" },
-							pathParam: {},
-						},
-					},
-				},
-				{
-					name: "textureBlitter",
-					type: "texture_blit",
-					config: {
-						size: graphSize,
-						keyMaps: { intParam: {}, floatParam: {}, stringParam: {} },
-					},
-				},
-			],
-			links: [
-				{
-					fromNode: "textureBlitter",
-					fromIndex: 0,
-					toNode: "video_saliency_seg_0",
-					toIndex: 0,
-				},
-			],
-		},
-		null,
-		2
-	)}\n`;
+  const graphSize = calculateVideoObjectGraphSize({ height, width });
+  return `${JSON.stringify(
+    {
+      version: "1.0",
+      mode: 2,
+      name: "AlgorithmGraph_9bpck63bYbqbZAcfdUcjcAbNdWcf",
+      nodes: [
+        {
+          name: "video_saliency_seg_0",
+          type: "general_seg",
+          config: {
+            keyMaps: {
+              intParam: {},
+              floatParam: {},
+              stringParam: { model_name: "video_saliency_seg_bce" },
+              pathParam: {},
+            },
+          },
+        },
+        {
+          name: "textureBlitter",
+          type: "texture_blit",
+          config: {
+            size: graphSize,
+            keyMaps: { intParam: {}, floatParam: {}, stringParam: {} },
+          },
+        },
+      ],
+      links: [
+        {
+          fromNode: "textureBlitter",
+          fromIndex: 0,
+          toNode: "video_saliency_seg_0",
+          toIndex: 0,
+        },
+      ],
+    },
+    null,
+    2,
+  )}\n`;
 }
 
-export interface JianyingVideoObjectRuntime {
-	bridgePath: string;
-	effectDirectory: string;
-	frameworkDirectory: string;
-	libraryPath: string;
-	modelDirectory: string;
-	modelSha256: string;
-	processorSha256: string;
-	graphHeight: number;
-	graphWidth: number;
+export interface JianyingVideoObjectRuntimeCandidate {
+  bridgePath: string;
+  capabilitySha256: string;
+  coreMLModelPath: string | null;
+  dependencyClosureSha256: string | null;
+  effectDirectory: string | null;
+  executionBackend: VideoObjectExecutionBackend;
+  frameworkDirectory: string | null;
+  graphDirectory: string | null;
+  libraryPath: string | null;
+  modelDirectory: string;
+  modelPath: string;
+  modelSha256: string;
+  processorSha256: string;
+  providerCapability:
+    | typeof VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY
+    | typeof VIDEO_OBJECT_PROVIDER_CAPABILITY
+    | typeof VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY;
+  readiness:
+    | typeof VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY.readiness
+    | typeof VIDEO_OBJECT_PROVIDER_CAPABILITY.readiness
+    | typeof VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY.readiness;
+}
+
+export function createVideoObjectRuntimeFingerprints({
+  backend = "same-model-coreml-v1",
+  bridgeSha256,
+  height,
+  width,
+}: {
+  backend?: VideoObjectExecutionBackend;
+  bridgeSha256: string;
+  height: number;
+  width: number;
+}) {
+  const providerCapability =
+    backend === "jianying-bach-v2-exact-d634-v1"
+      ? VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY
+      : backend === "same-model-coreml-v1"
+        ? VIDEO_OBJECT_PROVIDER_CAPABILITY
+        : VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY;
+  const runtimeFingerprint =
+    backend === "jianying-bach-v2-exact-d634-v1"
+      ? `${VIDEO_OBJECT_BACH_RUNTIME_SHA256}:${VIDEO_OBJECT_BACH_RUNTIME_UUID}:${VIDEO_OBJECT_BACH_DEPENDENCY_CLOSURE_SHA256}`
+      : backend === "same-model-coreml-v1"
+        ? "coreml-system-runtime-v1"
+        : VIDEO_FUSION_LIBRARY_SHA256;
+  const capabilitySha256 = createHash("sha256")
+    .update(bridgeSha256)
+    .update(runtimeFingerprint)
+    .update(VIDEO_OBJECT_GRAPH_SHA256)
+    .update(VIDEO_OBJECT_MODEL.sha256)
+    .update(EFFECT_CONFIG)
+    .update(JSON.stringify(providerCapability))
+    .digest("hex");
+  return {
+    capabilitySha256,
+    processorSha256: createHash("sha256")
+      .update(capabilitySha256)
+      .update(
+        backend === "jianying-bach-v2-exact-d634-v1"
+          ? VIDEO_OBJECT_BACH_PROCESSOR_VERSION
+          : VIDEO_OBJECT_COREML_PROCESSOR_VERSION,
+      )
+      .update(
+        backend === "effect-host-interop-v1"
+          ? createAlgorithmConfig({ height, width })
+          : JSON.stringify({ height, width, system: os.release() }),
+      )
+      .digest("hex"),
+  };
 }
 
 async function writeGeneratedFile({
-	contents,
-	filePath,
+  contents,
+  filePath,
 }: {
-	contents: string;
-	filePath: string;
+  contents: string;
+  filePath: string;
 }) {
-	try {
-		if ((await readFile(filePath, "utf8")) === contents) return;
-	} catch {
-		// Missing or partial cache files are repaired atomically below.
-	}
-	const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
-	await writeFile(temporaryPath, contents, "utf8");
-	await rename(temporaryPath, filePath);
+  try {
+    if ((await readFile(filePath, "utf8")) === contents) return;
+  } catch {
+    // Missing or partial cache files are repaired atomically below.
+  }
+  const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(temporaryPath, contents, "utf8");
+  await rename(temporaryPath, filePath);
 }
 
 async function prepareEffectDirectory({
-	graphSha256,
-	height,
-	width,
+  graphSha256,
+  height,
+  width,
 }: {
-	graphSha256: string;
-	height: number;
-	width: number;
+  graphSha256: string;
+  height: number;
+  width: number;
 }) {
-	const algorithmConfig = createAlgorithmConfig({ height, width });
-	const fingerprint = createHash("sha256")
-		.update(graphSha256)
-		.update(EFFECT_CONFIG)
-		.update(algorithmConfig)
-		.digest("hex")
-		.slice(0, 16);
-	const directory = path.join(
-		os.homedir(),
-		"Library",
-		"Caches",
-		"QCut",
-		"jianying-video-object-effect",
-		fingerprint
-	);
-	await mkdir(directory, { recursive: true });
-	await Promise.all([
-		writeGeneratedFile({
-			contents: algorithmConfig,
-			filePath: path.join(directory, "algorithmConfig.json"),
-		}),
-		writeGeneratedFile({
-			contents: EFFECT_CONFIG,
-			filePath: path.join(directory, "config.json"),
-		}),
-	]);
-	return directory;
+  const algorithmConfig = createAlgorithmConfig({ height, width });
+  const fingerprint = createHash("sha256")
+    .update(graphSha256)
+    .update(EFFECT_CONFIG)
+    .update(algorithmConfig)
+    .digest("hex")
+    .slice(0, 16);
+  const directory = path.join(
+    os.homedir(),
+    "Library",
+    "Caches",
+    "QCut",
+    "jianying-video-object-effect",
+    fingerprint,
+  );
+  await mkdir(directory, { recursive: true });
+  await Promise.all([
+    writeGeneratedFile({
+      contents: algorithmConfig,
+      filePath: path.join(directory, "algorithmConfig.json"),
+    }),
+    writeGeneratedFile({
+      contents: EFFECT_CONFIG,
+      filePath: path.join(directory, "config.json"),
+    }),
+  ]);
+  return directory;
 }
 
-export async function resolveJianyingVideoObjectRuntime({
-	height,
-	width,
+interface VideoObjectRuntimeAssetRoots {
+  configuredRoot: string | undefined;
+  jianyingEffectRoot: string;
+  privateRuntimeRoot: string;
+}
+
+function videoObjectRuntimeAssetRoots(): VideoObjectRuntimeAssetRoots {
+  const home = os.homedir();
+  return {
+    configuredRoot: process.env.QCUT_JIANYING_VIDEO_OBJECT_RUNTIME,
+    jianyingEffectRoot: path.join(
+      home,
+      "Movies",
+      "JianyingPro",
+      "User Data",
+      "Cache",
+      "effect",
+    ),
+    privateRuntimeRoot: path.join(
+      home,
+      "Library",
+      "Application Support",
+      "QCut",
+      "PrivateRuntimes",
+    ),
+  };
+}
+
+async function resolveVideoObjectModelDirectory({
+  roots,
 }: {
-	height: number;
-	width: number;
-}): Promise<JianyingVideoObjectRuntime | null> {
-	if (process.platform !== "darwin") return null;
-	const privateRuntimeRoot = path.join(
-		os.homedir(),
-		"Library",
-		"Application Support",
-		"QCut",
-		"PrivateRuntimes"
-	);
-	const jianyingEffectRoot = path.join(
-		os.homedir(),
-		"Movies",
-		"JianyingPro",
-		"User Data",
-		"Cache",
-		"effect"
-	);
-	const configuredRoot = process.env.QCUT_JIANYING_VIDEO_OBJECT_RUNTIME;
-	const modelDirectory = await firstMatchingDirectory({
-		candidates: [
-			...(configuredRoot ? [path.join(configuredRoot, "Models")] : []),
-			path.join(privateRuntimeRoot, "JianyingSaliency", "current", "Models"),
-			path.join(privateRuntimeRoot, "JianyingFilter", "current", "Models"),
-			path.join(jianyingEffectRoot, "model"),
-		],
-		files: [VIDEO_OBJECT_MODEL],
-	});
-	const graphPath = await firstMatchingFile({
-		candidates: [
-			...(configuredRoot
-				? [path.join(configuredRoot, "SourceEffect", "algorithmConfig.json")]
-				: []),
-			path.join(
-				privateRuntimeRoot,
-				"JianyingVideoObject",
-				"current",
-				"SourceEffect",
-				"algorithmConfig.json"
-			),
-			path.join(
-				jianyingEffectRoot,
-				"7366590389928595994",
-				"94715bdc841b34cd5451b4b9c181bde4",
-				"ai_matting_video_object",
-				"algorithmConfig.json"
-			),
-		],
-		sha256: VIDEO_OBJECT_GRAPH_SHA256,
-	});
-	const libraryPath = await firstMatchingFile({
-		candidates: [
-			...(configuredRoot
-				? [path.join(configuredRoot, "Frameworks", "libcccreator.dylib")]
-				: []),
-			path.join(
-				privateRuntimeRoot,
-				"JianyingVideoObject",
-				"current",
-				"Frameworks",
-				"libcccreator.dylib"
-			),
-			path.join(
-				"/Applications",
-				"VideoFusion-macOS.app",
-				"Contents",
-				"Frameworks",
-				"libcccreator.dylib"
-			),
-		],
-		sha256: VIDEO_FUSION_LIBRARY_SHA256,
-	});
-	const bridgePath = await resolveJianyingSaliencyBridge();
-	if (!bridgePath || !graphPath || !libraryPath || !modelDirectory) return null;
-	const bridgeSha256 = await sha256File({ filePath: bridgePath });
-	if (!bridgeSha256) return null;
-	const effectDirectory = await prepareEffectDirectory({
-		graphSha256: VIDEO_OBJECT_GRAPH_SHA256,
-		height,
-		width,
-	});
-	const graphSize = calculateVideoObjectGraphSize({ height, width });
-	return {
-		bridgePath,
-		effectDirectory,
-		frameworkDirectory: path.dirname(libraryPath),
-		libraryPath,
-		modelDirectory,
-		modelSha256: VIDEO_OBJECT_MODEL.sha256,
-		graphHeight: graphSize.height,
-		graphWidth: graphSize.width,
-		processorSha256: createHash("sha256")
-			.update(bridgeSha256)
-			.update(VIDEO_FUSION_LIBRARY_SHA256)
-			.update(VIDEO_OBJECT_GRAPH_SHA256)
-			.update(EFFECT_CONFIG)
-			.update(createAlgorithmConfig({ height, width }))
-			.digest("hex"),
-	};
+  roots: VideoObjectRuntimeAssetRoots;
+}) {
+  const { configuredRoot, jianyingEffectRoot, privateRuntimeRoot } = roots;
+  return firstMatchingDirectory({
+    candidates: [
+      ...(configuredRoot
+        ? [
+            path.join(configuredRoot, "Models"),
+            path.join(configuredRoot, "Models", "user-cache"),
+          ]
+        : []),
+      path.join(
+        privateRuntimeRoot,
+        "JianyingTransition",
+        "current",
+        "Models",
+        "user-cache",
+      ),
+      path.join(privateRuntimeRoot, "JianyingSaliency", "current", "Models"),
+      path.join(privateRuntimeRoot, "JianyingFilter", "current", "Models"),
+      path.join(jianyingEffectRoot, "model"),
+    ],
+    files: [VIDEO_OBJECT_MODEL],
+  });
+}
+
+function videoObjectGraphCandidates({
+  roots,
+}: {
+  roots: VideoObjectRuntimeAssetRoots;
+}) {
+  const { configuredRoot, jianyingEffectRoot, privateRuntimeRoot } = roots;
+  return [
+    ...(configuredRoot
+      ? [
+          path.join(configuredRoot, "SourceEffect", "algorithmConfig.json"),
+          path.join(
+            configuredRoot,
+            "Models",
+            "app-bundle",
+            "matting_config",
+            "ai_matting_video_object",
+            "algorithmConfig.json",
+          ),
+        ]
+      : []),
+    path.join(
+      privateRuntimeRoot,
+      "JianyingTransition",
+      "current",
+      "Models",
+      "app-bundle",
+      "matting_config",
+      "ai_matting_video_object",
+      "algorithmConfig.json",
+    ),
+    path.join(
+      privateRuntimeRoot,
+      "JianyingVideoObject",
+      "current",
+      "SourceEffect",
+      "algorithmConfig.json",
+    ),
+    path.join(
+      jianyingEffectRoot,
+      "7366590389928595994",
+      "94715bdc841b34cd5451b4b9c181bde4",
+      "ai_matting_video_object",
+      "algorithmConfig.json",
+    ),
+  ];
+}
+
+async function resolveBachVideoObjectCandidate({
+  height,
+  modelDirectory,
+  modelPath,
+  roots,
+  width,
+}: {
+  height: number;
+  modelDirectory: string;
+  modelPath: string;
+  roots: VideoObjectRuntimeAssetRoots;
+  width: number;
+}): Promise<JianyingVideoObjectRuntimeCandidate | null> {
+  try {
+    const { configuredRoot, privateRuntimeRoot } = roots;
+    const [bridgePath, graphPath, libraryPath] = await Promise.all([
+      resolveVideoObjectBachBridge(),
+      firstMatchingFile({
+        candidates: videoObjectGraphCandidates({ roots }),
+        sha256: VIDEO_OBJECT_GRAPH_SHA256,
+      }),
+      firstMatchingFile({
+        candidates: [
+          ...(configuredRoot
+            ? [path.join(configuredRoot, "Frameworks", "libcccreator.dylib")]
+            : []),
+          path.join(
+            privateRuntimeRoot,
+            "JianyingTransition",
+            "current",
+            "Frameworks",
+            "libcccreator.dylib",
+          ),
+          path.join(
+            privateRuntimeRoot,
+            "JianyingFilter",
+            "current",
+            "Frameworks",
+            "libcccreator.dylib",
+          ),
+        ],
+        sha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+      }),
+    ]);
+    if (!bridgePath || !graphPath || !libraryPath) return null;
+    const dependencyClosure = await verifyVideoObjectBachDependencyClosure({
+      expectedCoreUuid: VIDEO_OBJECT_BACH_RUNTIME_UUID,
+      expectedRuntimeSha256: VIDEO_OBJECT_BACH_RUNTIME_SHA256,
+      runtimeRoot: path.dirname(path.dirname(libraryPath)),
+    });
+    const bridgeSha256 = await sha256File({ filePath: bridgePath });
+    if (!bridgeSha256) return null;
+    const fingerprints = createVideoObjectRuntimeFingerprints({
+      backend: "jianying-bach-v2-exact-d634-v1",
+      bridgeSha256,
+      height,
+      width,
+    });
+    return {
+      bridgePath,
+      capabilitySha256: fingerprints.capabilitySha256,
+      coreMLModelPath: null,
+      dependencyClosureSha256: dependencyClosure.dependencyClosureSha256,
+      effectDirectory: null,
+      executionBackend: "jianying-bach-v2-exact-d634-v1",
+      frameworkDirectory: path.dirname(libraryPath),
+      graphDirectory: path.dirname(graphPath),
+      libraryPath,
+      modelDirectory,
+      modelPath,
+      modelSha256: VIDEO_OBJECT_MODEL.sha256,
+      processorSha256: fingerprints.processorSha256,
+      providerCapability: VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY,
+      readiness: VIDEO_OBJECT_BACH_PROVIDER_CAPABILITY.readiness,
+    };
+  } catch (error) {
+    console.warn(
+      "QCut could not prepare the audited Jianying Bach runtime.",
+      error,
+    );
+    return null;
+  }
+}
+
+async function resolveCoreMLVideoObjectCandidate({
+  height,
+  modelDirectory,
+  modelPath,
+  width,
+}: {
+  height: number;
+  modelDirectory: string;
+  modelPath: string;
+  width: number;
+}): Promise<JianyingVideoObjectRuntimeCandidate | null> {
+  try {
+    const bridgePath = await resolveVideoObjectCoreMLBridge();
+    if (!bridgePath) return null;
+    const coreMLModelPath = await prepareVideoObjectCoreMLModel({
+      modelPath,
+      modelSha256: VIDEO_OBJECT_MODEL.sha256,
+    });
+    const bridgeSha256 = await sha256File({ filePath: bridgePath });
+    if (!bridgeSha256) return null;
+    const fingerprints = createVideoObjectRuntimeFingerprints({
+      bridgeSha256,
+      height,
+      width,
+    });
+    return {
+      bridgePath,
+      capabilitySha256: fingerprints.capabilitySha256,
+      coreMLModelPath,
+      dependencyClosureSha256: null,
+      effectDirectory: null,
+      executionBackend: "same-model-coreml-v1",
+      frameworkDirectory: null,
+      graphDirectory: null,
+      libraryPath: null,
+      modelDirectory,
+      modelPath,
+      modelSha256: VIDEO_OBJECT_MODEL.sha256,
+      processorSha256: fingerprints.processorSha256,
+      providerCapability: VIDEO_OBJECT_PROVIDER_CAPABILITY,
+      readiness: VIDEO_OBJECT_PROVIDER_CAPABILITY.readiness,
+    };
+  } catch (error) {
+    console.warn(
+      "QCut could not prepare the same-model CoreML video-object runtime.",
+      error,
+    );
+    return null;
+  }
+}
+
+async function resolveLegacyHostVideoObjectCandidate({
+  height,
+  modelDirectory,
+  modelPath,
+  roots,
+  width,
+}: {
+  height: number;
+  modelDirectory: string;
+  modelPath: string;
+  roots: VideoObjectRuntimeAssetRoots;
+  width: number;
+}): Promise<JianyingVideoObjectRuntimeCandidate | null> {
+  try {
+    const { configuredRoot, privateRuntimeRoot } = roots;
+    const [graphPath, libraryPath] = await Promise.all([
+      firstMatchingFile({
+        candidates: videoObjectGraphCandidates({ roots }),
+        sha256: VIDEO_OBJECT_GRAPH_SHA256,
+      }),
+      firstMatchingFile({
+        candidates: [
+          ...(configuredRoot
+            ? [path.join(configuredRoot, "Frameworks", "libcccreator.dylib")]
+            : []),
+          path.join(
+            privateRuntimeRoot,
+            "JianyingVideoObject",
+            "current",
+            "Frameworks",
+            "libcccreator.dylib",
+          ),
+          path.join(
+            "/Applications",
+            "VideoFusion-macOS.app",
+            "Contents",
+            "Frameworks",
+            "libcccreator.dylib",
+          ),
+        ],
+        sha256: VIDEO_FUSION_LIBRARY_SHA256,
+      }),
+    ]);
+    if (!graphPath || !libraryPath) return null;
+    const bridgePath = await resolveJianyingSaliencyBridge();
+    if (!bridgePath) return null;
+    const bridgeSha256 = await sha256File({ filePath: bridgePath });
+    if (!bridgeSha256) return null;
+    const effectDirectory = await prepareEffectDirectory({
+      graphSha256: VIDEO_OBJECT_GRAPH_SHA256,
+      height,
+      width,
+    });
+    const fingerprints = createVideoObjectRuntimeFingerprints({
+      backend: "effect-host-interop-v1",
+      bridgeSha256,
+      height,
+      width,
+    });
+    return {
+      bridgePath,
+      capabilitySha256: fingerprints.capabilitySha256,
+      coreMLModelPath: null,
+      dependencyClosureSha256: null,
+      effectDirectory,
+      executionBackend: "effect-host-interop-v1",
+      frameworkDirectory: path.dirname(libraryPath),
+      graphDirectory: null,
+      libraryPath,
+      modelDirectory,
+      modelPath,
+      modelSha256: VIDEO_OBJECT_MODEL.sha256,
+      providerCapability: VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY,
+      readiness: VIDEO_OBJECT_HOST_INTEROP_PROVIDER_CAPABILITY.readiness,
+      processorSha256: fingerprints.processorSha256,
+    };
+  } catch (error) {
+    console.warn(
+      "QCut could not prepare the host video-object runtime.",
+      error,
+    );
+    return null;
+  }
+}
+
+export async function resolveJianyingVideoObjectRuntimeCandidates({
+  height,
+  width,
+}: {
+  height: number;
+  width: number;
+}): Promise<JianyingVideoObjectRuntimeCandidate[]> {
+  if (process.platform !== "darwin") return [];
+  const roots = videoObjectRuntimeAssetRoots();
+  let modelDirectory: string | null;
+  try {
+    modelDirectory = await resolveVideoObjectModelDirectory({ roots });
+  } catch (error) {
+    console.warn("QCut could not locate the video-object model.", error);
+    return [];
+  }
+  if (!modelDirectory) return [];
+  const modelPath = path.join(modelDirectory, VIDEO_OBJECT_MODEL.name);
+  const bach = await resolveBachVideoObjectCandidate({
+    height,
+    modelDirectory,
+    modelPath,
+    roots,
+    width,
+  });
+  const coreML = await resolveCoreMLVideoObjectCandidate({
+    height,
+    modelDirectory,
+    modelPath,
+    width,
+  });
+  const legacyHost = await resolveLegacyHostVideoObjectCandidate({
+    height,
+    modelDirectory,
+    modelPath,
+    roots,
+    width,
+  });
+  return [bach, coreML, legacyHost].filter(
+    (candidate): candidate is JianyingVideoObjectRuntimeCandidate =>
+      candidate !== null,
+  );
+}
+
+export async function resolveJianyingVideoObjectRuntimeCandidate({
+  height,
+  width,
+}: {
+  height: number;
+  width: number;
+}): Promise<JianyingVideoObjectRuntimeCandidate | null> {
+  return (
+    (await resolveJianyingVideoObjectRuntimeCandidates({ height, width }))[0] ??
+    null
+  );
 }

--- a/qcut/electron/main.ts
+++ b/qcut/electron/main.ts
@@ -81,6 +81,7 @@ import {
 	setupJianyingPortraitAdjustmentIPC,
 	type JianyingPortraitAdjustmentIPCController,
 } from "./jianying-portrait-adjustment-handler.js";
+import { setupJianyingPersonCutoutIPC } from "./jianying-person-cutout-handler.js";
 import { watchJianyingFilterCaches } from "./jianying-filter-cache-watcher.js";
 import {
 	setupJianyingFontLabIPC,
@@ -1090,6 +1091,7 @@ if (!isCliKeyCommand && !isHeadlessRecorder) {
 						});
 				},
 			],
+			["JianyingPersonCutoutIPC", setupJianyingPersonCutoutIPC],
 			[
 				"JianyingFontLabIPC",
 				() => {

--- a/qcut/electron/native-pipeline/cli/__tests__/cli-parse-filter-lab.test.ts
+++ b/qcut/electron/native-pipeline/cli/__tests__/cli-parse-filter-lab.test.ts
@@ -3,6 +3,37 @@ import { parseCliArgs } from "../cli.js";
 import { getCommand, getCommandFlag } from "../command-registry.js";
 
 describe("Filter Lab verification CLI registration", () => {
+	it.each(["render", "apply"])("registers and parses %s", (action) => {
+		const options = parseCliArgs([
+			"filter-lab",
+			action,
+			"--resource-id",
+			"123",
+			"-i",
+			"input.mp4",
+			"--output",
+			"output.mp4",
+			"--filter-intensity",
+			"75",
+			"--duration",
+			"1",
+			"--fps",
+			"24",
+			"--force",
+		]);
+		expect(options).toMatchObject({
+			command: "filter-lab-render",
+			resourceId: "123",
+			input: "input.mp4",
+			output: "output.mp4",
+			filterIntensity: 75,
+			duration: "1",
+			fps: 24,
+			force: true,
+		});
+		expect(getCommand("filter-lab-render")?.category).toBe("filter-lab");
+	});
+
 	it("registers rendered parity verification", () => {
 		expect(getCommand("filter-lab-verify")?.category).toBe("filter-lab");
 		expect(getCommandFlag("filter-lab-verify", "--reference-frame")?.type).toBe(

--- a/qcut/electron/native-pipeline/cli/__tests__/json-output.test.ts
+++ b/qcut/electron/native-pipeline/cli/__tests__/json-output.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	emitJsonResult,
+	jsonError,
+	jsonOk,
+	jsonPending,
+} from "../json-output.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("CLI JSON stdout", () => {
+	it("writes a complete large UTF-8 envelope to stdout, not console.log", () => {
+		const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const cards = Array.from({ length: 2000 }, (_, index) => ({
+			resourceId: String(index),
+			title: "\u6ee4\u955c".repeat(40),
+		}));
+		emitJsonResult(
+			"filter-lab-catalog",
+			{ success: true, data: { count: cards.length, cards } },
+			{ command_id: "test", duration_ms: 123 }
+		);
+		const raw = String(write.mock.calls[0]?.[0]);
+		expect(Buffer.byteLength(raw)).toBeGreaterThan(500_000);
+		expect(JSON.parse(raw)).toEqual({
+			status: "ok",
+			command_id: "test",
+			duration_ms: 123,
+			data: {
+				schema_version: "1",
+				command: "filter-lab-catalog",
+				data: { count: cards.length, cards },
+			},
+		});
+		expect(raw.endsWith("\n")).toBe(true);
+		expect(log).not.toHaveBeenCalled();
+	});
+
+	it("keeps success, error, and pending wire formats unchanged", () => {
+		const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		jsonOk({ value: 1 });
+		jsonError("failed", "render:failed", { partial: true }, "id", 10);
+		jsonPending("job-1");
+		expect(
+			write.mock.calls.map(([value]) => JSON.parse(String(value)))
+		).toEqual([
+			{ status: "ok", data: { value: 1 } },
+			{
+				status: "error",
+				error: "failed",
+				code: "render:failed",
+				data: { partial: true },
+				command_id: "id",
+				duration_ms: 10,
+			},
+			{ status: "pending", jobId: "job-1" },
+		]);
+	});
+
+	it("writes partial failure data even when the stream applies backpressure", () => {
+		const write = vi.spyOn(process.stdout, "write").mockReturnValue(false);
+		emitJsonResult("filter-lab-render", {
+			success: false,
+			error: "failed",
+			data: { rows: "x".repeat(500_000) },
+		});
+		expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toMatchObject({
+			status: "error",
+			error: "failed",
+			data: { data: { rows: "x".repeat(500_000) } },
+		});
+	});
+});

--- a/qcut/electron/native-pipeline/cli/cli-handlers-filter-lab-render.ts
+++ b/qcut/electron/native-pipeline/cli/cli-handlers-filter-lab-render.ts
@@ -1,0 +1,317 @@
+import {
+	link,
+	lstat,
+	mkdir,
+	mkdtemp,
+	rename,
+	rm,
+	stat,
+} from "node:fs/promises";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import {
+	probeFilterLabMedia,
+	type FilterLabMediaInfo,
+} from "../filters/filter-lab-media.js";
+import { resolveFilterLabRenderPlan } from "../filters/filter-lab-render-plan.js";
+import { renderFilterLabMedia } from "../filters/filter-lab-render.js";
+import { exportCatalogDefault } from "./cli-handlers-filter-lab-catalog.js";
+import type {
+	CLIResult,
+	CLIRunOptions,
+	ProgressFn,
+} from "./cli-runner/types.js";
+
+const IMAGE_EXTENSIONS = new Set([
+	".png",
+	".jpg",
+	".jpeg",
+	".webp",
+	".bmp",
+	".tif",
+	".tiff",
+]);
+const VIDEO_EXTENSIONS = new Set([
+	".mp4",
+	".mov",
+	".m4v",
+	".mkv",
+	".webm",
+	".avi",
+]);
+
+export interface FilterLabRenderDependencies {
+	exportCatalog: typeof exportCatalogDefault;
+	resolvePlan: typeof resolveFilterLabRenderPlan;
+	probe: typeof probeFilterLabMedia;
+	render: typeof renderFilterLabMedia;
+}
+
+function validateOptions({ options }: { options: CLIRunOptions }) {
+	if (!options.resourceId || !/^\d{1,30}$/.test(options.resourceId))
+		throw new Error(
+			"--resource-id must be an exact numeric ID from filter-lab catalog."
+		);
+	if (options.resourceIds && options.resourceIds.length > 1)
+		throw new Error("Render one --resource-id at a time.");
+	if (!options.input)
+		throw new Error("Missing --input/-i image or video path.");
+	const intensity = options.filterIntensity ?? 100;
+	if (!Number.isFinite(intensity) || intensity < 0 || intensity > 100)
+		throw new Error("--filter-intensity must be between 0 and 100.");
+	const duration =
+		options.duration === undefined ? undefined : Number(options.duration);
+	if (duration !== undefined && (!Number.isFinite(duration) || duration <= 0))
+		throw new Error("--duration must be a positive number of seconds.");
+	if (
+		options.fps !== undefined &&
+		(!Number.isFinite(options.fps) || options.fps <= 0 || options.fps > 120)
+	)
+		throw new Error("--fps must be greater than 0 and at most 120.");
+	const input = resolve(options.input);
+	const extension = extname(input).toLowerCase();
+	const isImage = IMAGE_EXTENSIONS.has(extension);
+	if (!isImage && !VIDEO_EXTENSIONS.has(extension))
+		throw new Error("Unsupported image/video extension.");
+	if (isImage && (duration !== undefined || options.fps !== undefined))
+		throw new Error("--duration and --fps apply only to video inputs.");
+	const output = options.output
+		? resolve(options.output)
+		: join(
+				resolve(options.outputDir),
+				`${basename(input, extname(input))}_${options.resourceId}${isImage ? ".png" : ".mp4"}`
+			);
+	if (extname(output).toLowerCase() !== (isImage ? ".png" : ".mp4"))
+		throw new Error("Use a .png output for images or .mp4 for videos.");
+	if (input === output)
+		throw new Error("Filter output cannot overwrite the input.");
+	return {
+		input,
+		output,
+		isImage,
+		intensity,
+		duration,
+		resourceId: options.resourceId,
+	};
+}
+
+async function validateFiles({
+	input,
+	output,
+	force,
+}: {
+	input: string;
+	output: string;
+	force: boolean;
+}) {
+	const source = await stat(input);
+	if (!source.isFile()) throw new Error("Input is not a regular file.");
+	const destination = await lstat(output).catch(
+		(error: NodeJS.ErrnoException) => {
+			if (error.code === "ENOENT") return undefined;
+			throw error;
+		}
+	);
+	if (!destination) return;
+	if (destination.dev === source.dev && destination.ino === source.ino)
+		throw new Error("Filter output cannot overwrite the input.");
+	if (!destination.isFile())
+		throw new Error(
+			"Output must be a regular file, not a directory or symlink."
+		);
+	if (!force)
+		throw new Error("Output already exists. Use --force to replace it.");
+}
+
+function selectRenderMedia({
+	media,
+	isImage,
+	duration,
+	fps,
+}: {
+	media: FilterLabMediaInfo;
+	isImage: boolean;
+	duration?: number;
+	fps?: number;
+}): FilterLabMediaInfo {
+	if (isImage) return { ...media, duration: 0, frameRate: 1, hasAudio: false };
+	const frameRate = fps ?? media.frameRate;
+	if (
+		media.duration <= 0 ||
+		!Number.isFinite(frameRate) ||
+		frameRate <= 0 ||
+		frameRate > 120
+	)
+		throw new Error(
+			"Video duration or frame rate is invalid; use --fps for sources without a usable rate."
+		);
+	if (media.width % 2 || media.height % 2)
+		throw new Error(
+			"MP4 output requires even dimensions; resize the source explicitly before rendering."
+		);
+	return {
+		...media,
+		frameRate,
+		duration: Math.min(duration ?? media.duration, media.duration),
+	};
+}
+
+function verifyOutput({
+	input,
+	output,
+	isImage,
+}: {
+	input: FilterLabMediaInfo;
+	output: FilterLabMediaInfo;
+	isImage: boolean;
+}) {
+	if (input.width !== output.width || input.height !== output.height)
+		throw new Error("Rendered dimensions differ from the input.");
+	if (isImage) return;
+	if (
+		Math.abs(input.duration - output.duration) >
+		Math.max(0.1, 1 / input.frameRate + 0.05)
+	)
+		throw new Error("Rendered duration differs from the requested duration.");
+	if (Math.abs(input.frameRate - output.frameRate) > 0.001)
+		throw new Error(
+			"Rendered frame rate differs from the requested frame rate."
+		);
+	if (input.hasAudio && !output.hasAudio)
+		throw new Error("Input audio was lost during rendering.");
+}
+
+export async function handleFilterLabRender({
+	options,
+	onProgress,
+	signal,
+	dependencies = {},
+}: {
+	options: CLIRunOptions;
+	onProgress: ProgressFn;
+	signal: AbortSignal;
+	dependencies?: Partial<FilterLabRenderDependencies>;
+}): Promise<CLIResult> {
+	const deps = {
+		exportCatalog: exportCatalogDefault,
+		resolvePlan: resolveFilterLabRenderPlan,
+		probe: probeFilterLabMedia,
+		render: renderFilterLabMedia,
+		...dependencies,
+	};
+	let stagingDirectory: string | undefined;
+	const started = Date.now();
+	try {
+		const paths = validateOptions({ options });
+		await validateFiles({ ...paths, force: options.force ?? false });
+		const renderSignal = AbortSignal.any([
+			signal,
+			AbortSignal.timeout(15 * 60 * 1000),
+		]);
+		renderSignal.throwIfAborted();
+		onProgress({
+			stage: "loading",
+			percent: 5,
+			message: "Loading local Filter Lab card...",
+		});
+		const catalog = await deps.exportCatalog();
+		const card = catalog.cards.find(
+			({ resourceId }) => resourceId === paths.resourceId
+		);
+		if (!card)
+			throw new Error("Filter resource ID is not in the local catalog.");
+		if (!card.available || card.cacheStatus !== "cached")
+			throw new Error(
+				`Filter ${card.title} has cache status "${card.cacheStatus}" but is not supported by the current Filter Lab loader.`
+			);
+		if (
+			options.filterVersion !== undefined &&
+			card.version !== options.filterVersion
+		)
+			throw new Error(
+				"--filter-version does not match the catalog's selected version."
+			);
+		const sourceMedia = await deps.probe({
+			filePath: paths.input,
+			signal: renderSignal,
+		});
+		const media = selectRenderMedia({
+			media: sourceMedia,
+			isImage: paths.isImage,
+			duration: paths.duration,
+			fps: options.fps,
+		});
+		const plan = await deps.resolvePlan({ card, intensity: paths.intensity });
+		renderSignal.throwIfAborted();
+		if (options.dryRun)
+			return {
+				success: true,
+				data: {
+					dryRun: true,
+					input: paths.input,
+					output: paths.output,
+					filter: plan.evidence,
+					media,
+				},
+			};
+		await mkdir(dirname(paths.output), { recursive: true });
+		stagingDirectory = await mkdtemp(
+			join(dirname(paths.output), ".qcut-filter-")
+		);
+		const temporaryOutput = join(
+			stagingDirectory,
+			`render${extname(paths.output)}`
+		);
+		onProgress({
+			stage: "filtering",
+			percent: 15,
+			message: `Rendering ${card.title} (${plan.evidence.backend})...`,
+		});
+		await deps.render({
+			input: paths.input,
+			output: temporaryOutput,
+			isImage: paths.isImage,
+			media,
+			plan,
+			signal: renderSignal,
+		});
+		const rendered = await deps.probe({
+			filePath: temporaryOutput,
+			signal: renderSignal,
+		});
+		verifyOutput({ input: media, output: rendered, isImage: paths.isImage });
+		if ((await stat(temporaryOutput)).size === 0)
+			throw new Error("Rendered output is empty.");
+		renderSignal.throwIfAborted();
+		await validateFiles({ ...paths, force: options.force ?? false });
+		// A hard link publishes without replacing a file created during rendering.
+		if (options.force) await rename(temporaryOutput, paths.output);
+		else await link(temporaryOutput, paths.output);
+		onProgress({
+			stage: "complete",
+			percent: 100,
+			message: "Filter Lab render complete",
+		});
+		return {
+			success: true,
+			outputPath: paths.output,
+			duration: (Date.now() - started) / 1000,
+			data: {
+				input: paths.input,
+				output: paths.output,
+				filter: plan.evidence,
+				media: rendered,
+				frameRateMode: paths.isImage ? "still" : "cfr",
+				audioPreserved: !media.hasAudio || rendered.hasAudio,
+			},
+		};
+	} catch (error) {
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : String(error),
+			duration: (Date.now() - started) / 1000,
+		};
+	} finally {
+		if (stagingDirectory)
+			await rm(stagingDirectory, { recursive: true, force: true });
+	}
+}

--- a/qcut/electron/native-pipeline/cli/cli-runner/handler-map.ts
+++ b/qcut/electron/native-pipeline/cli/cli-runner/handler-map.ts
@@ -131,6 +131,7 @@ import {
 	handleFilterLabVerify,
 } from "../cli-handlers-filter-lab.js";
 import { handleFilterLabCatalog } from "../cli-handlers-filter-lab-catalog.js";
+import { handleFilterLabRender } from "../cli-handlers-filter-lab-render.js";
 import {
 	handleFilterLabCoverage,
 	handleFilterLabVerifyBatch,
@@ -200,6 +201,9 @@ export const HANDLER_MAP: Record<string, CommandHandler> = {
 	"instances-use": wrap(handleInstancesCommand),
 	"filter-lab-list": wrap((options) =>
 		handleFilterLabList({ json: options.json })
+	),
+	"filter-lab-render": wrapOPS((options, onProgress, signal) =>
+		handleFilterLabRender({ options, onProgress, signal })
 	),
 	"filter-lab-catalog": wrap((options) =>
 		handleFilterLabCatalog({

--- a/qcut/electron/native-pipeline/cli/cli.ts
+++ b/qcut/electron/native-pipeline/cli/cli.ts
@@ -1361,7 +1361,8 @@ export async function main(
 			duration_ms: durationMs,
 		});
 		if (!result.success) {
-			process.exit(1);
+			// Let stdout drain when a failed result contains large partial data.
+			process.exitCode = 1;
 		}
 	} else if (result.success) {
 		if (result.outputPath) {

--- a/qcut/electron/native-pipeline/cli/command-groups.ts
+++ b/qcut/electron/native-pipeline/cli/command-groups.ts
@@ -117,11 +117,12 @@ export const COMMAND_GROUPS: CommandGroup[] = [
 	{
 		name: "filter-lab",
 		label: "Filter Lab",
-		description:
-			"Score QCut filter recipes against locally cached Jianying LUTs",
+		description: "Browse, render, and verify locally cached Jianying filters",
 		actions: {
 			list: "filter-lab-list",
 			catalog: "filter-lab-catalog",
+			render: "filter-lab-render",
+			apply: "filter-lab-render",
 			compare: "filter-lab-compare",
 			match: "filter-lab-match",
 			verify: "filter-lab-verify",

--- a/qcut/electron/native-pipeline/cli/command-registry.ts
+++ b/qcut/electron/native-pipeline/cli/command-registry.ts
@@ -140,6 +140,7 @@ export const CATEGORIES: CategoryDef[] = [
 		commands: [
 			"filter-lab-list",
 			"filter-lab-catalog",
+			"filter-lab-render",
 			"filter-lab-compare",
 			"filter-lab-match",
 			"filter-lab-verify",
@@ -337,6 +338,47 @@ const CORE_COMMANDS: Record<string, CommandDef> = {
 		examples: [
 			"qcut filter-lab catalog --json",
 			"qcut filter-lab catalog --sample 30 --seed 7 --stratify implementation,requirements --json",
+		],
+	},
+	"filter-lab-render": {
+		name: "filter-lab-render",
+		description:
+			"Apply an available Filter Lab card to a local image or video using the editor's LUT, native portrait, or multi-pass renderer; apply is an alias",
+		category: "filter-lab",
+		flags: [
+			f(
+				"--resource-id",
+				"string",
+				"Exact filter resource ID from filter-lab catalog",
+				{ required: true }
+			),
+			f("--input", "string", "Local image or video path", {
+				short: "-i",
+				required: true,
+			}),
+			f("--output", "string", "Output PNG for an image, or MP4 for a video"),
+			f("--filter-version", "string", "Require this exact cached version"),
+			f(
+				"--filter-intensity",
+				"number",
+				"Filter intensity from 0 to 100 (default: 100)"
+			),
+			f("--duration", "string", "Render at most this many seconds of video"),
+			f("--fps", "number", "Video output frame rate (default: source average)"),
+			f(
+				"--dry-run",
+				"boolean",
+				"Validate the card, runtime, and input without rendering"
+			),
+			f(
+				"--force",
+				"boolean",
+				"Replace an existing output after a successful render"
+			),
+		],
+		examples: [
+			"qcut filter-lab render --resource-id 7524288987129810214 -i portrait.jpg --output filtered.png --json",
+			"qcut filter-lab apply --resource-id 7392898023505792319 -i clip.mp4 --output filtered.mp4 --duration 2 --json",
 		],
 	},
 	"filter-lab-compare": {

--- a/qcut/electron/native-pipeline/cli/json-output.ts
+++ b/qcut/electron/native-pipeline/cli/json-output.ts
@@ -46,7 +46,7 @@ export function jsonOk(
 	const envelope: JsonOkEnvelope = { status: "ok", data };
 	if (commandId) envelope.command_id = commandId;
 	if (durationMs !== undefined) envelope.duration_ms = durationMs;
-	console.log(JSON.stringify(envelope, null, 2));
+	process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
 }
 
 /** Print a JSON error to stdout with optional partial-result data. */
@@ -63,13 +63,13 @@ export function jsonError(
 	if (data && Object.keys(data).length > 0) {
 		envelope.data = data;
 	}
-	console.log(JSON.stringify(envelope, null, 2));
+	process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
 }
 
 /** Print a pending/async job JSON result to stdout. */
 export function jsonPending(jobId: string): void {
 	const envelope: JsonPendingEnvelope = { status: "pending", jobId };
-	console.log(JSON.stringify(envelope, null, 2));
+	process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
 }
 
 /** Options for enriching JSON output with correlation and timing metadata. */

--- a/qcut/electron/native-pipeline/filters/filter-lab-frame-stream.ts
+++ b/qcut/electron/native-pipeline/filters/filter-lab-frame-stream.ts
@@ -1,0 +1,55 @@
+import { Transform } from "node:stream";
+import { mapWithConcurrency } from "../../lib/map-with-concurrency.js";
+
+export function createFilterLabFrameStream({
+	frameBytes,
+	renderFrame,
+}: {
+	frameBytes: number;
+	renderFrame: (input: { rgba: Buffer; index: number }) => Promise<Uint8Array>;
+}): Transform {
+	if (!Number.isSafeInteger(frameBytes) || frameBytes <= 0) {
+		throw new Error("Frame byte size must be a positive integer.");
+	}
+	let chunks: Buffer[] = [];
+	let bufferedBytes = 0;
+	let frameIndex = 0;
+	return new Transform({
+		transform(chunk: Buffer, _encoding, callback) {
+			chunks.push(chunk);
+			bufferedBytes += chunk.length;
+			if (bufferedBytes < frameBytes) {
+				callback();
+				return;
+			}
+			const buffer = Buffer.concat(chunks, bufferedBytes);
+			const count = Math.floor(buffer.length / frameBytes);
+			const remainder = buffer.subarray(count * frameBytes);
+			chunks = remainder.length ? [Buffer.from(remainder)] : [];
+			bufferedBytes = remainder.length;
+			// The native tracker is stateful: never render frames concurrently.
+			void mapWithConcurrency({
+				items: Array.from({ length: count }, (_, index) => index),
+				limit: 1,
+				task: async ({ item }) => {
+					const result = await renderFrame({
+						rgba: buffer.subarray(item * frameBytes, (item + 1) * frameBytes),
+						index: frameIndex++,
+					});
+					if (result.byteLength !== frameBytes)
+						throw new Error("Native filter returned an invalid frame size.");
+					this.push(Buffer.from(result));
+				},
+			}).then(
+				() => callback(),
+				(error: Error) => callback(error)
+			);
+		},
+		flush(callback) {
+			if (bufferedBytes)
+				callback(new Error("FFmpeg returned an incomplete RGBA frame."));
+			else if (frameIndex === 0) callback(new Error("No frames were decoded."));
+			else callback();
+		},
+	});
+}

--- a/qcut/electron/native-pipeline/filters/filter-lab-media.ts
+++ b/qcut/electron/native-pipeline/filters/filter-lab-media.ts
@@ -1,0 +1,151 @@
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { getFFmpegPath, getFFprobePath } from "../../ffmpeg/paths.js";
+
+export interface FilterLabMediaInfo {
+	width: number;
+	height: number;
+	duration: number;
+	frameRate: number;
+	hasAudio: boolean;
+}
+
+interface ProbeStream {
+	codec_type?: string;
+	width?: number;
+	height?: number;
+	duration?: string;
+	avg_frame_rate?: string;
+	r_frame_rate?: string;
+	tags?: { rotate?: string };
+	side_data_list?: Array<{ rotation?: number }>;
+}
+
+function frameRateValue({ value }: { value?: string }): number {
+	const [numerator, denominator = "1"] = (value ?? "0").split("/");
+	return Number(numerator) / Number(denominator);
+}
+
+export async function probeFilterLabMedia({
+	filePath,
+	signal,
+}: {
+	filePath: string;
+	signal: AbortSignal;
+}): Promise<FilterLabMediaInfo> {
+	const { stdout } = await promisify(execFile)(
+		await getFFprobePath(),
+		["-v", "error", "-show_streams", "-show_format", "-of", "json", filePath],
+		{ signal, timeout: 30_000, maxBuffer: 4 * 1024 * 1024 }
+	);
+	const data = JSON.parse(stdout) as {
+		streams?: ProbeStream[];
+		format?: { duration?: string };
+	};
+	const video = data.streams?.find((stream) => stream.codec_type === "video");
+	const rotation =
+		video?.side_data_list?.find((item) => item.rotation !== undefined)
+			?.rotation ?? Number(video?.tags?.rotate ?? 0);
+	const rotated = Math.abs(rotation) % 180 === 90;
+	const width = Number(rotated ? video?.height : video?.width);
+	const height = Number(rotated ? video?.width : video?.height);
+	if (
+		![width, height].every(
+			(value) => Number.isSafeInteger(value) && value > 0 && value <= 8192
+		) ||
+		width * height > 4096 ** 2
+	) {
+		throw new Error(
+			"Input must contain a video/image stream of at most 16 megapixels (8192 pixels per side)."
+		);
+	}
+	const averageRate = frameRateValue({ value: video?.avg_frame_rate });
+	const rate =
+		averageRate > 0
+			? averageRate
+			: frameRateValue({ value: video?.r_frame_rate });
+	const duration = Number(video?.duration ?? data.format?.duration ?? 0);
+	return {
+		width,
+		height,
+		duration: Number.isFinite(duration) ? duration : 0,
+		frameRate: Number.isFinite(rate) && rate > 0 ? rate : 0,
+		hasAudio:
+			data.streams?.some((stream) => stream.codec_type === "audio") ?? false,
+	};
+}
+
+export function startFilterLabFfmpeg({
+	args,
+	signal,
+}: {
+	args: string[];
+	signal: AbortSignal;
+}) {
+	const process = spawn(
+		getFFmpegPath(),
+		["-hide_banner", "-loglevel", "error", "-nostdin", "-y", ...args],
+		{
+			stdio: ["pipe", "pipe", "pipe"],
+			signal,
+			windowsHide: true,
+		}
+	);
+	let stderr = "";
+	process.stderr.setEncoding("utf8");
+	process.stderr.on("data", (chunk: string) => {
+		stderr = (stderr + chunk).slice(-32_768);
+	});
+	const completion = new Promise<void>((resolve, reject) => {
+		process.once("error", reject);
+		process.once("close", (code) => {
+			if (code === 0) resolve();
+			else reject(new Error(`FFmpeg failed (${code}): ${stderr.trim()}`));
+		});
+	});
+	// Native initialization can finish after FFmpeg has already failed.
+	void completion.catch(() => {});
+	return { process, completion };
+}
+
+export async function runFilterLabFfmpeg({
+	args,
+	signal,
+}: {
+	args: string[];
+	signal: AbortSignal;
+}): Promise<void> {
+	const task = startFilterLabFfmpeg({ args, signal });
+	task.process.stdin.end();
+	task.process.stdout.resume();
+	await task.completion;
+}
+
+export function filterLabEncodeArgs({
+	isImage,
+	duration,
+}: {
+	isImage: boolean;
+	duration: number;
+}): string[] {
+	return isImage
+		? ["-frames:v", "1", "-c:v", "png", "-pix_fmt", "rgba"]
+		: [
+				"-t",
+				String(duration),
+				"-c:v",
+				"libx264",
+				"-preset",
+				"fast",
+				"-crf",
+				"18",
+				"-pix_fmt",
+				"yuv420p",
+				"-c:a",
+				"aac",
+				"-b:a",
+				"192k",
+				"-movflags",
+				"+faststart",
+			];
+}

--- a/qcut/electron/native-pipeline/filters/filter-lab-render-plan.ts
+++ b/qcut/electron/native-pipeline/filters/filter-lab-render-plan.ts
@@ -1,0 +1,246 @@
+import { dirname } from "node:path";
+import type { JianyingFilterCatalogCard } from "../../jianying-filter-catalog-export.js";
+import {
+	buildJianyingFilterLabCatalog,
+	tiledReferencesFromPackages,
+} from "../../jianying-filter-lab-catalog.js";
+import { inspectJianyingFilterPackages } from "../../jianying-filter-package-inspector.js";
+import { loadJianyingFilterLabRenderer } from "../../jianying-filter-multi-pass-loader.js";
+import {
+	inspectJianyingFilterLocalRuntime,
+	type JianyingFilterLocalRuntimeInspection,
+} from "../../jianying-filter-local-runtime/runtime-discovery.js";
+import {
+	escapeFfmpegFilterPath,
+	materializeVideoCubeLut,
+} from "../../ffmpeg/color-lut-file.js";
+import { buildVideoColorMultiPassGraph } from "../../ffmpeg/color-multi-pass-filter.js";
+import {
+	jianyingFilterCacheRoots,
+	listJianyingLutReferences,
+	loadJianyingLut,
+} from "./filter-lab-lut.js";
+import {
+	loadJianyingMultiPassRecipe,
+	resolveMultiPassPackagePath,
+} from "./filter-lab-multi-pass.js";
+import { resolveJianyingNativePortraitPackagePath } from "./filter-lab-native-portrait.js";
+import { selectJianyingFilterCacheRoot } from "./filter-lab-package-path.js";
+import {
+	loadTiledLutCube,
+	resolveTiledLutPackagePath,
+} from "./filter-lab-tiled-lut.js";
+
+export interface FilterLabRenderEvidence {
+	resourceId: string;
+	title: string;
+	version: string;
+	implementation: JianyingFilterCatalogCard["implementation"];
+	verification: JianyingFilterCatalogCard["verification"];
+	intensity: number;
+	backend:
+		| "ffmpeg-lut"
+		| "ffmpeg-multi-pass"
+		| "jianying-native-portrait"
+		| "jianying-native-multi-pass";
+	fidelity: "lut" | "structural" | "native-local";
+}
+
+export type FilterLabRenderPlan = {
+	evidence: FilterLabRenderEvidence;
+} & (
+	| { kind: "ffmpeg"; filterGraph: string; outputLabel: string }
+	| {
+			kind: "native";
+			mode: "portrait" | "multi-pass";
+			packagePath: string;
+			runtime: JianyingFilterLocalRuntimeInspection;
+			captureFace: boolean;
+	  }
+);
+
+async function requireNativeRuntime() {
+	const runtime = await inspectJianyingFilterLocalRuntime();
+	if (runtime.status.state !== "ready") {
+		throw new Error(
+			`Local Jianying runtime is not ready: ${runtime.status.message}`
+		);
+	}
+	return runtime;
+}
+
+export async function resolveFilterLabRenderPlan({
+	card,
+	intensity,
+}: {
+	card: JianyingFilterCatalogCard;
+	intensity: number;
+}): Promise<FilterLabRenderPlan> {
+	if (!card.available || card.cacheStatus !== "cached" || !card.version) {
+		throw new Error(
+			`Filter ${card.resourceId} is not available in Filter Lab.`
+		);
+	}
+	const cacheRoots = [...new Set(jianyingFilterCacheRoots().map(dirname))];
+	const references = (await listJianyingLutReferences()).filter(
+		(reference) =>
+			reference.resourceId === card.resourceId && reference.size <= 65
+	);
+	const packages = await inspectJianyingFilterPackages({
+		filters: [card],
+		references,
+		cacheRoots,
+	});
+	const summary = buildJianyingFilterLabCatalog({
+		catalog: { order: card.categories, filters: [card] },
+		references,
+		packages,
+		verifications: new Map(),
+	});
+	const filter = summary.filters[0];
+	const packageSummary = packages.get(card.resourceId);
+	if (
+		!filter?.available ||
+		filter.version !== card.version ||
+		!packageSummary
+	) {
+		throw new Error(
+			"The selected filter package changed or is no longer loadable. Refresh the catalog."
+		);
+	}
+	const evidence = {
+		resourceId: card.resourceId,
+		title: card.title,
+		version: card.version,
+		implementation: filter.implementation,
+		verification: card.verification,
+		intensity,
+	};
+
+	const multiPass = packageSummary.multiPassRenderer;
+	if (filter.renderer && multiPass?.version === card.version) {
+		const cacheRoot = selectJianyingFilterCacheRoot({
+			cacheRoots,
+			identity: multiPass,
+		});
+		const settings = await loadJianyingFilterLabRenderer({
+			cacheRoot,
+			filterTitle: card.title,
+			loadRecipe: loadJianyingMultiPassRecipe,
+			renderer: multiPass,
+			resourceId: card.resourceId,
+		});
+		if (settings.nativeEffect) {
+			return {
+				kind: "native",
+				mode: "multi-pass",
+				captureFace: false,
+				packagePath: resolveMultiPassPackagePath({
+					cacheRoot,
+					renderer: multiPass,
+				}),
+				runtime: await requireNativeRuntime(),
+				evidence: {
+					...evidence,
+					backend: "jianying-native-multi-pass",
+					fidelity: "native-local",
+				},
+			};
+		}
+		const graph = buildVideoColorMultiPassGraph({
+			settings: { ...settings, intensity },
+			inputLabel: "filter_input",
+			labelPrefix: "filter_lab",
+		});
+		return {
+			kind: "ffmpeg",
+			filterGraph: [
+				"[0:v:0]format=rgba[filter_input]",
+				...graph.filterSteps,
+			].join(";"),
+			outputLabel: graph.outputLabel,
+			evidence: {
+				...evidence,
+				backend: "ffmpeg-multi-pass",
+				fidelity: "structural",
+			},
+		};
+	}
+
+	if (filter.implementation === "dual-lut") {
+		const native = packageSummary.nativePortraitRenderer;
+		const tiled = packageSummary.dualRenderer?.background;
+		const renderer = native?.version === card.version ? native : tiled;
+		if (!renderer || renderer.version !== card.version) {
+			throw new Error(
+				"This dual LUT has no supported native skin-segmentation package."
+			);
+		}
+		const cacheRoot = selectJianyingFilterCacheRoot({
+			cacheRoots,
+			identity: renderer,
+		});
+		return {
+			kind: "native",
+			mode: "portrait",
+			packagePath:
+				renderer === native
+					? resolveJianyingNativePortraitPackagePath({
+							cacheRoot,
+							renderer: native,
+						})
+					: resolveTiledLutPackagePath({ cacheRoot, renderer: tiled! }),
+			captureFace: native?.faceDetection === true,
+			runtime: await requireNativeRuntime(),
+			evidence: {
+				...evidence,
+				backend: "jianying-native-portrait",
+				fidelity: "native-local",
+			},
+		};
+	}
+
+	const single = filter.luts.find(({ role }) => role === "single");
+	const tiledReferences = tiledReferencesFromPackages({ packages, cacheRoots });
+	const reference =
+		single &&
+		(references.find(({ lutId }) => lutId === single.lutId) ??
+			tiledReferences.get(single.lutId));
+	if (!reference || reference.version !== card.version) {
+		throw new Error(
+			"No supported single LUT was found for the selected version."
+		);
+	}
+	const cube = tiledReferences.has(reference.lutId)
+		? await loadTiledLutCube({ filePath: reference.filePath })
+		: (await loadJianyingLut({ reference }))?.cube;
+	if (!cube) throw new Error("The selected LUT could not be decoded.");
+	const lutPlan = {
+		kind: "ffmpeg" as const,
+		outputLabel: "filter_output",
+		evidence: {
+			...evidence,
+			backend: "ffmpeg-lut" as const,
+			fidelity: "lut" as const,
+		},
+	};
+	if (intensity === 0) {
+		// Even an identity LUT can round 8-bit pixels during interpolation.
+		return { ...lutPlan, filterGraph: "[0:v:0]null[filter_output]" };
+	}
+	const lutPath = materializeVideoCubeLut({
+		name: card.title,
+		cube: {
+			size: cube.size,
+			values: Array.from(cube.values),
+			domainMin: cube.domainMin ?? [0, 0, 0],
+			domainMax: cube.domainMax ?? [1, 1, 1],
+		},
+		intensity,
+		skinProtection: 0,
+	});
+	return {
+		...lutPlan,
+		filterGraph: `[0:v:0]lut3d=file='${escapeFfmpegFilterPath(lutPath)}':interp=tetrahedral[filter_output]`,
+	};
+}

--- a/qcut/electron/native-pipeline/filters/filter-lab-render.ts
+++ b/qcut/electron/native-pipeline/filters/filter-lab-render.ts
@@ -1,0 +1,183 @@
+import { pipeline } from "node:stream/promises";
+import {
+	createJianyingFilterLocalRenderSession,
+	type JianyingFilterLocalRenderSession,
+} from "../../jianying-filter-local-runtime/render.js";
+import { createFilterLabFrameStream } from "./filter-lab-frame-stream.js";
+import {
+	filterLabEncodeArgs,
+	runFilterLabFfmpeg,
+	startFilterLabFfmpeg,
+	type FilterLabMediaInfo,
+} from "./filter-lab-media.js";
+import type { FilterLabRenderPlan } from "./filter-lab-render-plan.js";
+
+export interface FilterLabRenderMediaOptions {
+	input: string;
+	output: string;
+	isImage: boolean;
+	media: FilterLabMediaInfo;
+	plan: FilterLabRenderPlan;
+	signal: AbortSignal;
+}
+
+function restoreAlphaAndIntensity({
+	source,
+	rendered,
+	intensity,
+}: {
+	source: Uint8Array;
+	rendered: Uint8Array;
+	intensity: number;
+}): Uint8Array {
+	if (source.length !== rendered.length)
+		throw new Error("Native frame dimensions changed.");
+	const weight = intensity / 100;
+	const output = new Uint8Array(rendered.length);
+	for (let index = 0; index < output.length; index += 1) {
+		output[index] =
+			index % 4 === 3
+				? source[index]
+				: Math.round(
+						source[index] + (rendered[index] - source[index]) * weight
+					);
+	}
+	return output;
+}
+
+async function renderNativeMedia({
+	input,
+	output,
+	isImage,
+	media,
+	plan,
+	signal,
+}: FilterLabRenderMediaOptions & {
+	plan: Extract<FilterLabRenderPlan, { kind: "native" }>;
+}): Promise<void> {
+	let session: JianyingFilterLocalRenderSession | undefined;
+	const decode = startFilterLabFfmpeg({
+		args: [
+			"-i",
+			input,
+			"-map",
+			"0:v:0",
+			...(isImage
+				? ["-frames:v", "1"]
+				: ["-t", String(media.duration), "-vf", `fps=${media.frameRate}`]),
+			"-f",
+			"rawvideo",
+			"-pix_fmt",
+			"rgba",
+			"pipe:1",
+		],
+		signal,
+	});
+	const encode = startFilterLabFfmpeg({
+		args: [
+			"-f",
+			"rawvideo",
+			"-pixel_format",
+			"rgba",
+			"-video_size",
+			`${media.width}x${media.height}`,
+			"-framerate",
+			String(isImage ? 1 : media.frameRate),
+			"-i",
+			"pipe:0",
+			...(isImage ? [] : ["-i", input]),
+			"-map",
+			"0:v:0",
+			...(isImage ? [] : ["-map", "1:a?"]),
+			...filterLabEncodeArgs({ isImage, duration: media.duration }),
+			output,
+		],
+		signal,
+	});
+	decode.process.stdin.end();
+	encode.process.stdout.resume();
+	const frames = createFilterLabFrameStream({
+		frameBytes: media.width * media.height * 4,
+		renderFrame: async ({ rgba, index }) => {
+			signal.throwIfAborted();
+			if (!session) {
+				session = await createJianyingFilterLocalRenderSession({
+					resourceId: plan.evidence.resourceId,
+					packagePath: plan.packagePath,
+					width: media.width,
+					height: media.height,
+					bootstrapRgba: rgba,
+					runtime: plan.runtime,
+					mode: plan.mode,
+					intensity: plan.evidence.intensity,
+					captureFace: plan.captureFace,
+				});
+			}
+			signal.throwIfAborted();
+			const result = await session.render({
+				rgba,
+				timestampSeconds: isImage ? 0 : index / media.frameRate,
+			});
+			if (plan.mode === "portrait" && !result.mask)
+				throw new Error("Native skin segmentation did not return a mask.");
+			return restoreAlphaAndIntensity({
+				source: rgba,
+				rendered: result.rgba,
+				intensity: plan.mode === "portrait" ? plan.evidence.intensity : 100,
+			});
+		},
+	});
+	const transfer = pipeline(
+		decode.process.stdout,
+		frames,
+		encode.process.stdin,
+		{ signal }
+	);
+	const onAbort = () => {
+		void session?.dispose().catch(() => {});
+	};
+	signal.addEventListener("abort", onAbort, { once: true });
+	try {
+		await Promise.all([decode.completion, transfer, encode.completion]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+		decode.process.kill();
+		encode.process.kill();
+		frames.destroy();
+		decode.process.stdout.destroy();
+		encode.process.stdin.destroy();
+		await Promise.allSettled([decode.completion, transfer, encode.completion]);
+		await session?.dispose();
+	}
+}
+
+export async function renderFilterLabMedia({
+	input,
+	output,
+	isImage,
+	media,
+	plan,
+	signal,
+}: FilterLabRenderMediaOptions): Promise<void> {
+	if (plan.kind === "native") {
+		await renderNativeMedia({ input, output, isImage, media, plan, signal });
+		return;
+	}
+	const frameRateGraph = isImage
+		? plan.filterGraph
+		: `${plan.filterGraph};[${plan.outputLabel}]fps=${media.frameRate}[filter_cfr]`;
+	await runFilterLabFfmpeg({
+		args: [
+			"-i",
+			input,
+			"-filter_complex",
+			frameRateGraph,
+			"-map",
+			`[${isImage ? plan.outputLabel : "filter_cfr"}]`,
+			...(isImage ? [] : ["-map", "0:a?"]),
+			...filterLabEncodeArgs({ isImage, duration: media.duration }),
+			output,
+		],
+		signal,
+	});
+}

--- a/qcut/electron/native-pipeline/filters/filter-lab-tiled-lut.ts
+++ b/qcut/electron/native-pipeline/filters/filter-lab-tiled-lut.ts
@@ -26,6 +26,8 @@ export interface JianyingDualTiledLutRenderer {
 	skin: JianyingTiledLutRenderer;
 }
 
+type DualTiledLutShaderProfile = "legacy-mask" | "native-skin-seg-mask";
+
 export function createTiledLutId({
 	resourceId,
 	renderer,
@@ -104,18 +106,112 @@ export function isSupportedTiledLutShader({
 	);
 }
 
-export function isSupportedDualTiledLutShader({
+function dualTiledLutShaderProfile({
 	source,
 }: {
 	source: string;
-}): boolean {
-	return (
+}): DualTiledLutShaderProfile | null {
+	const legacyMask =
 		/uniform\s+sampler2D\s+u_mask\s*;/.test(source) &&
 		/uniform\s+sampler2D\s+u_lut0\s*;/.test(source) &&
 		/uniform\s+sampler2D\s+u_lut1\s*;/.test(source) &&
 		/src\s*\*=\s*63\.?0*\s*;/.test(source) &&
 		/texture2D\s*\(\s*lut\s*,/.test(source) &&
-		/mix\s*\(\s*res0\s*,\s*res1\s*,\s*mask\.a\s*\)/.test(source)
+		/mix\s*\(\s*res0\s*,\s*res1\s*,\s*mask\.a\s*\)/.test(source);
+	if (legacyMask) return "legacy-mask";
+
+	const nativeSkinSegMask =
+		/uniform\s+sampler2D\s+inputImageTexture\s*;/.test(source) &&
+		/uniform\s+sampler2D\s+filterBgTexture\s*;/.test(source) &&
+		/uniform\s+sampler2D\s+filterSkinTexture\s*;/.test(source) &&
+		/uniform\s+sampler2D\s+maskTexture\s*;/.test(source) &&
+		/uniform\s+float\s+intensity\s*;/.test(source) &&
+		isSupportedTiledLutShader({ source }) &&
+		/vec2\s+maskCoord\s*=\s*vec2\s*\(\s*uv0\.x\s*,\s*1\.?0*\s*-\s*uv0\.y\s*\)\s*;/.test(
+			source
+		) &&
+		/texture2D\s*\(\s*maskTexture\s*,\s*maskCoord\s*\)\.a/.test(source) &&
+		/lm_take_effect_filter\s*\(\s*filterBgTexture\s*,\s*color\s*,\s*intensity(?:\s*\*\s*bgBaseIntensity)?\s*\)/.test(
+			source
+		) &&
+		/lm_take_effect_filter\s*\(\s*filterSkinTexture\s*,\s*color\s*,\s*intensity(?:\s*\*\s*skinBaseIntensity)?\s*\)/.test(
+			source
+		) &&
+		/mix\s*\(\s*bgResultColor\s*,\s*skinResultColor\s*,\s*mask\s*\)/.test(
+			source
+		);
+	return nativeSkinSegMask ? "native-skin-seg-mask" : null;
+}
+
+export function isSupportedDualTiledLutShader({
+	source,
+}: {
+	source: string;
+}): boolean {
+	return dualTiledLutShaderProfile({ source }) !== null;
+}
+
+async function hasNativeSkinSegBindings({
+	paths,
+	root,
+}: {
+	paths: string[];
+	root: string;
+}): Promise<boolean> {
+	const algorithmPaths = paths.filter((filePath) =>
+		filePath.toLowerCase().endsWith("algorithmconfig.json")
+	);
+	const luaPaths = paths.filter((filePath) =>
+		filePath.toLowerCase().endsWith(".lua")
+	);
+	const materialPaths = paths.filter((filePath) =>
+		filePath.toLowerCase().endsWith(".material")
+	);
+	const [algorithmSources, luaSources, materialSources] = await Promise.all([
+		Promise.all(
+			algorithmPaths.map((filePath) =>
+				readFile(join(root, filePath), "utf8").catch(() => "")
+			)
+		),
+		Promise.all(
+			luaPaths.map((filePath) =>
+				readFile(join(root, filePath), "utf8").catch(() => "")
+			)
+		),
+		Promise.all(
+			materialPaths.map((filePath) =>
+				readFile(join(root, filePath))
+					.then((value) => value.toString("latin1"))
+					.catch(() => "")
+			)
+		),
+	]);
+	const hasSkinSegNode = algorithmSources.some((source) => {
+		try {
+			const value = JSON.parse(source) as { nodes?: Array<{ type?: unknown }> };
+			return value.nodes?.some((node) => node.type === "skin_seg") === true;
+		} catch {
+			return false;
+		}
+	});
+	const hasDynamicMaskBinding = luaSources.some(
+		(source) =>
+			/getSkinSegInfo\s*\(\s*\)/.test(source) &&
+			/getTex\s*\(\s*["']maskTexture["']\s*\)/.test(source) &&
+			/[.:]storage\s*\(\s*mask\s*\)/.test(source)
+	);
+	const hasStaticMaskBinding = materialSources.some(
+		(source) =>
+			source.includes("maskTexture") &&
+			source.includes("share://skinsegmask.texture")
+	);
+	const hasIntensityBinding = luaSources.some((source) =>
+		/setFloat\s*\(\s*["']intensity["']\s*,\s*intensity\s*\)/.test(source)
+	);
+	return (
+		hasSkinSegNode &&
+		hasIntensityBinding &&
+		(hasDynamicMaskBinding || hasStaticMaskBinding)
 	);
 }
 
@@ -215,10 +311,18 @@ export async function inspectDualTiledLutRenderer({
 			)
 		),
 	]);
+	const profiles = shaderSources
+		.map((source) => dualTiledLutShaderProfile({ source }))
+		.filter(
+			(profile): profile is DualTiledLutShaderProfile => profile !== null
+		);
+	if (!validBackground || !validSkin || profiles.length === 0) {
+		return null;
+	}
 	if (
-		!validBackground ||
-		!validSkin ||
-		!shaderSources.some((source) => isSupportedDualTiledLutShader({ source }))
+		!profiles.includes("legacy-mask") &&
+		profiles.includes("native-skin-seg-mask") &&
+		!(await hasNativeSkinSegBindings({ paths, root }))
 	) {
 		return null;
 	}

--- a/qcut/electron/preload-types/api-types/jianying-person-cutout-api.ts
+++ b/qcut/electron/preload-types/api-types/jianying-person-cutout-api.ts
@@ -1,0 +1,5 @@
+import type { JianyingPersonCutoutAPI } from "../../jianying-person-cutout-contract";
+
+export interface JianyingPersonCutoutPreloadAPI {
+	jianyingPersonCutout?: JianyingPersonCutoutAPI;
+}

--- a/qcut/electron/preload-types/electron-api.ts
+++ b/qcut/electron/preload-types/electron-api.ts
@@ -67,6 +67,7 @@ import type { JianyingEffectPreloadAPI } from "./api-types/jianying-effect-api";
 import type { JianyingTransitionPreloadAPI } from "./api-types/jianying-transition-api";
 import type { JianyingFilterLabPreloadAPI } from "./api-types/jianying-filter-lab-api";
 import type { JianyingPortraitAdjustmentPreloadAPI } from "./api-types/jianying-portrait-adjustment-api";
+import type { JianyingPersonCutoutPreloadAPI } from "./api-types/jianying-person-cutout-api";
 import type { JianyingFontLabPreloadAPI } from "./api-types/jianying-font-lab-api";
 import type { JianyingTextStyleLabPreloadAPI } from "./api-types/jianying-text-style-lab-api";
 import type { JianyingTextRuntimePreloadAPI } from "./api-types/jianying-text-runtime-api";
@@ -122,6 +123,7 @@ export interface ElectronAPI
 		JianyingEffectPreloadAPI,
 		JianyingFilterLabPreloadAPI,
 		JianyingPortraitAdjustmentPreloadAPI,
+		JianyingPersonCutoutPreloadAPI,
 		JianyingFontLabPreloadAPI,
 		JianyingTextStyleLabPreloadAPI,
 		JianyingTextRuntimePreloadAPI,

--- a/qcut/electron/preload.ts
+++ b/qcut/electron/preload.ts
@@ -100,6 +100,13 @@ import {
 	JIANYING_PORTRAIT_ADJUSTMENT_RENDER_CHANNEL,
 } from "./jianying-portrait-adjustment-contract.js";
 import {
+	JIANYING_PERSON_CUTOUT_INSPECT_CHANNEL,
+	JIANYING_PERSON_CUTOUT_CANCEL_CHANNEL,
+	JIANYING_PERSON_CUTOUT_PROGRESS_CHANNEL,
+	JIANYING_PERSON_CUTOUT_RELEASE_CHANNEL,
+	JIANYING_PERSON_CUTOUT_RENDER_CHANNEL,
+} from "./jianying-person-cutout-contract.js";
+import {
 	JIANYING_FONT_LAB_INSPECT_CHANNEL,
 	JIANYING_FONT_LAB_LIST_CHANNEL,
 	JIANYING_FONT_LAB_LOAD_CHANNEL,
@@ -241,6 +248,28 @@ const electronAPI: ElectronAPI & Record<string, unknown> = {
 			ipcRenderer.invoke(JIANYING_PORTRAIT_ADJUSTMENT_RENDER_CHANNEL, request),
 		detect: (request) =>
 			ipcRenderer.invoke(JIANYING_PORTRAIT_ADJUSTMENT_DETECT_CHANNEL, request),
+	},
+	jianyingPersonCutout: {
+		inspect: () => ipcRenderer.invoke(JIANYING_PERSON_CUTOUT_INSPECT_CHANNEL),
+		render: (request) =>
+			ipcRenderer.invoke(JIANYING_PERSON_CUTOUT_RENDER_CHANNEL, request),
+		cancel: (request) =>
+			ipcRenderer.invoke(JIANYING_PERSON_CUTOUT_CANCEL_CHANNEL, request),
+		onProgress: (callback) => {
+			const listener = (
+				_event: IpcRendererEvent,
+				progress: Parameters<typeof callback>[0]
+			) => callback(progress);
+			ipcRenderer.on(JIANYING_PERSON_CUTOUT_PROGRESS_CHANNEL, listener);
+			return () => {
+				ipcRenderer.removeListener(
+					JIANYING_PERSON_CUTOUT_PROGRESS_CHANNEL,
+					listener
+				);
+			};
+		},
+		release: (request) =>
+			ipcRenderer.invoke(JIANYING_PERSON_CUTOUT_RELEASE_CHANNEL, request),
 	},
 	jianyingFontLab: {
 		list: (request) =>

--- a/qcut/package.json
+++ b/qcut/package.json
@@ -18,6 +18,7 @@
 		"7zip-bin": "5.2.0",
 		"@qcut/editor-core": "workspace:*",
 		"@biomejs/biome": "^2.4.2",
+		"@electron/osx-sign": "^1.3.3",
 		"@vitejs/plugin-react": "^4.5.2",
 		"@emnapi/core": "^1.4.5",
 		"@emnapi/wasi-threads": "^1.1.0",
@@ -389,6 +390,7 @@
 				}
 			],
 			"hardenedRuntime": true,
+			"sign": "./scripts/sign-mac.mjs",
 			"gatekeeperAssess": false,
 			"entitlements": "build/entitlements.mac.plist",
 			"entitlementsInherit": "build/entitlements.mac.plist",

--- a/qcut/packages/editor-core/src/types/timeline.ts
+++ b/qcut/packages/editor-core/src/types/timeline.ts
@@ -349,7 +349,7 @@ export type MediaMaskTrackingDirection = "forward" | "backward" | "both";
 export interface MediaMaskTracking {
 	direction: MediaMaskTrackingDirection;
 	status?: "idle" | "processing" | "paused" | "ready" | "error";
-	source?: "manual" | "optical-flow" | "mediapipe" | "sam3";
+	source?: "manual" | "optical-flow" | "mediapipe" | "jianying-gru" | "sam3";
 	progress?: number;
 	anchorFrame?: number;
 	trackedFrames?: number;

--- a/qcut/packages/editor-core/src/types/timeline.ts
+++ b/qcut/packages/editor-core/src/types/timeline.ts
@@ -349,7 +349,13 @@ export type MediaMaskTrackingDirection = "forward" | "backward" | "both";
 export interface MediaMaskTracking {
 	direction: MediaMaskTrackingDirection;
 	status?: "idle" | "processing" | "paused" | "ready" | "error";
-	source?: "manual" | "optical-flow" | "mediapipe" | "jianying-gru" | "sam3";
+	source?:
+		| "manual"
+		| "optical-flow"
+		| "mediapipe"
+		| "qcut-person-matting"
+		| "jianying-gru"
+		| "sam3";
 	progress?: number;
 	anchorFrame?: number;
 	trackedFrames?: number;

--- a/qcut/research/jianying-runtime-probe/filter-probe.mm
+++ b/qcut/research/jianying-runtime-probe/filter-probe.mm
@@ -228,8 +228,10 @@ struct FilterSymbols {
     const FilterSymbols& symbols, void** manager, int width, int height,
     ResourceFinderMethod resourceFinder, bool algorithmAsync,
     void* graphicsDevice) {
+  const FilterRuntimeProfile profile = filterRuntimeProfile(
+      reinterpret_cast<const void*>(symbols.constructManager));
   verifyRuntimeImage(reinterpret_cast<const void*>(symbols.constructManager),
-                     kLegacyFilterCoreUuid);
+                     profile.uuid);
   void* instance = ::operator new(kVerifiedSwingManagerSize);
   symbols.constructManager(instance);
 

--- a/qcut/research/jianying-runtime-probe/run-probe.sh
+++ b/qcut/research/jianying-runtime-probe/run-probe.sh
@@ -47,6 +47,7 @@ xcrun clang++ \
   "$SCRIPT_DIR/probe.mm" \
   "$SCRIPT_DIR/amazer-context-scope.mm" \
   "$SCRIPT_DIR/filter-host-support.mm" \
+  "$SCRIPT_DIR/filter-face-inspect.mm" \
   "$SCRIPT_DIR/filter-sequence-io.cpp" \
   "$SCRIPT_DIR/graphics-runtime.mm" \
   "$SCRIPT_DIR/graphics-probe.mm" \

--- a/qcut/scripts/__tests__/release-distribution-command.test.ts
+++ b/qcut/scripts/__tests__/release-distribution-command.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { getReleaseDistributionCommand } from "../release.js";
+
+describe("release distribution command", () => {
+	it("routes macOS releases through the complete packaged-runtime pipeline", () => {
+		expect(getReleaseDistributionCommand({ platform: "darwin" })).toBe(
+			"bun run dist:mac"
+		);
+
+		const packageJson = JSON.parse(
+			readFileSync(new URL("../../package.json", import.meta.url), "utf8")
+		) as { scripts: Record<string, string> };
+		expect(packageJson.scripts["dist:mac"]).toContain("stage:all-binaries");
+		expect(packageJson.scripts["dist:mac"]).toContain(
+			"verify:packaged-jianying-runtime-bridges"
+		);
+	});
+
+	it("preserves the existing platform-specific non-macOS commands", () => {
+		expect(getReleaseDistributionCommand({ platform: "linux" })).toContain(
+			"electron-builder --linux"
+		);
+		expect(getReleaseDistributionCommand({ platform: "win32" })).toBe(
+			"bun run dist:win:release"
+		);
+	});
+});

--- a/qcut/scripts/__tests__/sign-mac.test.ts
+++ b/qcut/scripts/__tests__/sign-mac.test.ts
@@ -9,104 +9,114 @@ vi.mock("@electron/osx-sign", () => ({ signAsync: vi.fn() }));
 
 const app = path.resolve("/tmp/QCut AI Video Editor.app");
 const bridgePath = path.join(
-	app,
-	"Contents/Resources/bin/jianying-transition-bridge"
+  app,
+  "Contents/Resources/bin/jianying-transition-bridge",
 );
 const personCutoutBridgePath = path.join(
-	app,
-	"Contents/Resources/bin/jianying-person-cutout-bridge"
+  app,
+  "Contents/Resources/bin/jianying-person-cutout-bridge",
 );
 const saliencyBridgePath = path.join(
-	app,
-	"Contents/Resources/bin/jianying-saliency-script-bridge"
+  app,
+  "Contents/Resources/bin/jianying-saliency-script-bridge",
+);
+const videoObjectBachBridgePath = path.join(
+  app,
+  "Contents/Resources/bin/jianying-video-object-bach-bridge",
 );
 const original = {
-	entitlements: "build/entitlements.mac.plist",
-	hardenedRuntime: true,
-	timestamp: "none",
-	requirements: "=designated => anchor apple generic",
+  entitlements: "build/entitlements.mac.plist",
+  hardenedRuntime: true,
+  timestamp: "none",
+  requirements: "=designated => anchor apple generic",
 };
 
 afterEach(() => vi.clearAllMocks());
 
 describe("macOS transition bridge signing", () => {
-	it("uses dedicated entitlements only for the exact bundled helper", () => {
-		const options = withTransitionBridgeEntitlements({
-			options: { app, optionsForFile: () => original },
-		});
-		expect(options.optionsForFile?.(bridgePath)).toEqual({
-			...original,
-			entitlements: expect.stringContaining(
-				"build/entitlements.transition-bridge.mac.plist"
-			),
-		});
-		expect(options.optionsForFile?.(personCutoutBridgePath)).toEqual({
-			...original,
-			entitlements: expect.stringContaining(
-				"build/entitlements.transition-bridge.mac.plist"
-			),
-		});
-		expect(options.optionsForFile?.(saliencyBridgePath)).toEqual({
-			...original,
-			entitlements: expect.stringContaining(
-				"build/entitlements.transition-bridge.mac.plist"
-			),
-		});
-		for (const filePath of [
-			app,
-			path.join(app, "Contents/MacOS/QCut AI Video Editor"),
-			path.join(app, "Contents/Resources/bin/ffmpeg"),
-			path.join(app, "Contents/Resources/bin/jianying-text-runtime-bridge"),
-			path.join(app, "Contents/Frameworks/jianying-transition-bridge"),
-			path.join(
-				app,
-				"../Other.app/Contents/Resources/bin/jianying-transition-bridge"
-			),
-		]) {
-			expect(options.optionsForFile?.(filePath)).toBe(original);
-		}
-	});
+  it("uses dedicated entitlements only for the exact bundled helper", () => {
+    const options = withTransitionBridgeEntitlements({
+      options: { app, optionsForFile: () => original },
+    });
+    expect(options.optionsForFile?.(bridgePath)).toEqual({
+      ...original,
+      entitlements: expect.stringContaining(
+        "build/entitlements.transition-bridge.mac.plist",
+      ),
+    });
+    expect(options.optionsForFile?.(personCutoutBridgePath)).toEqual({
+      ...original,
+      entitlements: expect.stringContaining(
+        "build/entitlements.transition-bridge.mac.plist",
+      ),
+    });
+    expect(options.optionsForFile?.(saliencyBridgePath)).toEqual({
+      ...original,
+      entitlements: expect.stringContaining(
+        "build/entitlements.transition-bridge.mac.plist",
+      ),
+    });
+    expect(options.optionsForFile?.(videoObjectBachBridgePath)).toEqual({
+      ...original,
+      entitlements: expect.stringContaining(
+        "build/entitlements.transition-bridge.mac.plist",
+      ),
+    });
+    for (const filePath of [
+      app,
+      path.join(app, "Contents/MacOS/QCut AI Video Editor"),
+      path.join(app, "Contents/Resources/bin/ffmpeg"),
+      path.join(app, "Contents/Resources/bin/jianying-text-runtime-bridge"),
+      path.join(app, "Contents/Frameworks/jianying-transition-bridge"),
+      path.join(
+        app,
+        "../Other.app/Contents/Resources/bin/jianying-transition-bridge",
+      ),
+    ]) {
+      expect(options.optionsForFile?.(filePath)).toBe(original);
+    }
+  });
 
-	it("retains hardened runtime even if the upstream callback omits it", () => {
-		const options = withTransitionBridgeEntitlements({ options: { app } });
-		expect(options.optionsForFile?.(bridgePath)?.hardenedRuntime).toBe(true);
-		expect(options.optionsForFile?.(app)).toEqual({});
-	});
+  it("retains hardened runtime even if the upstream callback omits it", () => {
+    const options = withTransitionBridgeEntitlements({ options: { app } });
+    expect(options.optionsForFile?.(bridgePath)?.hardenedRuntime).toBe(true);
+    expect(options.optionsForFile?.(app)).toEqual({});
+  });
 
-	it("delegates signing and preserves identity, keychain, and verification", async () => {
-		const options: SignOptions = {
-			app,
-			identity: "test-identity",
-			keychain: "/tmp/test.keychain",
-			strictVerify: true,
-			identityValidation: false,
-			optionsForFile: () => original,
-		};
-		await sign(options);
-		expect(signAsync).toHaveBeenCalledOnce();
-		expect(signAsync).toHaveBeenCalledWith({
-			...options,
-			optionsForFile: expect.any(Function),
-		});
-		const passed = vi.mocked(signAsync).mock.calls[0][0];
-		expect(passed.optionsForFile?.(bridgePath)?.entitlements).not.toBe(
-			original.entitlements
-		);
-	});
+  it("delegates signing and preserves identity, keychain, and verification", async () => {
+    const options: SignOptions = {
+      app,
+      identity: "test-identity",
+      keychain: "/tmp/test.keychain",
+      strictVerify: true,
+      identityValidation: false,
+      optionsForFile: () => original,
+    };
+    await sign(options);
+    expect(signAsync).toHaveBeenCalledOnce();
+    expect(signAsync).toHaveBeenCalledWith({
+      ...options,
+      optionsForFile: expect.any(Function),
+    });
+    const passed = vi.mocked(signAsync).mock.calls[0][0];
+    expect(passed.optionsForFile?.(bridgePath)?.entitlements).not.toBe(
+      original.entitlements,
+    );
+  });
 
-	it("propagates signing failures instead of publishing an unsigned app", async () => {
-		vi.mocked(signAsync).mockRejectedValueOnce(new Error("signature failed"));
-		await expect(sign({ app })).rejects.toThrow("signature failed");
-	});
+  it("propagates signing failures instead of publishing an unsigned app", async () => {
+    vi.mocked(signAsync).mockRejectedValueOnce(new Error("signature failed"));
+    await expect(sign({ app })).rejects.toThrow("signature failed");
+  });
 
-	it("wires the signing hook into electron-builder without changing app entitlements", () => {
-		const pkg = JSON.parse(
-			readFileSync(new URL("../../package.json", import.meta.url), "utf8")
-		);
-		expect(pkg.build.mac.sign).toBe("./scripts/sign-mac.mjs");
-		expect(pkg.build.mac.entitlements).toBe("build/entitlements.mac.plist");
-		expect(pkg.build.mac.entitlementsInherit).toBe(
-			"build/entitlements.mac.plist"
-		);
-	});
+  it("wires the signing hook into electron-builder without changing app entitlements", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    );
+    expect(pkg.build.mac.sign).toBe("./scripts/sign-mac.mjs");
+    expect(pkg.build.mac.entitlements).toBe("build/entitlements.mac.plist");
+    expect(pkg.build.mac.entitlementsInherit).toBe(
+      "build/entitlements.mac.plist",
+    );
+  });
 });

--- a/qcut/scripts/__tests__/sign-mac.test.ts
+++ b/qcut/scripts/__tests__/sign-mac.test.ts
@@ -9,114 +9,114 @@ vi.mock("@electron/osx-sign", () => ({ signAsync: vi.fn() }));
 
 const app = path.resolve("/tmp/QCut AI Video Editor.app");
 const bridgePath = path.join(
-  app,
-  "Contents/Resources/bin/jianying-transition-bridge",
+	app,
+	"Contents/Resources/bin/jianying-transition-bridge"
 );
 const personCutoutBridgePath = path.join(
-  app,
-  "Contents/Resources/bin/jianying-person-cutout-bridge",
+	app,
+	"Contents/Resources/bin/jianying-person-cutout-bridge"
 );
 const saliencyBridgePath = path.join(
-  app,
-  "Contents/Resources/bin/jianying-saliency-script-bridge",
+	app,
+	"Contents/Resources/bin/jianying-saliency-script-bridge"
 );
 const videoObjectBachBridgePath = path.join(
-  app,
-  "Contents/Resources/bin/jianying-video-object-bach-bridge",
+	app,
+	"Contents/Resources/bin/jianying-video-object-bach-bridge"
 );
 const original = {
-  entitlements: "build/entitlements.mac.plist",
-  hardenedRuntime: true,
-  timestamp: "none",
-  requirements: "=designated => anchor apple generic",
+	entitlements: "build/entitlements.mac.plist",
+	hardenedRuntime: true,
+	timestamp: "none",
+	requirements: "=designated => anchor apple generic",
 };
 
 afterEach(() => vi.clearAllMocks());
 
 describe("macOS transition bridge signing", () => {
-  it("uses dedicated entitlements only for the exact bundled helper", () => {
-    const options = withTransitionBridgeEntitlements({
-      options: { app, optionsForFile: () => original },
-    });
-    expect(options.optionsForFile?.(bridgePath)).toEqual({
-      ...original,
-      entitlements: expect.stringContaining(
-        "build/entitlements.transition-bridge.mac.plist",
-      ),
-    });
-    expect(options.optionsForFile?.(personCutoutBridgePath)).toEqual({
-      ...original,
-      entitlements: expect.stringContaining(
-        "build/entitlements.transition-bridge.mac.plist",
-      ),
-    });
-    expect(options.optionsForFile?.(saliencyBridgePath)).toEqual({
-      ...original,
-      entitlements: expect.stringContaining(
-        "build/entitlements.transition-bridge.mac.plist",
-      ),
-    });
-    expect(options.optionsForFile?.(videoObjectBachBridgePath)).toEqual({
-      ...original,
-      entitlements: expect.stringContaining(
-        "build/entitlements.transition-bridge.mac.plist",
-      ),
-    });
-    for (const filePath of [
-      app,
-      path.join(app, "Contents/MacOS/QCut AI Video Editor"),
-      path.join(app, "Contents/Resources/bin/ffmpeg"),
-      path.join(app, "Contents/Resources/bin/jianying-text-runtime-bridge"),
-      path.join(app, "Contents/Frameworks/jianying-transition-bridge"),
-      path.join(
-        app,
-        "../Other.app/Contents/Resources/bin/jianying-transition-bridge",
-      ),
-    ]) {
-      expect(options.optionsForFile?.(filePath)).toBe(original);
-    }
-  });
+	it("uses dedicated entitlements only for the exact bundled helper", () => {
+		const options = withTransitionBridgeEntitlements({
+			options: { app, optionsForFile: () => original },
+		});
+		expect(options.optionsForFile?.(bridgePath)).toEqual({
+			...original,
+			entitlements: expect.stringContaining(
+				"build/entitlements.transition-bridge.mac.plist"
+			),
+		});
+		expect(options.optionsForFile?.(personCutoutBridgePath)).toEqual({
+			...original,
+			entitlements: expect.stringContaining(
+				"build/entitlements.transition-bridge.mac.plist"
+			),
+		});
+		expect(options.optionsForFile?.(saliencyBridgePath)).toEqual({
+			...original,
+			entitlements: expect.stringContaining(
+				"build/entitlements.transition-bridge.mac.plist"
+			),
+		});
+		expect(options.optionsForFile?.(videoObjectBachBridgePath)).toEqual({
+			...original,
+			entitlements: expect.stringContaining(
+				"build/entitlements.transition-bridge.mac.plist"
+			),
+		});
+		for (const filePath of [
+			app,
+			path.join(app, "Contents/MacOS/QCut AI Video Editor"),
+			path.join(app, "Contents/Resources/bin/ffmpeg"),
+			path.join(app, "Contents/Resources/bin/jianying-text-runtime-bridge"),
+			path.join(app, "Contents/Frameworks/jianying-transition-bridge"),
+			path.join(
+				app,
+				"../Other.app/Contents/Resources/bin/jianying-transition-bridge"
+			),
+		]) {
+			expect(options.optionsForFile?.(filePath)).toBe(original);
+		}
+	});
 
-  it("retains hardened runtime even if the upstream callback omits it", () => {
-    const options = withTransitionBridgeEntitlements({ options: { app } });
-    expect(options.optionsForFile?.(bridgePath)?.hardenedRuntime).toBe(true);
-    expect(options.optionsForFile?.(app)).toEqual({});
-  });
+	it("retains hardened runtime even if the upstream callback omits it", () => {
+		const options = withTransitionBridgeEntitlements({ options: { app } });
+		expect(options.optionsForFile?.(bridgePath)?.hardenedRuntime).toBe(true);
+		expect(options.optionsForFile?.(app)).toEqual({});
+	});
 
-  it("delegates signing and preserves identity, keychain, and verification", async () => {
-    const options: SignOptions = {
-      app,
-      identity: "test-identity",
-      keychain: "/tmp/test.keychain",
-      strictVerify: true,
-      identityValidation: false,
-      optionsForFile: () => original,
-    };
-    await sign(options);
-    expect(signAsync).toHaveBeenCalledOnce();
-    expect(signAsync).toHaveBeenCalledWith({
-      ...options,
-      optionsForFile: expect.any(Function),
-    });
-    const passed = vi.mocked(signAsync).mock.calls[0][0];
-    expect(passed.optionsForFile?.(bridgePath)?.entitlements).not.toBe(
-      original.entitlements,
-    );
-  });
+	it("delegates signing and preserves identity, keychain, and verification", async () => {
+		const options: SignOptions = {
+			app,
+			identity: "test-identity",
+			keychain: "/tmp/test.keychain",
+			strictVerify: true,
+			identityValidation: false,
+			optionsForFile: () => original,
+		};
+		await sign(options);
+		expect(signAsync).toHaveBeenCalledOnce();
+		expect(signAsync).toHaveBeenCalledWith({
+			...options,
+			optionsForFile: expect.any(Function),
+		});
+		const passed = vi.mocked(signAsync).mock.calls[0][0];
+		expect(passed.optionsForFile?.(bridgePath)?.entitlements).not.toBe(
+			original.entitlements
+		);
+	});
 
-  it("propagates signing failures instead of publishing an unsigned app", async () => {
-    vi.mocked(signAsync).mockRejectedValueOnce(new Error("signature failed"));
-    await expect(sign({ app })).rejects.toThrow("signature failed");
-  });
+	it("propagates signing failures instead of publishing an unsigned app", async () => {
+		vi.mocked(signAsync).mockRejectedValueOnce(new Error("signature failed"));
+		await expect(sign({ app })).rejects.toThrow("signature failed");
+	});
 
-  it("wires the signing hook into electron-builder without changing app entitlements", () => {
-    const pkg = JSON.parse(
-      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
-    );
-    expect(pkg.build.mac.sign).toBe("./scripts/sign-mac.mjs");
-    expect(pkg.build.mac.entitlements).toBe("build/entitlements.mac.plist");
-    expect(pkg.build.mac.entitlementsInherit).toBe(
-      "build/entitlements.mac.plist",
-    );
-  });
+	it("wires the signing hook into electron-builder without changing app entitlements", () => {
+		const pkg = JSON.parse(
+			readFileSync(new URL("../../package.json", import.meta.url), "utf8")
+		);
+		expect(pkg.build.mac.sign).toBe("./scripts/sign-mac.mjs");
+		expect(pkg.build.mac.entitlements).toBe("build/entitlements.mac.plist");
+		expect(pkg.build.mac.entitlementsInherit).toBe(
+			"build/entitlements.mac.plist"
+		);
+	});
 });

--- a/qcut/scripts/__tests__/sign-mac.test.ts
+++ b/qcut/scripts/__tests__/sign-mac.test.ts
@@ -24,6 +24,10 @@ const videoObjectBachBridgePath = path.join(
 	app,
 	"Contents/Resources/bin/jianying-video-object-bach-bridge"
 );
+const transitionEntitlementsSuffix = path.join(
+	"build",
+	"entitlements.transition-bridge.mac.plist"
+);
 const original = {
 	entitlements: "build/entitlements.mac.plist",
 	hardenedRuntime: true,
@@ -40,27 +44,19 @@ describe("macOS transition bridge signing", () => {
 		});
 		expect(options.optionsForFile?.(bridgePath)).toEqual({
 			...original,
-			entitlements: expect.stringContaining(
-				"build/entitlements.transition-bridge.mac.plist"
-			),
+			entitlements: expect.stringContaining(transitionEntitlementsSuffix),
 		});
 		expect(options.optionsForFile?.(personCutoutBridgePath)).toEqual({
 			...original,
-			entitlements: expect.stringContaining(
-				"build/entitlements.transition-bridge.mac.plist"
-			),
+			entitlements: expect.stringContaining(transitionEntitlementsSuffix),
 		});
 		expect(options.optionsForFile?.(saliencyBridgePath)).toEqual({
 			...original,
-			entitlements: expect.stringContaining(
-				"build/entitlements.transition-bridge.mac.plist"
-			),
+			entitlements: expect.stringContaining(transitionEntitlementsSuffix),
 		});
 		expect(options.optionsForFile?.(videoObjectBachBridgePath)).toEqual({
 			...original,
-			entitlements: expect.stringContaining(
-				"build/entitlements.transition-bridge.mac.plist"
-			),
+			entitlements: expect.stringContaining(transitionEntitlementsSuffix),
 		});
 		for (const filePath of [
 			app,

--- a/qcut/scripts/__tests__/sign-mac.test.ts
+++ b/qcut/scripts/__tests__/sign-mac.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { signAsync, type SignOptions } from "@electron/osx-sign";
+import { sign, withTransitionBridgeEntitlements } from "../sign-mac.mjs";
+
+vi.mock("@electron/osx-sign", () => ({ signAsync: vi.fn() }));
+
+const app = path.resolve("/tmp/QCut AI Video Editor.app");
+const bridgePath = path.join(
+	app,
+	"Contents/Resources/bin/jianying-transition-bridge"
+);
+const personCutoutBridgePath = path.join(
+	app,
+	"Contents/Resources/bin/jianying-person-cutout-bridge"
+);
+const saliencyBridgePath = path.join(
+	app,
+	"Contents/Resources/bin/jianying-saliency-script-bridge"
+);
+const original = {
+	entitlements: "build/entitlements.mac.plist",
+	hardenedRuntime: true,
+	timestamp: "none",
+	requirements: "=designated => anchor apple generic",
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe("macOS transition bridge signing", () => {
+	it("uses dedicated entitlements only for the exact bundled helper", () => {
+		const options = withTransitionBridgeEntitlements({
+			options: { app, optionsForFile: () => original },
+		});
+		expect(options.optionsForFile?.(bridgePath)).toEqual({
+			...original,
+			entitlements: expect.stringContaining(
+				"build/entitlements.transition-bridge.mac.plist"
+			),
+		});
+		expect(options.optionsForFile?.(personCutoutBridgePath)).toEqual({
+			...original,
+			entitlements: expect.stringContaining(
+				"build/entitlements.transition-bridge.mac.plist"
+			),
+		});
+		expect(options.optionsForFile?.(saliencyBridgePath)).toEqual({
+			...original,
+			entitlements: expect.stringContaining(
+				"build/entitlements.transition-bridge.mac.plist"
+			),
+		});
+		for (const filePath of [
+			app,
+			path.join(app, "Contents/MacOS/QCut AI Video Editor"),
+			path.join(app, "Contents/Resources/bin/ffmpeg"),
+			path.join(app, "Contents/Resources/bin/jianying-text-runtime-bridge"),
+			path.join(app, "Contents/Frameworks/jianying-transition-bridge"),
+			path.join(
+				app,
+				"../Other.app/Contents/Resources/bin/jianying-transition-bridge"
+			),
+		]) {
+			expect(options.optionsForFile?.(filePath)).toBe(original);
+		}
+	});
+
+	it("retains hardened runtime even if the upstream callback omits it", () => {
+		const options = withTransitionBridgeEntitlements({ options: { app } });
+		expect(options.optionsForFile?.(bridgePath)?.hardenedRuntime).toBe(true);
+		expect(options.optionsForFile?.(app)).toEqual({});
+	});
+
+	it("delegates signing and preserves identity, keychain, and verification", async () => {
+		const options: SignOptions = {
+			app,
+			identity: "test-identity",
+			keychain: "/tmp/test.keychain",
+			strictVerify: true,
+			identityValidation: false,
+			optionsForFile: () => original,
+		};
+		await sign(options);
+		expect(signAsync).toHaveBeenCalledOnce();
+		expect(signAsync).toHaveBeenCalledWith({
+			...options,
+			optionsForFile: expect.any(Function),
+		});
+		const passed = vi.mocked(signAsync).mock.calls[0][0];
+		expect(passed.optionsForFile?.(bridgePath)?.entitlements).not.toBe(
+			original.entitlements
+		);
+	});
+
+	it("propagates signing failures instead of publishing an unsigned app", async () => {
+		vi.mocked(signAsync).mockRejectedValueOnce(new Error("signature failed"));
+		await expect(sign({ app })).rejects.toThrow("signature failed");
+	});
+
+	it("wires the signing hook into electron-builder without changing app entitlements", () => {
+		const pkg = JSON.parse(
+			readFileSync(new URL("../../package.json", import.meta.url), "utf8")
+		);
+		expect(pkg.build.mac.sign).toBe("./scripts/sign-mac.mjs");
+		expect(pkg.build.mac.entitlements).toBe("build/entitlements.mac.plist");
+		expect(pkg.build.mac.entitlementsInherit).toBe(
+			"build/entitlements.mac.plist"
+		);
+	});
+});

--- a/qcut/scripts/__tests__/transition-bridge-signature.test.ts
+++ b/qcut/scripts/__tests__/transition-bridge-signature.test.ts
@@ -6,111 +6,165 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	requireTransitionBridgeEntitlements,
-	verifyPackagedJianyingRuntimeBridge,
+  requireTransitionBridgeEntitlements,
+  requiresDyldRuntimeEntitlements,
+  verifyPackagedJianyingRuntimeBridge,
 } from "../verify-packaged-jianying-runtime-bridge.js";
 
 const bridgeFileName = "jianying-transition-bridge";
 const temporaryDirectories: string[] = [];
 const projectRoot = fileURLToPath(new URL("../../", import.meta.url));
 
-afterEach(async () => {
-	await Promise.all(
-		temporaryDirectories
-			.splice(0)
-			.map((directory) => rm(directory, { recursive: true, force: true }))
-	);
+describe("DYLD runtime bridge classification", () => {
+  it("requires dedicated entitlements for the audited Bach helper", () => {
+    expect(
+      requiresDyldRuntimeEntitlements({
+        bridgeFileName: "jianying-video-object-bach-bridge",
+      }),
+    ).toBe(true);
+    expect(
+      requiresDyldRuntimeEntitlements({
+        bridgeFileName: "jianying-video-object-coreml-bridge",
+      }),
+    ).toBe(false);
+  });
 });
 
-async function createFixture({ entitlements }: { entitlements: string }) {
-	const root = await mkdtemp(path.join(tmpdir(), "qcut-signed-bridge-"));
-	temporaryDirectories.push(root);
-	const stagedPath = path.join(root, "electron/resources/bin", bridgeFileName);
-	const distRoot = path.join(root, "dist-electron");
-	const packagedPath = path.join(
-		distRoot,
-		"mac-arm64/QCut.app/Contents/Resources/bin",
-		bridgeFileName
-	);
-	await mkdir(path.dirname(stagedPath), { recursive: true });
-	await mkdir(path.dirname(packagedPath), { recursive: true });
-	const source = path.join(root, "bridge.c");
-	await writeFile(
-		source,
-		'#include <stdlib.h>\n#include <stdio.h>\nint main(void) {\nconst char *p = getenv("DYLD_LIBRARY_PATH");\nif (!p) return 7;\nputs(p);\nreturn 0;\n}\n'
-	);
-	execFileSync("/usr/bin/clang", [source, "-o", stagedPath], {
-		timeout: 30_000,
-	});
-	await copyFile(stagedPath, packagedPath);
-	execFileSync("/usr/bin/codesign", [
-		"--force",
-		"--sign",
-		"-",
-		"--options",
-		"runtime",
-		"--timestamp=none",
-		"--entitlements",
-		entitlements,
-		packagedPath,
-	]);
-	return { projectRoot: root, distRoot, packagedPath };
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function createFixture({
+  bridgeFileName: fixtureBridgeFileName = bridgeFileName,
+  entitlements,
+}: {
+  bridgeFileName?: string;
+  entitlements: string;
+}) {
+  const root = await mkdtemp(path.join(tmpdir(), "qcut-signed-bridge-"));
+  temporaryDirectories.push(root);
+  const stagedPath = path.join(
+    root,
+    "electron/resources/bin",
+    fixtureBridgeFileName,
+  );
+  const distRoot = path.join(root, "dist-electron");
+  const packagedPath = path.join(
+    distRoot,
+    "mac-arm64/QCut.app/Contents/Resources/bin",
+    fixtureBridgeFileName,
+  );
+  await mkdir(path.dirname(stagedPath), { recursive: true });
+  await mkdir(path.dirname(packagedPath), { recursive: true });
+  const source = path.join(root, "bridge.c");
+  await writeFile(
+    source,
+    '#include <stdlib.h>\n#include <stdio.h>\nint main(void) {\nconst char *p = getenv("DYLD_LIBRARY_PATH");\nif (!p) return 7;\nputs(p);\nreturn 0;\n}\n',
+  );
+  execFileSync("/usr/bin/clang", [source, "-o", stagedPath], {
+    timeout: 30_000,
+  });
+  await copyFile(stagedPath, packagedPath);
+  execFileSync("/usr/bin/codesign", [
+    "--force",
+    "--sign",
+    "-",
+    "--options",
+    "runtime",
+    "--timestamp=none",
+    "--entitlements",
+    entitlements,
+    packagedPath,
+  ]);
+  return { projectRoot: root, distRoot, packagedPath };
 }
 
 // This exercises macOS dyld and codesign, not a mock of their behavior.
 describe.skipIf(process.platform !== "darwin")(
-	"signed transition bridge",
-	() => {
-		it("reproduces the old failure and rejects the packaged helper", async () => {
-			const fixture = await createFixture({
-				entitlements: path.join(projectRoot, "build/entitlements.mac.plist"),
-			});
-			const result = spawnSync(fixture.packagedPath, [], {
-				env: {
-					...process.env,
-					DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
-				},
-			});
-			expect(result.status).toBe(7);
-			await expect(
-				verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName })
-			).rejects.toThrow("allow-dyld-environment-variables");
-		}, 30_000);
+  "signed transition bridge",
+  () => {
+    it("reproduces the old failure and rejects the packaged helper", async () => {
+      const fixture = await createFixture({
+        entitlements: path.join(projectRoot, "build/entitlements.mac.plist"),
+      });
+      const result = spawnSync(fixture.packagedPath, [], {
+        env: {
+          ...process.env,
+          DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
+        },
+      });
+      expect(result.status).toBe(7);
+      await expect(
+        verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName }),
+      ).rejects.toThrow("allow-dyld-environment-variables");
+    }, 30_000);
 
-		it("preserves the runtime search path and accepts the corrected signature", async () => {
-			const fixture = await createFixture({
-				entitlements: path.join(
-					projectRoot,
-					"build/entitlements.transition-bridge.mac.plist"
-				),
-			});
-			const output = execFileSync(fixture.packagedPath, [], {
-				env: {
-					...process.env,
-					DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
-				},
-				encoding: "utf8",
-			});
-			expect(output.trim()).toBe("/tmp/qcut-private-frameworks");
-			await expect(
-				verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName })
-			).resolves.toBe(fixture.packagedPath);
-		}, 30_000);
+    it("preserves the runtime search path and accepts the corrected signature", async () => {
+      const fixture = await createFixture({
+        entitlements: path.join(
+          projectRoot,
+          "build/entitlements.transition-bridge.mac.plist",
+        ),
+      });
+      const output = execFileSync(fixture.packagedPath, [], {
+        env: {
+          ...process.env,
+          DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
+        },
+        encoding: "utf8",
+      });
+      expect(output.trim()).toBe("/tmp/qcut-private-frameworks");
+      await expect(
+        verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName }),
+      ).resolves.toBe(fixture.packagedPath);
+    }, 30_000);
 
-		it("rejects false entitlements rather than accepting their key names", async () => {
-			const root = await mkdtemp(
-				path.join(tmpdir(), "qcut-false-entitlements-")
-			);
-			temporaryDirectories.push(root);
-			const plist = path.join(root, "false.plist");
-			await writeFile(
-				plist,
-				'<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.security.cs.allow-dyld-environment-variables</key><false/><key>com.apple.security.cs.disable-library-validation</key><true/></dict></plist>'
-			);
-			const fixture = await createFixture({ entitlements: plist });
-			await expect(
-				requireTransitionBridgeEntitlements({ filePath: fixture.packagedPath })
-			).rejects.toThrow("allow-dyld-environment-variables");
-		}, 30_000);
-	}
+    it("applies the same signed-package gate to the Bach helper", async () => {
+      const bachBridgeFileName = "jianying-video-object-bach-bridge";
+      const rejected = await createFixture({
+        bridgeFileName: bachBridgeFileName,
+        entitlements: path.join(projectRoot, "build/entitlements.mac.plist"),
+      });
+      await expect(
+        verifyPackagedJianyingRuntimeBridge({
+          ...rejected,
+          bridgeFileName: bachBridgeFileName,
+        }),
+      ).rejects.toThrow("allow-dyld-environment-variables");
+
+      const accepted = await createFixture({
+        bridgeFileName: bachBridgeFileName,
+        entitlements: path.join(
+          projectRoot,
+          "build/entitlements.transition-bridge.mac.plist",
+        ),
+      });
+      await expect(
+        verifyPackagedJianyingRuntimeBridge({
+          ...accepted,
+          bridgeFileName: bachBridgeFileName,
+        }),
+      ).resolves.toBe(accepted.packagedPath);
+    }, 30_000);
+
+    it("rejects false entitlements rather than accepting their key names", async () => {
+      const root = await mkdtemp(
+        path.join(tmpdir(), "qcut-false-entitlements-"),
+      );
+      temporaryDirectories.push(root);
+      const plist = path.join(root, "false.plist");
+      await writeFile(
+        plist,
+        '<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.security.cs.allow-dyld-environment-variables</key><false/><key>com.apple.security.cs.disable-library-validation</key><true/></dict></plist>',
+      );
+      const fixture = await createFixture({ entitlements: plist });
+      await expect(
+        requireTransitionBridgeEntitlements({ filePath: fixture.packagedPath }),
+      ).rejects.toThrow("allow-dyld-environment-variables");
+    }, 30_000);
+  },
 );

--- a/qcut/scripts/__tests__/transition-bridge-signature.test.ts
+++ b/qcut/scripts/__tests__/transition-bridge-signature.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+import { execFileSync, spawnSync } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	requireTransitionBridgeEntitlements,
+	verifyPackagedJianyingRuntimeBridge,
+} from "../verify-packaged-jianying-runtime-bridge.js";
+
+const bridgeFileName = "jianying-transition-bridge";
+const temporaryDirectories: string[] = [];
+const projectRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { recursive: true, force: true }))
+	);
+});
+
+async function createFixture({ entitlements }: { entitlements: string }) {
+	const root = await mkdtemp(path.join(tmpdir(), "qcut-signed-bridge-"));
+	temporaryDirectories.push(root);
+	const stagedPath = path.join(root, "electron/resources/bin", bridgeFileName);
+	const distRoot = path.join(root, "dist-electron");
+	const packagedPath = path.join(
+		distRoot,
+		"mac-arm64/QCut.app/Contents/Resources/bin",
+		bridgeFileName
+	);
+	await mkdir(path.dirname(stagedPath), { recursive: true });
+	await mkdir(path.dirname(packagedPath), { recursive: true });
+	const source = path.join(root, "bridge.c");
+	await writeFile(
+		source,
+		'#include <stdlib.h>\n#include <stdio.h>\nint main(void) {\nconst char *p = getenv("DYLD_LIBRARY_PATH");\nif (!p) return 7;\nputs(p);\nreturn 0;\n}\n'
+	);
+	execFileSync("/usr/bin/clang", [source, "-o", stagedPath], {
+		timeout: 30_000,
+	});
+	await copyFile(stagedPath, packagedPath);
+	execFileSync("/usr/bin/codesign", [
+		"--force",
+		"--sign",
+		"-",
+		"--options",
+		"runtime",
+		"--timestamp=none",
+		"--entitlements",
+		entitlements,
+		packagedPath,
+	]);
+	return { projectRoot: root, distRoot, packagedPath };
+}
+
+// This exercises macOS dyld and codesign, not a mock of their behavior.
+describe.skipIf(process.platform !== "darwin")(
+	"signed transition bridge",
+	() => {
+		it("reproduces the old failure and rejects the packaged helper", async () => {
+			const fixture = await createFixture({
+				entitlements: path.join(projectRoot, "build/entitlements.mac.plist"),
+			});
+			const result = spawnSync(fixture.packagedPath, [], {
+				env: {
+					...process.env,
+					DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
+				},
+			});
+			expect(result.status).toBe(7);
+			await expect(
+				verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName })
+			).rejects.toThrow("allow-dyld-environment-variables");
+		}, 30_000);
+
+		it("preserves the runtime search path and accepts the corrected signature", async () => {
+			const fixture = await createFixture({
+				entitlements: path.join(
+					projectRoot,
+					"build/entitlements.transition-bridge.mac.plist"
+				),
+			});
+			const output = execFileSync(fixture.packagedPath, [], {
+				env: {
+					...process.env,
+					DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
+				},
+				encoding: "utf8",
+			});
+			expect(output.trim()).toBe("/tmp/qcut-private-frameworks");
+			await expect(
+				verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName })
+			).resolves.toBe(fixture.packagedPath);
+		}, 30_000);
+
+		it("rejects false entitlements rather than accepting their key names", async () => {
+			const root = await mkdtemp(
+				path.join(tmpdir(), "qcut-false-entitlements-")
+			);
+			temporaryDirectories.push(root);
+			const plist = path.join(root, "false.plist");
+			await writeFile(
+				plist,
+				'<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.security.cs.allow-dyld-environment-variables</key><false/><key>com.apple.security.cs.disable-library-validation</key><true/></dict></plist>'
+			);
+			const fixture = await createFixture({ entitlements: plist });
+			await expect(
+				requireTransitionBridgeEntitlements({ filePath: fixture.packagedPath })
+			).rejects.toThrow("allow-dyld-environment-variables");
+		}, 30_000);
+	}
+);

--- a/qcut/scripts/__tests__/transition-bridge-signature.test.ts
+++ b/qcut/scripts/__tests__/transition-bridge-signature.test.ts
@@ -6,9 +6,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  requireTransitionBridgeEntitlements,
-  requiresDyldRuntimeEntitlements,
-  verifyPackagedJianyingRuntimeBridge,
+	requireTransitionBridgeEntitlements,
+	requiresDyldRuntimeEntitlements,
+	verifyPackagedJianyingRuntimeBridge,
 } from "../verify-packaged-jianying-runtime-bridge.js";
 
 const bridgeFileName = "jianying-transition-bridge";
@@ -16,155 +16,155 @@ const temporaryDirectories: string[] = [];
 const projectRoot = fileURLToPath(new URL("../../", import.meta.url));
 
 describe("DYLD runtime bridge classification", () => {
-  it("requires dedicated entitlements for the audited Bach helper", () => {
-    expect(
-      requiresDyldRuntimeEntitlements({
-        bridgeFileName: "jianying-video-object-bach-bridge",
-      }),
-    ).toBe(true);
-    expect(
-      requiresDyldRuntimeEntitlements({
-        bridgeFileName: "jianying-video-object-coreml-bridge",
-      }),
-    ).toBe(false);
-  });
+	it("requires dedicated entitlements for the audited Bach helper", () => {
+		expect(
+			requiresDyldRuntimeEntitlements({
+				bridgeFileName: "jianying-video-object-bach-bridge",
+			})
+		).toBe(true);
+		expect(
+			requiresDyldRuntimeEntitlements({
+				bridgeFileName: "jianying-video-object-coreml-bridge",
+			})
+		).toBe(false);
+	});
 });
 
 afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { recursive: true, force: true })),
-  );
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { recursive: true, force: true }))
+	);
 });
 
 async function createFixture({
-  bridgeFileName: fixtureBridgeFileName = bridgeFileName,
-  entitlements,
+	bridgeFileName: fixtureBridgeFileName = bridgeFileName,
+	entitlements,
 }: {
-  bridgeFileName?: string;
-  entitlements: string;
+	bridgeFileName?: string;
+	entitlements: string;
 }) {
-  const root = await mkdtemp(path.join(tmpdir(), "qcut-signed-bridge-"));
-  temporaryDirectories.push(root);
-  const stagedPath = path.join(
-    root,
-    "electron/resources/bin",
-    fixtureBridgeFileName,
-  );
-  const distRoot = path.join(root, "dist-electron");
-  const packagedPath = path.join(
-    distRoot,
-    "mac-arm64/QCut.app/Contents/Resources/bin",
-    fixtureBridgeFileName,
-  );
-  await mkdir(path.dirname(stagedPath), { recursive: true });
-  await mkdir(path.dirname(packagedPath), { recursive: true });
-  const source = path.join(root, "bridge.c");
-  await writeFile(
-    source,
-    '#include <stdlib.h>\n#include <stdio.h>\nint main(void) {\nconst char *p = getenv("DYLD_LIBRARY_PATH");\nif (!p) return 7;\nputs(p);\nreturn 0;\n}\n',
-  );
-  execFileSync("/usr/bin/clang", [source, "-o", stagedPath], {
-    timeout: 30_000,
-  });
-  await copyFile(stagedPath, packagedPath);
-  execFileSync("/usr/bin/codesign", [
-    "--force",
-    "--sign",
-    "-",
-    "--options",
-    "runtime",
-    "--timestamp=none",
-    "--entitlements",
-    entitlements,
-    packagedPath,
-  ]);
-  return { projectRoot: root, distRoot, packagedPath };
+	const root = await mkdtemp(path.join(tmpdir(), "qcut-signed-bridge-"));
+	temporaryDirectories.push(root);
+	const stagedPath = path.join(
+		root,
+		"electron/resources/bin",
+		fixtureBridgeFileName
+	);
+	const distRoot = path.join(root, "dist-electron");
+	const packagedPath = path.join(
+		distRoot,
+		"mac-arm64/QCut.app/Contents/Resources/bin",
+		fixtureBridgeFileName
+	);
+	await mkdir(path.dirname(stagedPath), { recursive: true });
+	await mkdir(path.dirname(packagedPath), { recursive: true });
+	const source = path.join(root, "bridge.c");
+	await writeFile(
+		source,
+		'#include <stdlib.h>\n#include <stdio.h>\nint main(void) {\nconst char *p = getenv("DYLD_LIBRARY_PATH");\nif (!p) return 7;\nputs(p);\nreturn 0;\n}\n'
+	);
+	execFileSync("/usr/bin/clang", [source, "-o", stagedPath], {
+		timeout: 30_000,
+	});
+	await copyFile(stagedPath, packagedPath);
+	execFileSync("/usr/bin/codesign", [
+		"--force",
+		"--sign",
+		"-",
+		"--options",
+		"runtime",
+		"--timestamp=none",
+		"--entitlements",
+		entitlements,
+		packagedPath,
+	]);
+	return { projectRoot: root, distRoot, packagedPath };
 }
 
 // This exercises macOS dyld and codesign, not a mock of their behavior.
 describe.skipIf(process.platform !== "darwin")(
-  "signed transition bridge",
-  () => {
-    it("reproduces the old failure and rejects the packaged helper", async () => {
-      const fixture = await createFixture({
-        entitlements: path.join(projectRoot, "build/entitlements.mac.plist"),
-      });
-      const result = spawnSync(fixture.packagedPath, [], {
-        env: {
-          ...process.env,
-          DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
-        },
-      });
-      expect(result.status).toBe(7);
-      await expect(
-        verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName }),
-      ).rejects.toThrow("allow-dyld-environment-variables");
-    }, 30_000);
+	"signed transition bridge",
+	() => {
+		it("reproduces the old failure and rejects the packaged helper", async () => {
+			const fixture = await createFixture({
+				entitlements: path.join(projectRoot, "build/entitlements.mac.plist"),
+			});
+			const result = spawnSync(fixture.packagedPath, [], {
+				env: {
+					...process.env,
+					DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
+				},
+			});
+			expect(result.status).toBe(7);
+			await expect(
+				verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName })
+			).rejects.toThrow("allow-dyld-environment-variables");
+		}, 30_000);
 
-    it("preserves the runtime search path and accepts the corrected signature", async () => {
-      const fixture = await createFixture({
-        entitlements: path.join(
-          projectRoot,
-          "build/entitlements.transition-bridge.mac.plist",
-        ),
-      });
-      const output = execFileSync(fixture.packagedPath, [], {
-        env: {
-          ...process.env,
-          DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
-        },
-        encoding: "utf8",
-      });
-      expect(output.trim()).toBe("/tmp/qcut-private-frameworks");
-      await expect(
-        verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName }),
-      ).resolves.toBe(fixture.packagedPath);
-    }, 30_000);
+		it("preserves the runtime search path and accepts the corrected signature", async () => {
+			const fixture = await createFixture({
+				entitlements: path.join(
+					projectRoot,
+					"build/entitlements.transition-bridge.mac.plist"
+				),
+			});
+			const output = execFileSync(fixture.packagedPath, [], {
+				env: {
+					...process.env,
+					DYLD_LIBRARY_PATH: "/tmp/qcut-private-frameworks",
+				},
+				encoding: "utf8",
+			});
+			expect(output.trim()).toBe("/tmp/qcut-private-frameworks");
+			await expect(
+				verifyPackagedJianyingRuntimeBridge({ ...fixture, bridgeFileName })
+			).resolves.toBe(fixture.packagedPath);
+		}, 30_000);
 
-    it("applies the same signed-package gate to the Bach helper", async () => {
-      const bachBridgeFileName = "jianying-video-object-bach-bridge";
-      const rejected = await createFixture({
-        bridgeFileName: bachBridgeFileName,
-        entitlements: path.join(projectRoot, "build/entitlements.mac.plist"),
-      });
-      await expect(
-        verifyPackagedJianyingRuntimeBridge({
-          ...rejected,
-          bridgeFileName: bachBridgeFileName,
-        }),
-      ).rejects.toThrow("allow-dyld-environment-variables");
+		it("applies the same signed-package gate to the Bach helper", async () => {
+			const bachBridgeFileName = "jianying-video-object-bach-bridge";
+			const rejected = await createFixture({
+				bridgeFileName: bachBridgeFileName,
+				entitlements: path.join(projectRoot, "build/entitlements.mac.plist"),
+			});
+			await expect(
+				verifyPackagedJianyingRuntimeBridge({
+					...rejected,
+					bridgeFileName: bachBridgeFileName,
+				})
+			).rejects.toThrow("allow-dyld-environment-variables");
 
-      const accepted = await createFixture({
-        bridgeFileName: bachBridgeFileName,
-        entitlements: path.join(
-          projectRoot,
-          "build/entitlements.transition-bridge.mac.plist",
-        ),
-      });
-      await expect(
-        verifyPackagedJianyingRuntimeBridge({
-          ...accepted,
-          bridgeFileName: bachBridgeFileName,
-        }),
-      ).resolves.toBe(accepted.packagedPath);
-    }, 30_000);
+			const accepted = await createFixture({
+				bridgeFileName: bachBridgeFileName,
+				entitlements: path.join(
+					projectRoot,
+					"build/entitlements.transition-bridge.mac.plist"
+				),
+			});
+			await expect(
+				verifyPackagedJianyingRuntimeBridge({
+					...accepted,
+					bridgeFileName: bachBridgeFileName,
+				})
+			).resolves.toBe(accepted.packagedPath);
+		}, 30_000);
 
-    it("rejects false entitlements rather than accepting their key names", async () => {
-      const root = await mkdtemp(
-        path.join(tmpdir(), "qcut-false-entitlements-"),
-      );
-      temporaryDirectories.push(root);
-      const plist = path.join(root, "false.plist");
-      await writeFile(
-        plist,
-        '<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.security.cs.allow-dyld-environment-variables</key><false/><key>com.apple.security.cs.disable-library-validation</key><true/></dict></plist>',
-      );
-      const fixture = await createFixture({ entitlements: plist });
-      await expect(
-        requireTransitionBridgeEntitlements({ filePath: fixture.packagedPath }),
-      ).rejects.toThrow("allow-dyld-environment-variables");
-    }, 30_000);
-  },
+		it("rejects false entitlements rather than accepting their key names", async () => {
+			const root = await mkdtemp(
+				path.join(tmpdir(), "qcut-false-entitlements-")
+			);
+			temporaryDirectories.push(root);
+			const plist = path.join(root, "false.plist");
+			await writeFile(
+				plist,
+				'<?xml version="1.0"?><plist version="1.0"><dict><key>com.apple.security.cs.allow-dyld-environment-variables</key><false/><key>com.apple.security.cs.disable-library-validation</key><true/></dict></plist>'
+			);
+			const fixture = await createFixture({ entitlements: plist });
+			await expect(
+				requireTransitionBridgeEntitlements({ filePath: fixture.packagedPath })
+			).rejects.toThrow("allow-dyld-environment-variables");
+		}, 30_000);
+	}
 );

--- a/qcut/scripts/__tests__/verify-packaged-jianying-runtime-bridges.test.ts
+++ b/qcut/scripts/__tests__/verify-packaged-jianying-runtime-bridges.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME } from "../../electron/jianying-filter-local-runtime/bridge-resolver.js";
 import { JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME } from "../../electron/jianying-portrait-adjustment-runtime/bridge-resolver.js";
+import { JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME } from "../../electron/jianying-person-cutout/bridge-resolver.js";
+import { JIANYING_SALIENCY_BRIDGE_FILE_NAME } from "../../electron/jianying-person-cutout/saliency-bridge-resolver.js";
 import { JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME } from "../../electron/jianying-text-runtime/bridge-resolver.js";
 import { JIANYING_TRANSITION_BRIDGE_FILE_NAME } from "../../electron/jianying-transition/bridge-resolver.js";
 import { verifyPackagedJianyingRuntimeBridges } from "../verify-packaged-jianying-runtime-bridges.js";
@@ -57,7 +59,16 @@ async function createFixture({
 		},
 		{
 			name: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
-			contents: "#!/bin/sh\nexit 0\n",
+			contents: "#!/bin/sh\n# HTSGLContext\nexit 0\n",
+		},
+		{
+			name: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+			contents:
+				"#!/bin/sh\n# TEMattingBlendEffectV2-native-metal Vision-person-fusion-v1\nexit 0\n",
+		},
+		{
+			name: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+			contents: "#!/bin/sh\n# video-object-general-seg-v1\nexit 0\n",
 		},
 	];
 	await Promise.all(
@@ -94,6 +105,12 @@ describe("packaged Jianying runtime bridge verification", () => {
 			),
 			portraitAdjustmentHost: expect.stringContaining(
 				JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME
+			),
+			personCutoutBridge: expect.stringContaining(
+				JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME
+			),
+			saliencyBridge: expect.stringContaining(
+				JIANYING_SALIENCY_BRIDGE_FILE_NAME
 			),
 		});
 	});

--- a/qcut/scripts/__tests__/verify-packaged-jianying-runtime-bridges.test.ts
+++ b/qcut/scripts/__tests__/verify-packaged-jianying-runtime-bridges.test.ts
@@ -7,6 +7,11 @@ import { JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME } from "../../electron/jianying-
 import { JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME } from "../../electron/jianying-portrait-adjustment-runtime/bridge-resolver.js";
 import { JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME } from "../../electron/jianying-person-cutout/bridge-resolver.js";
 import { JIANYING_SALIENCY_BRIDGE_FILE_NAME } from "../../electron/jianying-person-cutout/saliency-bridge-resolver.js";
+import {
+  VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+  VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS,
+} from "../../electron/jianying-person-cutout/video-object-bach-bridge-resolver.js";
+import { VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME } from "../../electron/jianying-person-cutout/video-object-coreml-bridge-resolver.js";
 import { JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME } from "../../electron/jianying-text-runtime/bridge-resolver.js";
 import { JIANYING_TRANSITION_BRIDGE_FILE_NAME } from "../../electron/jianying-transition/bridge-resolver.js";
 import { verifyPackagedJianyingRuntimeBridges } from "../verify-packaged-jianying-runtime-bridges.js";
@@ -14,113 +19,186 @@ import { verifyPackagedJianyingRuntimeBridges } from "../verify-packaged-jianyin
 const temporaryDirectories: string[] = [];
 
 async function writeBridge({
-	contents,
-	filePath,
+  contents,
+  filePath,
 }: {
-	contents: string;
-	filePath: string;
+  contents: string;
+  filePath: string;
 }) {
-	await mkdir(path.dirname(filePath), { recursive: true });
-	await writeFile(filePath, contents);
-	await chmod(filePath, 0o755);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, contents);
+  await chmod(filePath, 0o755);
 }
 
 async function createFixture({
-	transitionUsage = "transition-video|effect-video",
+  personCutoutCapabilities = "TEMattingBlendEffectV2-native-metal-canary Vision-person-fusion-v1",
+  saliencyCapabilities = "video-object-general-seg-v1 video-object-alpha-quality-v1",
+  videoObjectBachCapabilities = VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.join(
+    " ",
+  ),
+  videoObjectCoreMLCapabilities = "video-object-same-model-coreml-v1",
+  transitionUsage = "transition-video|effect-video",
 }: {
-	transitionUsage?: string;
+  personCutoutCapabilities?: string;
+  saliencyCapabilities?: string;
+  videoObjectBachCapabilities?: string;
+  videoObjectCoreMLCapabilities?: string;
+  transitionUsage?: string;
 } = {}) {
-	const projectRoot = await mkdtemp(
-		path.join(tmpdir(), "qcut-packaged-runtime-bridges-")
-	);
-	temporaryDirectories.push(projectRoot);
-	const distRoot = path.join(projectRoot, "dist-electron");
-	const stagedRoot = path.join(projectRoot, "electron", "resources", "bin");
-	const packagedRoot = path.join(
-		distRoot,
-		"mac-arm64",
-		"QCut AI Video Editor.app",
-		"Contents",
-		"Resources",
-		"bin"
-	);
-	const bridges = [
-		{
-			name: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
-			contents: `#!/bin/sh\necho '${transitionUsage}' >&2\nexit 2\n`,
-		},
-		{
-			name: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
-			contents: "#!/bin/sh\nexit 0\n",
-		},
-		{
-			name: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
-			contents: "#!/bin/sh\nexit 0\n",
-		},
-		{
-			name: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
-			contents: "#!/bin/sh\n# HTSGLContext\nexit 0\n",
-		},
-		{
-			name: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
-			contents:
-				"#!/bin/sh\n# TEMattingBlendEffectV2-native-metal Vision-person-fusion-v1\nexit 0\n",
-		},
-		{
-			name: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
-			contents: "#!/bin/sh\n# video-object-general-seg-v1\nexit 0\n",
-		},
-	];
-	await Promise.all(
-		bridges.flatMap(({ name, contents }) => [
-			writeBridge({ filePath: path.join(stagedRoot, name), contents }),
-			writeBridge({ filePath: path.join(packagedRoot, name), contents }),
-		])
-	);
-	return { distRoot, projectRoot };
+  const projectRoot = await mkdtemp(
+    path.join(tmpdir(), "qcut-packaged-runtime-bridges-"),
+  );
+  temporaryDirectories.push(projectRoot);
+  const distRoot = path.join(projectRoot, "dist-electron");
+  const stagedRoot = path.join(projectRoot, "electron", "resources", "bin");
+  const packagedRoot = path.join(
+    distRoot,
+    "mac-arm64",
+    "QCut AI Video Editor.app",
+    "Contents",
+    "Resources",
+    "bin",
+  );
+  const bridges = [
+    {
+      name: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
+      contents: `#!/bin/sh\necho '${transitionUsage}' >&2\nexit 2\n`,
+    },
+    {
+      name: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
+      contents: "#!/bin/sh\nexit 0\n",
+    },
+    {
+      name: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
+      contents: "#!/bin/sh\nexit 0\n",
+    },
+    {
+      name: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
+      contents: "#!/bin/sh\n# HTSGLContext\nexit 0\n",
+    },
+    {
+      name: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+      contents: `#!/bin/sh\n# ${personCutoutCapabilities}\nexit 0\n`,
+    },
+    {
+      name: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+      contents: `#!/bin/sh\n# ${saliencyCapabilities}\nexit 0\n`,
+    },
+    {
+      name: VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+      contents: `#!/bin/sh\n# ${videoObjectBachCapabilities}\nexit 0\n`,
+    },
+    {
+      name: VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+      contents: `#!/bin/sh\n# ${videoObjectCoreMLCapabilities}\nexit 0\n`,
+    },
+  ];
+  await Promise.all(
+    bridges.flatMap(({ name, contents }) => [
+      writeBridge({ filePath: path.join(stagedRoot, name), contents }),
+      writeBridge({ filePath: path.join(packagedRoot, name), contents }),
+    ]),
+  );
+  return { distRoot, projectRoot };
 }
 
 afterEach(async () => {
-	await Promise.all(
-		temporaryDirectories
-			.splice(0)
-			.map((directory) => rm(directory, { recursive: true, force: true }))
-	);
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
 });
 
 describe("packaged Jianying runtime bridge verification", () => {
-	it("accepts all bridges when the transition bridge supports effects", async () => {
-		const fixture = await createFixture();
-		await expect(
-			verifyPackagedJianyingRuntimeBridges(fixture)
-		).resolves.toMatchObject({
-			transitionBridge: expect.stringContaining(
-				JIANYING_TRANSITION_BRIDGE_FILE_NAME
-			),
-			textBridge: expect.stringContaining(
-				JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME
-			),
-			filterBridge: expect.stringContaining(
-				JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME
-			),
-			portraitAdjustmentHost: expect.stringContaining(
-				JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME
-			),
-			personCutoutBridge: expect.stringContaining(
-				JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME
-			),
-			saliencyBridge: expect.stringContaining(
-				JIANYING_SALIENCY_BRIDGE_FILE_NAME
-			),
-		});
-	});
+  it("accepts all bridges when the transition bridge supports effects", async () => {
+    const fixture = await createFixture();
+    await expect(
+      verifyPackagedJianyingRuntimeBridges(fixture),
+    ).resolves.toMatchObject({
+      transitionBridge: expect.stringContaining(
+        JIANYING_TRANSITION_BRIDGE_FILE_NAME,
+      ),
+      textBridge: expect.stringContaining(
+        JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
+      ),
+      filterBridge: expect.stringContaining(
+        JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
+      ),
+      portraitAdjustmentHost: expect.stringContaining(
+        JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
+      ),
+      personCutoutBridge: expect.stringContaining(
+        JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+      ),
+      saliencyBridge: expect.stringContaining(
+        JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+      ),
+      videoObjectBachBridge: expect.stringContaining(
+        VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+      ),
+      videoObjectCoreMLBridge: expect.stringContaining(
+        VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+      ),
+    });
+  });
 
-	it("rejects a transition bridge built before effect rendering existed", async () => {
-		const fixture = await createFixture({
-			transitionUsage: "transition-video|text-frame",
-		});
-		await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
-			"required mode: effect-video"
-		);
-	});
+  it("rejects a transition bridge built before effect rendering existed", async () => {
+    const fixture = await createFixture({
+      transitionUsage: "transition-video|text-frame",
+    });
+    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+      "required mode: effect-video",
+    );
+  });
+
+  it("rejects a video-object bridge without the Alpha quality gate", async () => {
+    const fixture = await createFixture({
+      saliencyCapabilities: "video-object-general-seg-v1",
+    });
+    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+      "video-object Alpha quality gate",
+    );
+  });
+
+  it("rejects a stale same-model CoreML bridge", async () => {
+    const fixture = await createFixture({
+      videoObjectCoreMLCapabilities: "video-object-alpha-quality-v1",
+    });
+    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+      "same-model CoreML bridge is stale",
+    );
+  });
+
+  it("rejects a Bach bridge without every audited runtime pin", async () => {
+    const fixture = await createFixture({
+      videoObjectBachCapabilities:
+        "video-object-jianying-bach-v2-exact-d634-v1 TEMattingBlendEffectV2-vendor-exact D6342ECD-5432-33F0-A2AD-0C28F5699994",
+    });
+    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+      "missing audited capability",
+    );
+  });
+
+  it("rejects a Bach bridge without the pinned dependency closure", async () => {
+    const fixture = await createFixture({
+      videoObjectBachCapabilities:
+        VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.filter(
+          (marker) => !marker.startsWith("jianying-runtime-framework-closure-"),
+        ).join(" "),
+    });
+    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+      "missing audited capability",
+    );
+  });
+
+  it("rejects a person bridge that still claims full native Metal blending", async () => {
+    const fixture = await createFixture({
+      personCutoutCapabilities:
+        "TEMattingBlendEffectV2-native-metal Vision-person-fusion-v1",
+    });
+    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+      "native Metal canary validation",
+    );
+  });
 });

--- a/qcut/scripts/__tests__/verify-packaged-jianying-runtime-bridges.test.ts
+++ b/qcut/scripts/__tests__/verify-packaged-jianying-runtime-bridges.test.ts
@@ -8,8 +8,8 @@ import { JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME } from "../../electron/jian
 import { JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME } from "../../electron/jianying-person-cutout/bridge-resolver.js";
 import { JIANYING_SALIENCY_BRIDGE_FILE_NAME } from "../../electron/jianying-person-cutout/saliency-bridge-resolver.js";
 import {
-  VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
-  VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS,
+	VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+	VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS,
 } from "../../electron/jianying-person-cutout/video-object-bach-bridge-resolver.js";
 import { VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME } from "../../electron/jianying-person-cutout/video-object-coreml-bridge-resolver.js";
 import { JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME } from "../../electron/jianying-text-runtime/bridge-resolver.js";
@@ -19,186 +19,186 @@ import { verifyPackagedJianyingRuntimeBridges } from "../verify-packaged-jianyin
 const temporaryDirectories: string[] = [];
 
 async function writeBridge({
-  contents,
-  filePath,
+	contents,
+	filePath,
 }: {
-  contents: string;
-  filePath: string;
+	contents: string;
+	filePath: string;
 }) {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, contents);
-  await chmod(filePath, 0o755);
+	await mkdir(path.dirname(filePath), { recursive: true });
+	await writeFile(filePath, contents);
+	await chmod(filePath, 0o755);
 }
 
 async function createFixture({
-  personCutoutCapabilities = "TEMattingBlendEffectV2-native-metal-canary Vision-person-fusion-v1",
-  saliencyCapabilities = "video-object-general-seg-v1 video-object-alpha-quality-v1",
-  videoObjectBachCapabilities = VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.join(
-    " ",
-  ),
-  videoObjectCoreMLCapabilities = "video-object-same-model-coreml-v1",
-  transitionUsage = "transition-video|effect-video",
+	personCutoutCapabilities = "TEMattingBlendEffectV2-native-metal-canary Vision-person-fusion-v1",
+	saliencyCapabilities = "video-object-general-seg-v1 video-object-alpha-quality-v1",
+	videoObjectBachCapabilities = VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.join(
+		" "
+	),
+	videoObjectCoreMLCapabilities = "video-object-same-model-coreml-v1",
+	transitionUsage = "transition-video|effect-video",
 }: {
-  personCutoutCapabilities?: string;
-  saliencyCapabilities?: string;
-  videoObjectBachCapabilities?: string;
-  videoObjectCoreMLCapabilities?: string;
-  transitionUsage?: string;
+	personCutoutCapabilities?: string;
+	saliencyCapabilities?: string;
+	videoObjectBachCapabilities?: string;
+	videoObjectCoreMLCapabilities?: string;
+	transitionUsage?: string;
 } = {}) {
-  const projectRoot = await mkdtemp(
-    path.join(tmpdir(), "qcut-packaged-runtime-bridges-"),
-  );
-  temporaryDirectories.push(projectRoot);
-  const distRoot = path.join(projectRoot, "dist-electron");
-  const stagedRoot = path.join(projectRoot, "electron", "resources", "bin");
-  const packagedRoot = path.join(
-    distRoot,
-    "mac-arm64",
-    "QCut AI Video Editor.app",
-    "Contents",
-    "Resources",
-    "bin",
-  );
-  const bridges = [
-    {
-      name: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
-      contents: `#!/bin/sh\necho '${transitionUsage}' >&2\nexit 2\n`,
-    },
-    {
-      name: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
-      contents: "#!/bin/sh\nexit 0\n",
-    },
-    {
-      name: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
-      contents: "#!/bin/sh\nexit 0\n",
-    },
-    {
-      name: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
-      contents: "#!/bin/sh\n# HTSGLContext\nexit 0\n",
-    },
-    {
-      name: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
-      contents: `#!/bin/sh\n# ${personCutoutCapabilities}\nexit 0\n`,
-    },
-    {
-      name: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
-      contents: `#!/bin/sh\n# ${saliencyCapabilities}\nexit 0\n`,
-    },
-    {
-      name: VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
-      contents: `#!/bin/sh\n# ${videoObjectBachCapabilities}\nexit 0\n`,
-    },
-    {
-      name: VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
-      contents: `#!/bin/sh\n# ${videoObjectCoreMLCapabilities}\nexit 0\n`,
-    },
-  ];
-  await Promise.all(
-    bridges.flatMap(({ name, contents }) => [
-      writeBridge({ filePath: path.join(stagedRoot, name), contents }),
-      writeBridge({ filePath: path.join(packagedRoot, name), contents }),
-    ]),
-  );
-  return { distRoot, projectRoot };
+	const projectRoot = await mkdtemp(
+		path.join(tmpdir(), "qcut-packaged-runtime-bridges-")
+	);
+	temporaryDirectories.push(projectRoot);
+	const distRoot = path.join(projectRoot, "dist-electron");
+	const stagedRoot = path.join(projectRoot, "electron", "resources", "bin");
+	const packagedRoot = path.join(
+		distRoot,
+		"mac-arm64",
+		"QCut AI Video Editor.app",
+		"Contents",
+		"Resources",
+		"bin"
+	);
+	const bridges = [
+		{
+			name: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
+			contents: `#!/bin/sh\necho '${transitionUsage}' >&2\nexit 2\n`,
+		},
+		{
+			name: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
+			contents: "#!/bin/sh\nexit 0\n",
+		},
+		{
+			name: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
+			contents: "#!/bin/sh\nexit 0\n",
+		},
+		{
+			name: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
+			contents: "#!/bin/sh\n# HTSGLContext\nexit 0\n",
+		},
+		{
+			name: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+			contents: `#!/bin/sh\n# ${personCutoutCapabilities}\nexit 0\n`,
+		},
+		{
+			name: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+			contents: `#!/bin/sh\n# ${saliencyCapabilities}\nexit 0\n`,
+		},
+		{
+			name: VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+			contents: `#!/bin/sh\n# ${videoObjectBachCapabilities}\nexit 0\n`,
+		},
+		{
+			name: VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+			contents: `#!/bin/sh\n# ${videoObjectCoreMLCapabilities}\nexit 0\n`,
+		},
+	];
+	await Promise.all(
+		bridges.flatMap(({ name, contents }) => [
+			writeBridge({ filePath: path.join(stagedRoot, name), contents }),
+			writeBridge({ filePath: path.join(packagedRoot, name), contents }),
+		])
+	);
+	return { distRoot, projectRoot };
 }
 
 afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { recursive: true, force: true })),
-  );
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { recursive: true, force: true }))
+	);
 });
 
 describe("packaged Jianying runtime bridge verification", () => {
-  it("accepts all bridges when the transition bridge supports effects", async () => {
-    const fixture = await createFixture();
-    await expect(
-      verifyPackagedJianyingRuntimeBridges(fixture),
-    ).resolves.toMatchObject({
-      transitionBridge: expect.stringContaining(
-        JIANYING_TRANSITION_BRIDGE_FILE_NAME,
-      ),
-      textBridge: expect.stringContaining(
-        JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
-      ),
-      filterBridge: expect.stringContaining(
-        JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
-      ),
-      portraitAdjustmentHost: expect.stringContaining(
-        JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
-      ),
-      personCutoutBridge: expect.stringContaining(
-        JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
-      ),
-      saliencyBridge: expect.stringContaining(
-        JIANYING_SALIENCY_BRIDGE_FILE_NAME,
-      ),
-      videoObjectBachBridge: expect.stringContaining(
-        VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
-      ),
-      videoObjectCoreMLBridge: expect.stringContaining(
-        VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
-      ),
-    });
-  });
+	it("accepts all bridges when the transition bridge supports effects", async () => {
+		const fixture = await createFixture();
+		await expect(
+			verifyPackagedJianyingRuntimeBridges(fixture)
+		).resolves.toMatchObject({
+			transitionBridge: expect.stringContaining(
+				JIANYING_TRANSITION_BRIDGE_FILE_NAME
+			),
+			textBridge: expect.stringContaining(
+				JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME
+			),
+			filterBridge: expect.stringContaining(
+				JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME
+			),
+			portraitAdjustmentHost: expect.stringContaining(
+				JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME
+			),
+			personCutoutBridge: expect.stringContaining(
+				JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME
+			),
+			saliencyBridge: expect.stringContaining(
+				JIANYING_SALIENCY_BRIDGE_FILE_NAME
+			),
+			videoObjectBachBridge: expect.stringContaining(
+				VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME
+			),
+			videoObjectCoreMLBridge: expect.stringContaining(
+				VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME
+			),
+		});
+	});
 
-  it("rejects a transition bridge built before effect rendering existed", async () => {
-    const fixture = await createFixture({
-      transitionUsage: "transition-video|text-frame",
-    });
-    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
-      "required mode: effect-video",
-    );
-  });
+	it("rejects a transition bridge built before effect rendering existed", async () => {
+		const fixture = await createFixture({
+			transitionUsage: "transition-video|text-frame",
+		});
+		await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+			"required mode: effect-video"
+		);
+	});
 
-  it("rejects a video-object bridge without the Alpha quality gate", async () => {
-    const fixture = await createFixture({
-      saliencyCapabilities: "video-object-general-seg-v1",
-    });
-    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
-      "video-object Alpha quality gate",
-    );
-  });
+	it("rejects a video-object bridge without the Alpha quality gate", async () => {
+		const fixture = await createFixture({
+			saliencyCapabilities: "video-object-general-seg-v1",
+		});
+		await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+			"video-object Alpha quality gate"
+		);
+	});
 
-  it("rejects a stale same-model CoreML bridge", async () => {
-    const fixture = await createFixture({
-      videoObjectCoreMLCapabilities: "video-object-alpha-quality-v1",
-    });
-    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
-      "same-model CoreML bridge is stale",
-    );
-  });
+	it("rejects a stale same-model CoreML bridge", async () => {
+		const fixture = await createFixture({
+			videoObjectCoreMLCapabilities: "video-object-alpha-quality-v1",
+		});
+		await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+			"same-model CoreML bridge is stale"
+		);
+	});
 
-  it("rejects a Bach bridge without every audited runtime pin", async () => {
-    const fixture = await createFixture({
-      videoObjectBachCapabilities:
-        "video-object-jianying-bach-v2-exact-d634-v1 TEMattingBlendEffectV2-vendor-exact D6342ECD-5432-33F0-A2AD-0C28F5699994",
-    });
-    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
-      "missing audited capability",
-    );
-  });
+	it("rejects a Bach bridge without every audited runtime pin", async () => {
+		const fixture = await createFixture({
+			videoObjectBachCapabilities:
+				"video-object-jianying-bach-v2-exact-d634-v1 TEMattingBlendEffectV2-vendor-exact D6342ECD-5432-33F0-A2AD-0C28F5699994",
+		});
+		await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+			"missing audited capability"
+		);
+	});
 
-  it("rejects a Bach bridge without the pinned dependency closure", async () => {
-    const fixture = await createFixture({
-      videoObjectBachCapabilities:
-        VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.filter(
-          (marker) => !marker.startsWith("jianying-runtime-framework-closure-"),
-        ).join(" "),
-    });
-    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
-      "missing audited capability",
-    );
-  });
+	it("rejects a Bach bridge without the pinned dependency closure", async () => {
+		const fixture = await createFixture({
+			videoObjectBachCapabilities:
+				VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS.filter(
+					(marker) => !marker.startsWith("jianying-runtime-framework-closure-")
+				).join(" "),
+		});
+		await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+			"missing audited capability"
+		);
+	});
 
-  it("rejects a person bridge that still claims full native Metal blending", async () => {
-    const fixture = await createFixture({
-      personCutoutCapabilities:
-        "TEMattingBlendEffectV2-native-metal Vision-person-fusion-v1",
-    });
-    await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
-      "native Metal canary validation",
-    );
-  });
+	it("rejects a person bridge that still claims full native Metal blending", async () => {
+		const fixture = await createFixture({
+			personCutoutCapabilities:
+				"TEMattingBlendEffectV2-native-metal Vision-person-fusion-v1",
+		});
+		await expect(verifyPackagedJianyingRuntimeBridges(fixture)).rejects.toThrow(
+			"native Metal canary validation"
+		);
+	});
 });

--- a/qcut/scripts/release.ts
+++ b/qcut/scripts/release.ts
@@ -385,12 +385,15 @@ function buildWebApp(): void {
 	}
 }
 
-function getDistCommand(): string {
+export function getReleaseDistributionCommand({
+	platform,
+}: {
+	platform: NodeJS.Platform;
+}): string {
+	if (platform === "darwin") return "bun run dist:mac";
 	const stageCmd =
 		"bun run stage-ffmpeg-binaries && bun run stage-aicp-binaries";
-	switch (process.platform) {
-		case "darwin":
-			return `${stageCmd} && npx electron-builder --mac --publish never`;
+	switch (platform) {
 		case "linux":
 			return `${stageCmd} && npx electron-builder --linux --publish never`;
 		case "win32":
@@ -414,19 +417,23 @@ function getInstallerPattern(): RegExp {
 }
 
 function buildElectronApp(): void {
-	try {
-		execSync("bun run compile-afterpack", { stdio: "inherit" });
-	} catch {
-		process.stdout.write("⚠️  afterPack compilation skipped (non-fatal)\n");
+	const macDistributionOwnsPackagingChecks = process.platform === "darwin";
+	if (!macDistributionOwnsPackagingChecks) {
+		try {
+			execSync("bun run compile-afterpack", { stdio: "inherit" });
+		} catch {
+			process.stdout.write("⚠️  afterPack compilation skipped (non-fatal)\n");
+		}
 	}
 
-	const cmd = getDistCommand();
+	const cmd = getReleaseDistributionCommand({ platform: process.platform });
 	try {
 		execSync(cmd, { stdio: "inherit" });
 		process.stdout.write("✅ Electron application built successfully\n");
 	} catch (error: any) {
 		throw new Error("Failed to build Electron application");
 	}
+	if (macDistributionOwnsPackagingChecks) return;
 
 	try {
 		execSync("bun run verify:packaged-ffmpeg", { stdio: "inherit" });
@@ -633,7 +640,7 @@ function getPreviousVersion(): string {
 	}
 }
 
-main();
+if (import.meta.main) main();
 
 export { main, bumpVersion, generateChecksums, parseVersion };
 export type { ReleaseType, PackageJson, ParsedVersion, PrereleaseChannel };

--- a/qcut/scripts/sign-mac.mjs
+++ b/qcut/scripts/sign-mac.mjs
@@ -1,0 +1,41 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { signAsync } from "@electron/osx-sign";
+
+const transitionEntitlements = fileURLToPath(
+	new URL("../build/entitlements.transition-bridge.mac.plist", import.meta.url)
+);
+
+/**
+ * @param {{ options: import('@electron/osx-sign').SignOptions }} input
+ * @returns {import('@electron/osx-sign').SignOptions}
+ */
+export function withTransitionBridgeEntitlements({ options }) {
+	const bridgePaths = new Set(
+		[
+			"jianying-transition-bridge",
+			"jianying-person-cutout-bridge",
+			"jianying-saliency-script-bridge",
+		].map(
+			(fileName) =>
+				path.resolve(options.app, "Contents/Resources/bin", fileName)
+		)
+	);
+	return {
+		...options,
+		optionsForFile: (filePath) => {
+			const original = options.optionsForFile?.(filePath) ?? {};
+			if (!bridgePaths.has(path.resolve(filePath))) return original;
+			return {
+				...original,
+				entitlements: transitionEntitlements,
+				hardenedRuntime: true,
+			};
+		},
+	};
+}
+
+/** @param {import('@electron/osx-sign').SignOptions} options */
+export async function sign({ ...options }) {
+	await signAsync(withTransitionBridgeEntitlements({ options }));
+}

--- a/qcut/scripts/sign-mac.mjs
+++ b/qcut/scripts/sign-mac.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { signAsync } from "@electron/osx-sign";
 
 const transitionEntitlements = fileURLToPath(
-	new URL("../build/entitlements.transition-bridge.mac.plist", import.meta.url)
+  new URL("../build/entitlements.transition-bridge.mac.plist", import.meta.url),
 );
 
 /**
@@ -11,31 +11,31 @@ const transitionEntitlements = fileURLToPath(
  * @returns {import('@electron/osx-sign').SignOptions}
  */
 export function withTransitionBridgeEntitlements({ options }) {
-	const bridgePaths = new Set(
-		[
-			"jianying-transition-bridge",
-			"jianying-person-cutout-bridge",
-			"jianying-saliency-script-bridge",
-		].map(
-			(fileName) =>
-				path.resolve(options.app, "Contents/Resources/bin", fileName)
-		)
-	);
-	return {
-		...options,
-		optionsForFile: (filePath) => {
-			const original = options.optionsForFile?.(filePath) ?? {};
-			if (!bridgePaths.has(path.resolve(filePath))) return original;
-			return {
-				...original,
-				entitlements: transitionEntitlements,
-				hardenedRuntime: true,
-			};
-		},
-	};
+  const bridgePaths = new Set(
+    [
+      "jianying-transition-bridge",
+      "jianying-person-cutout-bridge",
+      "jianying-saliency-script-bridge",
+      "jianying-video-object-bach-bridge",
+    ].map((fileName) =>
+      path.resolve(options.app, "Contents/Resources/bin", fileName),
+    ),
+  );
+  return {
+    ...options,
+    optionsForFile: (filePath) => {
+      const original = options.optionsForFile?.(filePath) ?? {};
+      if (!bridgePaths.has(path.resolve(filePath))) return original;
+      return {
+        ...original,
+        entitlements: transitionEntitlements,
+        hardenedRuntime: true,
+      };
+    },
+  };
 }
 
 /** @param {import('@electron/osx-sign').SignOptions} options */
 export async function sign({ ...options }) {
-	await signAsync(withTransitionBridgeEntitlements({ options }));
+  await signAsync(withTransitionBridgeEntitlements({ options }));
 }

--- a/qcut/scripts/sign-mac.mjs
+++ b/qcut/scripts/sign-mac.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { signAsync } from "@electron/osx-sign";
 
 const transitionEntitlements = fileURLToPath(
-  new URL("../build/entitlements.transition-bridge.mac.plist", import.meta.url),
+	new URL("../build/entitlements.transition-bridge.mac.plist", import.meta.url)
 );
 
 /**
@@ -11,31 +11,31 @@ const transitionEntitlements = fileURLToPath(
  * @returns {import('@electron/osx-sign').SignOptions}
  */
 export function withTransitionBridgeEntitlements({ options }) {
-  const bridgePaths = new Set(
-    [
-      "jianying-transition-bridge",
-      "jianying-person-cutout-bridge",
-      "jianying-saliency-script-bridge",
-      "jianying-video-object-bach-bridge",
-    ].map((fileName) =>
-      path.resolve(options.app, "Contents/Resources/bin", fileName),
-    ),
-  );
-  return {
-    ...options,
-    optionsForFile: (filePath) => {
-      const original = options.optionsForFile?.(filePath) ?? {};
-      if (!bridgePaths.has(path.resolve(filePath))) return original;
-      return {
-        ...original,
-        entitlements: transitionEntitlements,
-        hardenedRuntime: true,
-      };
-    },
-  };
+	const bridgePaths = new Set(
+		[
+			"jianying-transition-bridge",
+			"jianying-person-cutout-bridge",
+			"jianying-saliency-script-bridge",
+			"jianying-video-object-bach-bridge",
+		].map((fileName) =>
+			path.resolve(options.app, "Contents/Resources/bin", fileName)
+		)
+	);
+	return {
+		...options,
+		optionsForFile: (filePath) => {
+			const original = options.optionsForFile?.(filePath) ?? {};
+			if (!bridgePaths.has(path.resolve(filePath))) return original;
+			return {
+				...original,
+				entitlements: transitionEntitlements,
+				hardenedRuntime: true,
+			};
+		},
+	};
 }
 
 /** @param {import('@electron/osx-sign').SignOptions} options */
 export async function sign({ ...options }) {
-  await signAsync(withTransitionBridgeEntitlements({ options }));
+	await signAsync(withTransitionBridgeEntitlements({ options }));
 }

--- a/qcut/scripts/stage-jianying-filter-local-bridge.ts
+++ b/qcut/scripts/stage-jianying-filter-local-bridge.ts
@@ -1,120 +1,120 @@
 import path from "node:path";
 import { rm } from "node:fs/promises";
 import {
-  compileJianyingFilterLocalBridge,
-  JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
+	compileJianyingFilterLocalBridge,
+	JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
 } from "../electron/jianying-filter-local-runtime/bridge-resolver.js";
 import {
-  compileJianyingPortraitAdjustmentHost,
-  JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
+	compileJianyingPortraitAdjustmentHost,
+	JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
 } from "../electron/jianying-portrait-adjustment-runtime/bridge-resolver.js";
 import {
-  compileJianyingPersonCutoutBridge,
-  JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+	compileJianyingPersonCutoutBridge,
+	JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
 } from "../electron/jianying-person-cutout/bridge-resolver.js";
 import {
-  compileJianyingSaliencyBridge,
-  JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+	compileJianyingSaliencyBridge,
+	JIANYING_SALIENCY_BRIDGE_FILE_NAME,
 } from "../electron/jianying-person-cutout/saliency-bridge-resolver.js";
 import {
-  compileVideoObjectBachBridge,
-  VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+	compileVideoObjectBachBridge,
+	VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
 } from "../electron/jianying-person-cutout/video-object-bach-bridge-resolver.js";
 import {
-  compileVideoObjectCoreMLBridge,
-  VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+	compileVideoObjectCoreMLBridge,
+	VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
 } from "../electron/jianying-person-cutout/video-object-coreml-bridge-resolver.js";
 
 if (process.platform !== "darwin") {
-  console.log("Skipping Jianying filter local bridge: macOS only.");
-  process.exit(0);
+	console.log("Skipping Jianying filter local bridge: macOS only.");
+	process.exit(0);
 }
 
 const projectRoot = path.resolve(import.meta.dir, "..");
 const filterOutputPath = path.join(
-  projectRoot,
-  "electron",
-  "resources",
-  "bin",
-  JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
+	projectRoot,
+	"electron",
+	"resources",
+	"bin",
+	JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME
 );
 const portraitOutputPath = path.join(
-  projectRoot,
-  "electron",
-  "resources",
-  "bin",
-  JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
+	projectRoot,
+	"electron",
+	"resources",
+	"bin",
+	JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME
 );
 const personCutoutOutputPath = path.join(
-  projectRoot,
-  "electron",
-  "resources",
-  "bin",
-  JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+	projectRoot,
+	"electron",
+	"resources",
+	"bin",
+	JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME
 );
 const saliencyOutputPath = path.join(
-  projectRoot,
-  "electron",
-  "resources",
-  "bin",
-  JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+	projectRoot,
+	"electron",
+	"resources",
+	"bin",
+	JIANYING_SALIENCY_BRIDGE_FILE_NAME
 );
 const videoObjectCoreMLOutputPath = path.join(
-  projectRoot,
-  "electron",
-  "resources",
-  "bin",
-  VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+	projectRoot,
+	"electron",
+	"resources",
+	"bin",
+	VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME
 );
 const videoObjectBachOutputPath = path.join(
-  projectRoot,
-  "electron",
-  "resources",
-  "bin",
-  VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+	projectRoot,
+	"electron",
+	"resources",
+	"bin",
+	VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME
 );
 
 await Promise.all([
-  rm(filterOutputPath, { force: true }),
-  rm(portraitOutputPath, { force: true }),
-  rm(personCutoutOutputPath, { force: true }),
-  rm(saliencyOutputPath, { force: true }),
-  rm(videoObjectCoreMLOutputPath, { force: true }),
-  rm(videoObjectBachOutputPath, { force: true }),
+	rm(filterOutputPath, { force: true }),
+	rm(portraitOutputPath, { force: true }),
+	rm(personCutoutOutputPath, { force: true }),
+	rm(saliencyOutputPath, { force: true }),
+	rm(videoObjectCoreMLOutputPath, { force: true }),
+	rm(videoObjectBachOutputPath, { force: true }),
 ]);
 await Promise.all([
-  compileJianyingFilterLocalBridge({
-    projectRoot,
-    outputPath: filterOutputPath,
-  }),
-  compileJianyingPortraitAdjustmentHost({
-    projectRoot,
-    outputPath: portraitOutputPath,
-  }),
-  compileJianyingPersonCutoutBridge({
-    projectRoot,
-    outputPath: personCutoutOutputPath,
-  }),
-  compileJianyingSaliencyBridge({
-    projectRoot,
-    outputPath: saliencyOutputPath,
-  }),
-  compileVideoObjectCoreMLBridge({
-    projectRoot,
-    outputPath: videoObjectCoreMLOutputPath,
-  }),
-  compileVideoObjectBachBridge({
-    projectRoot,
-    outputPath: videoObjectBachOutputPath,
-  }),
+	compileJianyingFilterLocalBridge({
+		projectRoot,
+		outputPath: filterOutputPath,
+	}),
+	compileJianyingPortraitAdjustmentHost({
+		projectRoot,
+		outputPath: portraitOutputPath,
+	}),
+	compileJianyingPersonCutoutBridge({
+		projectRoot,
+		outputPath: personCutoutOutputPath,
+	}),
+	compileJianyingSaliencyBridge({
+		projectRoot,
+		outputPath: saliencyOutputPath,
+	}),
+	compileVideoObjectCoreMLBridge({
+		projectRoot,
+		outputPath: videoObjectCoreMLOutputPath,
+	}),
+	compileVideoObjectBachBridge({
+		projectRoot,
+		outputPath: videoObjectBachOutputPath,
+	}),
 ]);
 console.log(`Staged Jianying filter local bridge: ${filterOutputPath}`);
 console.log(`Staged Jianying portrait adjustment host: ${portraitOutputPath}`);
 console.log(`Staged Jianying person cutout bridge: ${personCutoutOutputPath}`);
 console.log(`Staged Jianying saliency bridge: ${saliencyOutputPath}`);
 console.log(
-  `Staged Jianying video-object CoreML bridge: ${videoObjectCoreMLOutputPath}`,
+	`Staged Jianying video-object CoreML bridge: ${videoObjectCoreMLOutputPath}`
 );
 console.log(
-  `Staged Jianying video-object Bach bridge: ${videoObjectBachOutputPath}`,
+	`Staged Jianying video-object Bach bridge: ${videoObjectBachOutputPath}`
 );

--- a/qcut/scripts/stage-jianying-filter-local-bridge.ts
+++ b/qcut/scripts/stage-jianying-filter-local-bridge.ts
@@ -1,82 +1,120 @@
 import path from "node:path";
 import { rm } from "node:fs/promises";
 import {
-	compileJianyingFilterLocalBridge,
-	JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
+  compileJianyingFilterLocalBridge,
+  JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
 } from "../electron/jianying-filter-local-runtime/bridge-resolver.js";
 import {
-	compileJianyingPortraitAdjustmentHost,
-	JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
+  compileJianyingPortraitAdjustmentHost,
+  JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
 } from "../electron/jianying-portrait-adjustment-runtime/bridge-resolver.js";
 import {
-	compileJianyingPersonCutoutBridge,
-	JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+  compileJianyingPersonCutoutBridge,
+  JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
 } from "../electron/jianying-person-cutout/bridge-resolver.js";
 import {
-	compileJianyingSaliencyBridge,
-	JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+  compileJianyingSaliencyBridge,
+  JIANYING_SALIENCY_BRIDGE_FILE_NAME,
 } from "../electron/jianying-person-cutout/saliency-bridge-resolver.js";
+import {
+  compileVideoObjectBachBridge,
+  VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+} from "../electron/jianying-person-cutout/video-object-bach-bridge-resolver.js";
+import {
+  compileVideoObjectCoreMLBridge,
+  VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+} from "../electron/jianying-person-cutout/video-object-coreml-bridge-resolver.js";
 
 if (process.platform !== "darwin") {
-	console.log("Skipping Jianying filter local bridge: macOS only.");
-	process.exit(0);
+  console.log("Skipping Jianying filter local bridge: macOS only.");
+  process.exit(0);
 }
 
 const projectRoot = path.resolve(import.meta.dir, "..");
 const filterOutputPath = path.join(
-	projectRoot,
-	"electron",
-	"resources",
-	"bin",
-	JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME
+  projectRoot,
+  "electron",
+  "resources",
+  "bin",
+  JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
 );
 const portraitOutputPath = path.join(
-	projectRoot,
-	"electron",
-	"resources",
-	"bin",
-	JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME
+  projectRoot,
+  "electron",
+  "resources",
+  "bin",
+  JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
 );
 const personCutoutOutputPath = path.join(
-	projectRoot,
-	"electron",
-	"resources",
-	"bin",
-	JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME
+  projectRoot,
+  "electron",
+  "resources",
+  "bin",
+  JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
 );
 const saliencyOutputPath = path.join(
-	projectRoot,
-	"electron",
-	"resources",
-	"bin",
-	JIANYING_SALIENCY_BRIDGE_FILE_NAME
+  projectRoot,
+  "electron",
+  "resources",
+  "bin",
+  JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+);
+const videoObjectCoreMLOutputPath = path.join(
+  projectRoot,
+  "electron",
+  "resources",
+  "bin",
+  VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+);
+const videoObjectBachOutputPath = path.join(
+  projectRoot,
+  "electron",
+  "resources",
+  "bin",
+  VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
 );
 
 await Promise.all([
-	rm(filterOutputPath, { force: true }),
-	rm(portraitOutputPath, { force: true }),
-	rm(personCutoutOutputPath, { force: true }),
-	rm(saliencyOutputPath, { force: true }),
+  rm(filterOutputPath, { force: true }),
+  rm(portraitOutputPath, { force: true }),
+  rm(personCutoutOutputPath, { force: true }),
+  rm(saliencyOutputPath, { force: true }),
+  rm(videoObjectCoreMLOutputPath, { force: true }),
+  rm(videoObjectBachOutputPath, { force: true }),
 ]);
 await Promise.all([
-	compileJianyingFilterLocalBridge({
-		projectRoot,
-		outputPath: filterOutputPath,
-	}),
-	compileJianyingPortraitAdjustmentHost({
-		projectRoot,
-		outputPath: portraitOutputPath,
-	}),
-	compileJianyingPersonCutoutBridge({
-		projectRoot,
-		outputPath: personCutoutOutputPath,
-	}),
-	compileJianyingSaliencyBridge({
-		projectRoot,
-		outputPath: saliencyOutputPath,
-	}),
+  compileJianyingFilterLocalBridge({
+    projectRoot,
+    outputPath: filterOutputPath,
+  }),
+  compileJianyingPortraitAdjustmentHost({
+    projectRoot,
+    outputPath: portraitOutputPath,
+  }),
+  compileJianyingPersonCutoutBridge({
+    projectRoot,
+    outputPath: personCutoutOutputPath,
+  }),
+  compileJianyingSaliencyBridge({
+    projectRoot,
+    outputPath: saliencyOutputPath,
+  }),
+  compileVideoObjectCoreMLBridge({
+    projectRoot,
+    outputPath: videoObjectCoreMLOutputPath,
+  }),
+  compileVideoObjectBachBridge({
+    projectRoot,
+    outputPath: videoObjectBachOutputPath,
+  }),
 ]);
 console.log(`Staged Jianying filter local bridge: ${filterOutputPath}`);
 console.log(`Staged Jianying portrait adjustment host: ${portraitOutputPath}`);
 console.log(`Staged Jianying person cutout bridge: ${personCutoutOutputPath}`);
 console.log(`Staged Jianying saliency bridge: ${saliencyOutputPath}`);
+console.log(
+  `Staged Jianying video-object CoreML bridge: ${videoObjectCoreMLOutputPath}`,
+);
+console.log(
+  `Staged Jianying video-object Bach bridge: ${videoObjectBachOutputPath}`,
+);

--- a/qcut/scripts/stage-jianying-filter-local-bridge.ts
+++ b/qcut/scripts/stage-jianying-filter-local-bridge.ts
@@ -8,6 +8,14 @@ import {
 	compileJianyingPortraitAdjustmentHost,
 	JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
 } from "../electron/jianying-portrait-adjustment-runtime/bridge-resolver.js";
+import {
+	compileJianyingPersonCutoutBridge,
+	JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+} from "../electron/jianying-person-cutout/bridge-resolver.js";
+import {
+	compileJianyingSaliencyBridge,
+	JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+} from "../electron/jianying-person-cutout/saliency-bridge-resolver.js";
 
 if (process.platform !== "darwin") {
 	console.log("Skipping Jianying filter local bridge: macOS only.");
@@ -29,10 +37,26 @@ const portraitOutputPath = path.join(
 	"bin",
 	JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME
 );
+const personCutoutOutputPath = path.join(
+	projectRoot,
+	"electron",
+	"resources",
+	"bin",
+	JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME
+);
+const saliencyOutputPath = path.join(
+	projectRoot,
+	"electron",
+	"resources",
+	"bin",
+	JIANYING_SALIENCY_BRIDGE_FILE_NAME
+);
 
 await Promise.all([
 	rm(filterOutputPath, { force: true }),
 	rm(portraitOutputPath, { force: true }),
+	rm(personCutoutOutputPath, { force: true }),
+	rm(saliencyOutputPath, { force: true }),
 ]);
 await Promise.all([
 	compileJianyingFilterLocalBridge({
@@ -43,6 +67,16 @@ await Promise.all([
 		projectRoot,
 		outputPath: portraitOutputPath,
 	}),
+	compileJianyingPersonCutoutBridge({
+		projectRoot,
+		outputPath: personCutoutOutputPath,
+	}),
+	compileJianyingSaliencyBridge({
+		projectRoot,
+		outputPath: saliencyOutputPath,
+	}),
 ]);
 console.log(`Staged Jianying filter local bridge: ${filterOutputPath}`);
 console.log(`Staged Jianying portrait adjustment host: ${portraitOutputPath}`);
+console.log(`Staged Jianying person cutout bridge: ${personCutoutOutputPath}`);
+console.log(`Staged Jianying saliency bridge: ${saliencyOutputPath}`);

--- a/qcut/scripts/verify-packaged-jianying-runtime-bridge.ts
+++ b/qcut/scripts/verify-packaged-jianying-runtime-bridge.ts
@@ -6,178 +6,191 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const MACH_O_MAGICS = new Set([
-	0xfeedface, 0xfeedfacf, 0xcefaedfe, 0xcffaedfe, 0xcafebabe, 0xcafebabf,
-	0xbebafeca, 0xbfbafeca,
+  0xfeedface, 0xfeedfacf, 0xcefaedfe, 0xcffaedfe, 0xcafebabe, 0xcafebabf,
+  0xbebafeca, 0xbfbafeca,
 ]);
 const DYLD_RUNTIME_BRIDGES = new Set([
-	"jianying-person-cutout-bridge",
-	"jianying-saliency-script-bridge",
-	"jianying-transition-bridge",
+  "jianying-person-cutout-bridge",
+  "jianying-saliency-script-bridge",
+  "jianying-transition-bridge",
+  "jianying-video-object-bach-bridge",
 ]);
 
-async function newestPackagedBridge({
-	distRoot,
-	bridgeFileName,
+export function requiresDyldRuntimeEntitlements({
+  bridgeFileName,
 }: {
-	distRoot: string;
-	bridgeFileName: string;
+  bridgeFileName: string;
 }) {
-	const entries = await readdir(distRoot, { recursive: true }).catch(() => []);
-	const suffix = path.join("Contents", "Resources", "bin", bridgeFileName);
-	const candidates = entries
-		.filter((entry) => entry.endsWith(suffix))
-		.map((entry) => path.join(distRoot, entry));
-	if (candidates.length === 0) {
-		throw new Error(
-			`Packaged Jianying runtime bridge not found under ${distRoot}: ${bridgeFileName}`
-		);
-	}
-	const metadata = await Promise.all(
-		candidates.map(async (filePath) => ({
-			filePath,
-			modifiedAt: (await stat(filePath)).mtimeMs,
-		}))
-	);
-	return metadata.sort((left, right) => right.modifiedAt - left.modifiedAt)[0]
-		.filePath;
+  return DYLD_RUNTIME_BRIDGES.has(bridgeFileName);
+}
+
+async function newestPackagedBridge({
+  distRoot,
+  bridgeFileName,
+}: {
+  distRoot: string;
+  bridgeFileName: string;
+}) {
+  const entries = await readdir(distRoot, { recursive: true }).catch(() => []);
+  const suffix = path.join("Contents", "Resources", "bin", bridgeFileName);
+  const candidates = entries
+    .filter((entry) => entry.endsWith(suffix))
+    .map((entry) => path.join(distRoot, entry));
+  if (candidates.length === 0) {
+    throw new Error(
+      `Packaged Jianying runtime bridge not found under ${distRoot}: ${bridgeFileName}`,
+    );
+  }
+  const metadata = await Promise.all(
+    candidates.map(async (filePath) => ({
+      filePath,
+      modifiedAt: (await stat(filePath)).mtimeMs,
+    })),
+  );
+  return metadata.sort((left, right) => right.modifiedAt - left.modifiedAt)[0]
+    .filePath;
 }
 
 async function requireExecutable({ filePath }: { filePath: string }) {
-	try {
-		await access(filePath, constants.X_OK);
-	} catch {
-		throw new Error(`Jianying runtime bridge is not executable: ${filePath}`);
-	}
+  try {
+    await access(filePath, constants.X_OK);
+  } catch {
+    throw new Error(`Jianying runtime bridge is not executable: ${filePath}`);
+  }
 }
 
 function isMachO({ contents }: { contents: Buffer }) {
-	return contents.length >= 4 && MACH_O_MAGICS.has(contents.readUInt32BE(0));
+  return contents.length >= 4 && MACH_O_MAGICS.has(contents.readUInt32BE(0));
 }
 
 export function parseMachOUuidOutput({ output }: { output: string }) {
-	return output
-		.split(/\r?\n/)
-		.flatMap((line) => {
-			const match = line.match(/UUID:\s+([0-9A-F-]+)\s+\(([^)]+)\)/i);
-			return match ? [`${match[2]}:${match[1].toUpperCase()}`] : [];
-		})
-		.sort();
+  return output
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      const match = line.match(/UUID:\s+([0-9A-F-]+)\s+\(([^)]+)\)/i);
+      return match ? [`${match[2]}:${match[1].toUpperCase()}`] : [];
+    })
+    .sort();
 }
 
 async function machOUuids({ filePath }: { filePath: string }) {
-	const { stdout } = await execFileAsync("dwarfdump", ["--uuid", filePath]);
-	const identities = parseMachOUuidOutput({ output: stdout });
-	if (identities.length === 0) {
-		throw new Error(`Mach-O UUID not found: ${filePath}`);
-	}
-	return identities;
+  const { stdout } = await execFileAsync("dwarfdump", ["--uuid", filePath]);
+  const identities = parseMachOUuidOutput({ output: stdout });
+  if (identities.length === 0) {
+    throw new Error(`Mach-O UUID not found: ${filePath}`);
+  }
+  return identities;
 }
 
 async function requireValidCodeSignature({ filePath }: { filePath: string }) {
-	try {
-		await execFileAsync("codesign", ["--verify", "--strict", filePath]);
-	} catch {
-		throw new Error(
-			`Packaged Jianying runtime bridge has an invalid signature: ${filePath}`
-		);
-	}
+  try {
+    await execFileAsync("codesign", ["--verify", "--strict", filePath]);
+  } catch {
+    throw new Error(
+      `Packaged Jianying runtime bridge has an invalid signature: ${filePath}`,
+    );
+  }
 }
 
 export async function requireTransitionBridgeEntitlements({
-	filePath,
+  filePath,
 }: {
-	filePath: string;
+  filePath: string;
 }) {
-	const { stdout } = await execFileAsync("/usr/bin/codesign", [
-		"--display",
-		"--entitlements",
-		"-",
-		"--xml",
-		filePath,
-	]);
-	const entitlements: Record<string, unknown> = JSON.parse(
-		execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", "-"], {
-			input: stdout,
-			encoding: "utf8",
-			timeout: 10_000,
-		})
-	);
-	for (const key of [
-		"com.apple.security.cs.allow-dyld-environment-variables",
-		"com.apple.security.cs.disable-library-validation",
-	]) {
-		if (entitlements[key] !== true) {
-			throw new Error(
-				`Packaged Jianying runtime bridge is missing required entitlement ${key}: ${filePath}`
-			);
-		}
-	}
+  const { stdout } = await execFileAsync("/usr/bin/codesign", [
+    "--display",
+    "--entitlements",
+    "-",
+    "--xml",
+    filePath,
+  ]);
+  const entitlements: Record<string, unknown> = JSON.parse(
+    execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", "-"], {
+      input: stdout,
+      encoding: "utf8",
+      timeout: 10_000,
+    }),
+  );
+  for (const key of [
+    "com.apple.security.cs.allow-dyld-environment-variables",
+    "com.apple.security.cs.disable-library-validation",
+  ]) {
+    if (entitlements[key] !== true) {
+      throw new Error(
+        `Packaged Jianying runtime bridge is missing required entitlement ${key}: ${filePath}`,
+      );
+    }
+  }
 }
 
 async function requireMatchingBridge({
-	packaged,
-	packagedPath,
-	staged,
-	stagedPath,
+  packaged,
+  packagedPath,
+  staged,
+  stagedPath,
 }: {
-	packaged: Buffer;
-	packagedPath: string;
-	staged: Buffer;
-	stagedPath: string;
+  packaged: Buffer;
+  packagedPath: string;
+  staged: Buffer;
+  stagedPath: string;
 }) {
-	const stagedIsMachO = isMachO({ contents: staged });
-	const packagedIsMachO = isMachO({ contents: packaged });
-	if (stagedIsMachO && packagedIsMachO) {
-		const [stagedUuids, packagedUuids] = await Promise.all([
-			machOUuids({ filePath: stagedPath }),
-			machOUuids({ filePath: packagedPath }),
-		]);
-		if (JSON.stringify(stagedUuids) !== JSON.stringify(packagedUuids)) {
-			throw new Error(
-				`Packaged Jianying runtime bridge differs from the staged binary: ${path.basename(packagedPath)}`
-			);
-		}
-		await requireValidCodeSignature({ filePath: packagedPath });
-		if (DYLD_RUNTIME_BRIDGES.has(path.basename(packagedPath))) {
-			await requireTransitionBridgeEntitlements({ filePath: packagedPath });
-		}
-		return;
-	}
-	if (stagedIsMachO !== packagedIsMachO || !staged.equals(packaged)) {
-		throw new Error(
-			`Packaged Jianying runtime bridge differs from the staged binary: ${path.basename(packagedPath)}`
-		);
-	}
+  const stagedIsMachO = isMachO({ contents: staged });
+  const packagedIsMachO = isMachO({ contents: packaged });
+  if (stagedIsMachO && packagedIsMachO) {
+    const [stagedUuids, packagedUuids] = await Promise.all([
+      machOUuids({ filePath: stagedPath }),
+      machOUuids({ filePath: packagedPath }),
+    ]);
+    if (JSON.stringify(stagedUuids) !== JSON.stringify(packagedUuids)) {
+      throw new Error(
+        `Packaged Jianying runtime bridge differs from the staged binary: ${path.basename(packagedPath)}`,
+      );
+    }
+    await requireValidCodeSignature({ filePath: packagedPath });
+    if (
+      requiresDyldRuntimeEntitlements({
+        bridgeFileName: path.basename(packagedPath),
+      })
+    ) {
+      await requireTransitionBridgeEntitlements({ filePath: packagedPath });
+    }
+    return;
+  }
+  if (stagedIsMachO !== packagedIsMachO || !staged.equals(packaged)) {
+    throw new Error(
+      `Packaged Jianying runtime bridge differs from the staged binary: ${path.basename(packagedPath)}`,
+    );
+  }
 }
 
 export async function verifyPackagedJianyingRuntimeBridge({
-	bridgeFileName,
-	distRoot,
-	projectRoot,
+  bridgeFileName,
+  distRoot,
+  projectRoot,
 }: {
-	bridgeFileName: string;
-	distRoot: string;
-	projectRoot: string;
+  bridgeFileName: string;
+  distRoot: string;
+  projectRoot: string;
 }) {
-	const stagedPath = path.join(
-		projectRoot,
-		"electron",
-		"resources",
-		"bin",
-		bridgeFileName
-	);
-	const packagedPath = await newestPackagedBridge({
-		distRoot,
-		bridgeFileName,
-	});
-	await Promise.all([
-		requireExecutable({ filePath: stagedPath }),
-		requireExecutable({ filePath: packagedPath }),
-	]);
-	const [staged, packaged] = await Promise.all([
-		readFile(stagedPath),
-		readFile(packagedPath),
-	]);
-	await requireMatchingBridge({ packaged, packagedPath, staged, stagedPath });
-	return packagedPath;
+  const stagedPath = path.join(
+    projectRoot,
+    "electron",
+    "resources",
+    "bin",
+    bridgeFileName,
+  );
+  const packagedPath = await newestPackagedBridge({
+    distRoot,
+    bridgeFileName,
+  });
+  await Promise.all([
+    requireExecutable({ filePath: stagedPath }),
+    requireExecutable({ filePath: packagedPath }),
+  ]);
+  const [staged, packaged] = await Promise.all([
+    readFile(stagedPath),
+    readFile(packagedPath),
+  ]);
+  await requireMatchingBridge({ packaged, packagedPath, staged, stagedPath });
+  return packagedPath;
 }

--- a/qcut/scripts/verify-packaged-jianying-runtime-bridge.ts
+++ b/qcut/scripts/verify-packaged-jianying-runtime-bridge.ts
@@ -6,191 +6,191 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const MACH_O_MAGICS = new Set([
-  0xfeedface, 0xfeedfacf, 0xcefaedfe, 0xcffaedfe, 0xcafebabe, 0xcafebabf,
-  0xbebafeca, 0xbfbafeca,
+	0xfeedface, 0xfeedfacf, 0xcefaedfe, 0xcffaedfe, 0xcafebabe, 0xcafebabf,
+	0xbebafeca, 0xbfbafeca,
 ]);
 const DYLD_RUNTIME_BRIDGES = new Set([
-  "jianying-person-cutout-bridge",
-  "jianying-saliency-script-bridge",
-  "jianying-transition-bridge",
-  "jianying-video-object-bach-bridge",
+	"jianying-person-cutout-bridge",
+	"jianying-saliency-script-bridge",
+	"jianying-transition-bridge",
+	"jianying-video-object-bach-bridge",
 ]);
 
 export function requiresDyldRuntimeEntitlements({
-  bridgeFileName,
+	bridgeFileName,
 }: {
-  bridgeFileName: string;
+	bridgeFileName: string;
 }) {
-  return DYLD_RUNTIME_BRIDGES.has(bridgeFileName);
+	return DYLD_RUNTIME_BRIDGES.has(bridgeFileName);
 }
 
 async function newestPackagedBridge({
-  distRoot,
-  bridgeFileName,
+	distRoot,
+	bridgeFileName,
 }: {
-  distRoot: string;
-  bridgeFileName: string;
+	distRoot: string;
+	bridgeFileName: string;
 }) {
-  const entries = await readdir(distRoot, { recursive: true }).catch(() => []);
-  const suffix = path.join("Contents", "Resources", "bin", bridgeFileName);
-  const candidates = entries
-    .filter((entry) => entry.endsWith(suffix))
-    .map((entry) => path.join(distRoot, entry));
-  if (candidates.length === 0) {
-    throw new Error(
-      `Packaged Jianying runtime bridge not found under ${distRoot}: ${bridgeFileName}`,
-    );
-  }
-  const metadata = await Promise.all(
-    candidates.map(async (filePath) => ({
-      filePath,
-      modifiedAt: (await stat(filePath)).mtimeMs,
-    })),
-  );
-  return metadata.sort((left, right) => right.modifiedAt - left.modifiedAt)[0]
-    .filePath;
+	const entries = await readdir(distRoot, { recursive: true }).catch(() => []);
+	const suffix = path.join("Contents", "Resources", "bin", bridgeFileName);
+	const candidates = entries
+		.filter((entry) => entry.endsWith(suffix))
+		.map((entry) => path.join(distRoot, entry));
+	if (candidates.length === 0) {
+		throw new Error(
+			`Packaged Jianying runtime bridge not found under ${distRoot}: ${bridgeFileName}`
+		);
+	}
+	const metadata = await Promise.all(
+		candidates.map(async (filePath) => ({
+			filePath,
+			modifiedAt: (await stat(filePath)).mtimeMs,
+		}))
+	);
+	return metadata.sort((left, right) => right.modifiedAt - left.modifiedAt)[0]
+		.filePath;
 }
 
 async function requireExecutable({ filePath }: { filePath: string }) {
-  try {
-    await access(filePath, constants.X_OK);
-  } catch {
-    throw new Error(`Jianying runtime bridge is not executable: ${filePath}`);
-  }
+	try {
+		await access(filePath, constants.X_OK);
+	} catch {
+		throw new Error(`Jianying runtime bridge is not executable: ${filePath}`);
+	}
 }
 
 function isMachO({ contents }: { contents: Buffer }) {
-  return contents.length >= 4 && MACH_O_MAGICS.has(contents.readUInt32BE(0));
+	return contents.length >= 4 && MACH_O_MAGICS.has(contents.readUInt32BE(0));
 }
 
 export function parseMachOUuidOutput({ output }: { output: string }) {
-  return output
-    .split(/\r?\n/)
-    .flatMap((line) => {
-      const match = line.match(/UUID:\s+([0-9A-F-]+)\s+\(([^)]+)\)/i);
-      return match ? [`${match[2]}:${match[1].toUpperCase()}`] : [];
-    })
-    .sort();
+	return output
+		.split(/\r?\n/)
+		.flatMap((line) => {
+			const match = line.match(/UUID:\s+([0-9A-F-]+)\s+\(([^)]+)\)/i);
+			return match ? [`${match[2]}:${match[1].toUpperCase()}`] : [];
+		})
+		.sort();
 }
 
 async function machOUuids({ filePath }: { filePath: string }) {
-  const { stdout } = await execFileAsync("dwarfdump", ["--uuid", filePath]);
-  const identities = parseMachOUuidOutput({ output: stdout });
-  if (identities.length === 0) {
-    throw new Error(`Mach-O UUID not found: ${filePath}`);
-  }
-  return identities;
+	const { stdout } = await execFileAsync("dwarfdump", ["--uuid", filePath]);
+	const identities = parseMachOUuidOutput({ output: stdout });
+	if (identities.length === 0) {
+		throw new Error(`Mach-O UUID not found: ${filePath}`);
+	}
+	return identities;
 }
 
 async function requireValidCodeSignature({ filePath }: { filePath: string }) {
-  try {
-    await execFileAsync("codesign", ["--verify", "--strict", filePath]);
-  } catch {
-    throw new Error(
-      `Packaged Jianying runtime bridge has an invalid signature: ${filePath}`,
-    );
-  }
+	try {
+		await execFileAsync("codesign", ["--verify", "--strict", filePath]);
+	} catch {
+		throw new Error(
+			`Packaged Jianying runtime bridge has an invalid signature: ${filePath}`
+		);
+	}
 }
 
 export async function requireTransitionBridgeEntitlements({
-  filePath,
+	filePath,
 }: {
-  filePath: string;
+	filePath: string;
 }) {
-  const { stdout } = await execFileAsync("/usr/bin/codesign", [
-    "--display",
-    "--entitlements",
-    "-",
-    "--xml",
-    filePath,
-  ]);
-  const entitlements: Record<string, unknown> = JSON.parse(
-    execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", "-"], {
-      input: stdout,
-      encoding: "utf8",
-      timeout: 10_000,
-    }),
-  );
-  for (const key of [
-    "com.apple.security.cs.allow-dyld-environment-variables",
-    "com.apple.security.cs.disable-library-validation",
-  ]) {
-    if (entitlements[key] !== true) {
-      throw new Error(
-        `Packaged Jianying runtime bridge is missing required entitlement ${key}: ${filePath}`,
-      );
-    }
-  }
+	const { stdout } = await execFileAsync("/usr/bin/codesign", [
+		"--display",
+		"--entitlements",
+		"-",
+		"--xml",
+		filePath,
+	]);
+	const entitlements: Record<string, unknown> = JSON.parse(
+		execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", "-"], {
+			input: stdout,
+			encoding: "utf8",
+			timeout: 10_000,
+		})
+	);
+	for (const key of [
+		"com.apple.security.cs.allow-dyld-environment-variables",
+		"com.apple.security.cs.disable-library-validation",
+	]) {
+		if (entitlements[key] !== true) {
+			throw new Error(
+				`Packaged Jianying runtime bridge is missing required entitlement ${key}: ${filePath}`
+			);
+		}
+	}
 }
 
 async function requireMatchingBridge({
-  packaged,
-  packagedPath,
-  staged,
-  stagedPath,
+	packaged,
+	packagedPath,
+	staged,
+	stagedPath,
 }: {
-  packaged: Buffer;
-  packagedPath: string;
-  staged: Buffer;
-  stagedPath: string;
+	packaged: Buffer;
+	packagedPath: string;
+	staged: Buffer;
+	stagedPath: string;
 }) {
-  const stagedIsMachO = isMachO({ contents: staged });
-  const packagedIsMachO = isMachO({ contents: packaged });
-  if (stagedIsMachO && packagedIsMachO) {
-    const [stagedUuids, packagedUuids] = await Promise.all([
-      machOUuids({ filePath: stagedPath }),
-      machOUuids({ filePath: packagedPath }),
-    ]);
-    if (JSON.stringify(stagedUuids) !== JSON.stringify(packagedUuids)) {
-      throw new Error(
-        `Packaged Jianying runtime bridge differs from the staged binary: ${path.basename(packagedPath)}`,
-      );
-    }
-    await requireValidCodeSignature({ filePath: packagedPath });
-    if (
-      requiresDyldRuntimeEntitlements({
-        bridgeFileName: path.basename(packagedPath),
-      })
-    ) {
-      await requireTransitionBridgeEntitlements({ filePath: packagedPath });
-    }
-    return;
-  }
-  if (stagedIsMachO !== packagedIsMachO || !staged.equals(packaged)) {
-    throw new Error(
-      `Packaged Jianying runtime bridge differs from the staged binary: ${path.basename(packagedPath)}`,
-    );
-  }
+	const stagedIsMachO = isMachO({ contents: staged });
+	const packagedIsMachO = isMachO({ contents: packaged });
+	if (stagedIsMachO && packagedIsMachO) {
+		const [stagedUuids, packagedUuids] = await Promise.all([
+			machOUuids({ filePath: stagedPath }),
+			machOUuids({ filePath: packagedPath }),
+		]);
+		if (JSON.stringify(stagedUuids) !== JSON.stringify(packagedUuids)) {
+			throw new Error(
+				`Packaged Jianying runtime bridge differs from the staged binary: ${path.basename(packagedPath)}`
+			);
+		}
+		await requireValidCodeSignature({ filePath: packagedPath });
+		if (
+			requiresDyldRuntimeEntitlements({
+				bridgeFileName: path.basename(packagedPath),
+			})
+		) {
+			await requireTransitionBridgeEntitlements({ filePath: packagedPath });
+		}
+		return;
+	}
+	if (stagedIsMachO !== packagedIsMachO || !staged.equals(packaged)) {
+		throw new Error(
+			`Packaged Jianying runtime bridge differs from the staged binary: ${path.basename(packagedPath)}`
+		);
+	}
 }
 
 export async function verifyPackagedJianyingRuntimeBridge({
-  bridgeFileName,
-  distRoot,
-  projectRoot,
+	bridgeFileName,
+	distRoot,
+	projectRoot,
 }: {
-  bridgeFileName: string;
-  distRoot: string;
-  projectRoot: string;
+	bridgeFileName: string;
+	distRoot: string;
+	projectRoot: string;
 }) {
-  const stagedPath = path.join(
-    projectRoot,
-    "electron",
-    "resources",
-    "bin",
-    bridgeFileName,
-  );
-  const packagedPath = await newestPackagedBridge({
-    distRoot,
-    bridgeFileName,
-  });
-  await Promise.all([
-    requireExecutable({ filePath: stagedPath }),
-    requireExecutable({ filePath: packagedPath }),
-  ]);
-  const [staged, packaged] = await Promise.all([
-    readFile(stagedPath),
-    readFile(packagedPath),
-  ]);
-  await requireMatchingBridge({ packaged, packagedPath, staged, stagedPath });
-  return packagedPath;
+	const stagedPath = path.join(
+		projectRoot,
+		"electron",
+		"resources",
+		"bin",
+		bridgeFileName
+	);
+	const packagedPath = await newestPackagedBridge({
+		distRoot,
+		bridgeFileName,
+	});
+	await Promise.all([
+		requireExecutable({ filePath: stagedPath }),
+		requireExecutable({ filePath: packagedPath }),
+	]);
+	const [staged, packaged] = await Promise.all([
+		readFile(stagedPath),
+		readFile(packagedPath),
+	]);
+	await requireMatchingBridge({ packaged, packagedPath, staged, stagedPath });
+	return packagedPath;
 }

--- a/qcut/scripts/verify-packaged-jianying-runtime-bridge.ts
+++ b/qcut/scripts/verify-packaged-jianying-runtime-bridge.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { constants } from "node:fs";
 import { access, readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
@@ -8,6 +8,11 @@ const execFileAsync = promisify(execFile);
 const MACH_O_MAGICS = new Set([
 	0xfeedface, 0xfeedfacf, 0xcefaedfe, 0xcffaedfe, 0xcafebabe, 0xcafebabf,
 	0xbebafeca, 0xbfbafeca,
+]);
+const DYLD_RUNTIME_BRIDGES = new Set([
+	"jianying-person-cutout-bridge",
+	"jianying-saliency-script-bridge",
+	"jianying-transition-bridge",
 ]);
 
 async function newestPackagedBridge({
@@ -78,6 +83,37 @@ async function requireValidCodeSignature({ filePath }: { filePath: string }) {
 	}
 }
 
+export async function requireTransitionBridgeEntitlements({
+	filePath,
+}: {
+	filePath: string;
+}) {
+	const { stdout } = await execFileAsync("/usr/bin/codesign", [
+		"--display",
+		"--entitlements",
+		"-",
+		"--xml",
+		filePath,
+	]);
+	const entitlements: Record<string, unknown> = JSON.parse(
+		execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", "-"], {
+			input: stdout,
+			encoding: "utf8",
+			timeout: 10_000,
+		})
+	);
+	for (const key of [
+		"com.apple.security.cs.allow-dyld-environment-variables",
+		"com.apple.security.cs.disable-library-validation",
+	]) {
+		if (entitlements[key] !== true) {
+			throw new Error(
+				`Packaged Jianying runtime bridge is missing required entitlement ${key}: ${filePath}`
+			);
+		}
+	}
+}
+
 async function requireMatchingBridge({
 	packaged,
 	packagedPath,
@@ -102,6 +138,9 @@ async function requireMatchingBridge({
 			);
 		}
 		await requireValidCodeSignature({ filePath: packagedPath });
+		if (DYLD_RUNTIME_BRIDGES.has(path.basename(packagedPath))) {
+			await requireTransitionBridgeEntitlements({ filePath: packagedPath });
+		}
 		return;
 	}
 	if (stagedIsMachO !== packagedIsMachO || !staged.equals(packaged)) {

--- a/qcut/scripts/verify-packaged-jianying-runtime-bridges.ts
+++ b/qcut/scripts/verify-packaged-jianying-runtime-bridges.ts
@@ -7,8 +7,8 @@ import { JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME } from "../electron/jianyin
 import { JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME } from "../electron/jianying-person-cutout/bridge-resolver.js";
 import { JIANYING_SALIENCY_BRIDGE_FILE_NAME } from "../electron/jianying-person-cutout/saliency-bridge-resolver.js";
 import {
-  VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
-  VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS,
+	VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+	VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS,
 } from "../electron/jianying-person-cutout/video-object-bach-bridge-resolver.js";
 import { VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME } from "../electron/jianying-person-cutout/video-object-coreml-bridge-resolver.js";
 import { JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME } from "../electron/jianying-text-runtime/bridge-resolver.js";
@@ -17,31 +17,31 @@ import { verifyPackagedJianyingRuntimeBridge } from "./verify-packaged-jianying-
 
 const execFileAsync = promisify(execFile);
 const REQUIRED_TRANSITION_BRIDGE_MODES = [
-  "transition-video",
-  "effect-video",
+	"transition-video",
+	"effect-video",
 ] as const;
 
 async function bridgeUsage({ bridgePath }: { bridgePath: string }) {
-  try {
-    const { stdout, stderr } = await execFileAsync(bridgePath, [], {
-      timeout: 10_000,
-    });
-    return `${stdout}${stderr}`;
-  } catch (error) {
-    const processError = error as { stdout?: string; stderr?: string };
-    return `${processError.stdout ?? ""}${processError.stderr ?? ""}`;
-  }
+	try {
+		const { stdout, stderr } = await execFileAsync(bridgePath, [], {
+			timeout: 10_000,
+		});
+		return `${stdout}${stderr}`;
+	} catch (error) {
+		const processError = error as { stdout?: string; stderr?: string };
+		return `${processError.stdout ?? ""}${processError.stderr ?? ""}`;
+	}
 }
 
 async function requireTransitionModes({ bridgePath }: { bridgePath: string }) {
-  const usage = await bridgeUsage({ bridgePath });
-  for (const mode of REQUIRED_TRANSITION_BRIDGE_MODES) {
-    if (!usage.includes(mode)) {
-      throw new Error(
-        `Packaged Jianying transition bridge does not advertise required mode: ${mode}`,
-      );
-    }
-  }
+	const usage = await bridgeUsage({ bridgePath });
+	for (const mode of REQUIRED_TRANSITION_BRIDGE_MODES) {
+		if (!usage.includes(mode)) {
+			throw new Error(
+				`Packaged Jianying transition bridge does not advertise required mode: ${mode}`
+			);
+		}
+	}
 }
 
 /**
@@ -53,165 +53,165 @@ async function requireTransitionModes({ bridgePath }: { bridgePath: string }) {
  */
 const PORTRAIT_ENGINE_CONTEXT_MARKER = "HTSGLContext";
 const PERSON_CUTOUT_NATIVE_METAL_MARKER =
-  "TEMattingBlendEffectV2-native-metal-canary";
+	"TEMattingBlendEffectV2-native-metal-canary";
 const PERSON_CUTOUT_VISION_FUSION_MARKER = "Vision-person-fusion-v1";
 const VIDEO_OBJECT_ROUTE_MARKER = "video-object-general-seg-v1";
 const VIDEO_OBJECT_ALPHA_QUALITY_MARKER = "video-object-alpha-quality-v1";
 const VIDEO_OBJECT_SAME_MODEL_COREML_MARKER =
-  "video-object-same-model-coreml-v1";
+	"video-object-same-model-coreml-v1";
 async function requirePortraitEngineGlContext({
-  hostPath,
+	hostPath,
 }: {
-  hostPath: string;
+	hostPath: string;
 }) {
-  const image = await readFile(hostPath);
-  if (!image.includes(PORTRAIT_ENGINE_CONTEXT_MARKER)) {
-    throw new Error(
-      `Packaged Jianying portrait adjustment host predates the engine GL context fix (no ${PORTRAIT_ENGINE_CONTEXT_MARKER} reference): ${hostPath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
-    );
-  }
+	const image = await readFile(hostPath);
+	if (!image.includes(PORTRAIT_ENGINE_CONTEXT_MARKER)) {
+		throw new Error(
+			`Packaged Jianying portrait adjustment host predates the engine GL context fix (no ${PORTRAIT_ENGINE_CONTEXT_MARKER} reference): ${hostPath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
 }
 
 async function requirePersonCutoutNativeMetal({
-  bridgePath,
+	bridgePath,
 }: {
-  bridgePath: string;
+	bridgePath: string;
 }) {
-  const image = await readFile(bridgePath);
-  if (!image.includes(PERSON_CUTOUT_NATIVE_METAL_MARKER)) {
-    throw new Error(
-      `Packaged Jianying person cutout bridge predates native Metal canary validation: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
-    );
-  }
-  if (!image.includes(PERSON_CUTOUT_VISION_FUSION_MARKER)) {
-    throw new Error(
-      `Packaged Jianying person cutout bridge predates Vision fusion: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
-    );
-  }
+	const image = await readFile(bridgePath);
+	if (!image.includes(PERSON_CUTOUT_NATIVE_METAL_MARKER)) {
+		throw new Error(
+			`Packaged Jianying person cutout bridge predates native Metal canary validation: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
+	if (!image.includes(PERSON_CUTOUT_VISION_FUSION_MARKER)) {
+		throw new Error(
+			`Packaged Jianying person cutout bridge predates Vision fusion: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
 }
 
 async function requireVideoObjectRoute({ bridgePath }: { bridgePath: string }) {
-  const image = await readFile(bridgePath);
-  if (!image.includes(VIDEO_OBJECT_ROUTE_MARKER)) {
-    throw new Error(
-      `Packaged Jianying segmentation bridge predates the video-object route: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
-    );
-  }
-  if (!image.includes(VIDEO_OBJECT_ALPHA_QUALITY_MARKER)) {
-    throw new Error(
-      `Packaged Jianying segmentation bridge predates the video-object Alpha quality gate: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
-    );
-  }
+	const image = await readFile(bridgePath);
+	if (!image.includes(VIDEO_OBJECT_ROUTE_MARKER)) {
+		throw new Error(
+			`Packaged Jianying segmentation bridge predates the video-object route: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
+	if (!image.includes(VIDEO_OBJECT_ALPHA_QUALITY_MARKER)) {
+		throw new Error(
+			`Packaged Jianying segmentation bridge predates the video-object Alpha quality gate: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
 }
 
 async function requireSameModelCoreMLRoute({
-  bridgePath,
+	bridgePath,
 }: {
-  bridgePath: string;
+	bridgePath: string;
 }) {
-  const image = await readFile(bridgePath);
-  if (!image.includes(VIDEO_OBJECT_SAME_MODEL_COREML_MARKER)) {
-    throw new Error(
-      `Packaged Jianying same-model CoreML bridge is stale: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
-    );
-  }
+	const image = await readFile(bridgePath);
+	if (!image.includes(VIDEO_OBJECT_SAME_MODEL_COREML_MARKER)) {
+		throw new Error(
+			`Packaged Jianying same-model CoreML bridge is stale: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
 }
 
 async function requireAuditedBachRoute({ bridgePath }: { bridgePath: string }) {
-  const image = await readFile(bridgePath);
-  for (const marker of VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS) {
-    if (image.includes(marker)) continue;
-    throw new Error(
-      `Packaged Jianying Bach bridge is missing audited capability ${marker}: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
-    );
-  }
+	const image = await readFile(bridgePath);
+	for (const marker of VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS) {
+		if (image.includes(marker)) continue;
+		throw new Error(
+			`Packaged Jianying Bach bridge is missing audited capability ${marker}: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
 }
 
 export async function verifyPackagedJianyingRuntimeBridges({
-  distRoot,
-  projectRoot,
+	distRoot,
+	projectRoot,
 }: {
-  distRoot: string;
-  projectRoot: string;
+	distRoot: string;
+	projectRoot: string;
 }) {
-  const [
-    transitionBridge,
-    textBridge,
-    filterBridge,
-    portraitAdjustmentHost,
-    personCutoutBridge,
-    saliencyBridge,
-    videoObjectBachBridge,
-    videoObjectCoreMLBridge,
-  ] = await Promise.all([
-    verifyPackagedJianyingRuntimeBridge({
-      bridgeFileName: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
-      distRoot,
-      projectRoot,
-    }),
-    verifyPackagedJianyingRuntimeBridge({
-      bridgeFileName: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
-      distRoot,
-      projectRoot,
-    }),
-    verifyPackagedJianyingRuntimeBridge({
-      bridgeFileName: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
-      distRoot,
-      projectRoot,
-    }),
-    verifyPackagedJianyingRuntimeBridge({
-      bridgeFileName: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
-      distRoot,
-      projectRoot,
-    }),
-    verifyPackagedJianyingRuntimeBridge({
-      bridgeFileName: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
-      distRoot,
-      projectRoot,
-    }),
-    verifyPackagedJianyingRuntimeBridge({
-      bridgeFileName: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
-      distRoot,
-      projectRoot,
-    }),
-    verifyPackagedJianyingRuntimeBridge({
-      bridgeFileName: VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
-      distRoot,
-      projectRoot,
-    }),
-    verifyPackagedJianyingRuntimeBridge({
-      bridgeFileName: VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
-      distRoot,
-      projectRoot,
-    }),
-  ]);
-  await requireTransitionModes({ bridgePath: transitionBridge });
-  await Promise.all([
-    requirePortraitEngineGlContext({ hostPath: portraitAdjustmentHost }),
-    requirePersonCutoutNativeMetal({ bridgePath: personCutoutBridge }),
-    requireVideoObjectRoute({ bridgePath: saliencyBridge }),
-    requireAuditedBachRoute({ bridgePath: videoObjectBachBridge }),
-    requireSameModelCoreMLRoute({ bridgePath: videoObjectCoreMLBridge }),
-  ]);
-  return {
-    transitionBridge,
-    textBridge,
-    filterBridge,
-    portraitAdjustmentHost,
-    personCutoutBridge,
-    saliencyBridge,
-    videoObjectBachBridge,
-    videoObjectCoreMLBridge,
-  };
+	const [
+		transitionBridge,
+		textBridge,
+		filterBridge,
+		portraitAdjustmentHost,
+		personCutoutBridge,
+		saliencyBridge,
+		videoObjectBachBridge,
+		videoObjectCoreMLBridge,
+	] = await Promise.all([
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+	]);
+	await requireTransitionModes({ bridgePath: transitionBridge });
+	await Promise.all([
+		requirePortraitEngineGlContext({ hostPath: portraitAdjustmentHost }),
+		requirePersonCutoutNativeMetal({ bridgePath: personCutoutBridge }),
+		requireVideoObjectRoute({ bridgePath: saliencyBridge }),
+		requireAuditedBachRoute({ bridgePath: videoObjectBachBridge }),
+		requireSameModelCoreMLRoute({ bridgePath: videoObjectCoreMLBridge }),
+	]);
+	return {
+		transitionBridge,
+		textBridge,
+		filterBridge,
+		portraitAdjustmentHost,
+		personCutoutBridge,
+		saliencyBridge,
+		videoObjectBachBridge,
+		videoObjectCoreMLBridge,
+	};
 }
 
 if (import.meta.main) {
-  const projectRoot = path.resolve(import.meta.dir, "..");
-  const bridges = await verifyPackagedJianyingRuntimeBridges({
-    projectRoot,
-    distRoot: path.join(projectRoot, "dist-electron"),
-  });
-  console.log(
-    `Verified packaged Jianying runtime bridges: ${Object.values(bridges).join(", ")}`,
-  );
+	const projectRoot = path.resolve(import.meta.dir, "..");
+	const bridges = await verifyPackagedJianyingRuntimeBridges({
+		projectRoot,
+		distRoot: path.join(projectRoot, "dist-electron"),
+	});
+	console.log(
+		`Verified packaged Jianying runtime bridges: ${Object.values(bridges).join(", ")}`
+	);
 }

--- a/qcut/scripts/verify-packaged-jianying-runtime-bridges.ts
+++ b/qcut/scripts/verify-packaged-jianying-runtime-bridges.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME } from "../electron/jianying-filter-local-runtime/bridge-resolver.js";
 import { JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME } from "../electron/jianying-portrait-adjustment-runtime/bridge-resolver.js";
+import { JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME } from "../electron/jianying-person-cutout/bridge-resolver.js";
+import { JIANYING_SALIENCY_BRIDGE_FILE_NAME } from "../electron/jianying-person-cutout/saliency-bridge-resolver.js";
 import { JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME } from "../electron/jianying-text-runtime/bridge-resolver.js";
 import { JIANYING_TRANSITION_BRIDGE_FILE_NAME } from "../electron/jianying-transition/bridge-resolver.js";
 import { verifyPackagedJianyingRuntimeBridge } from "./verify-packaged-jianying-runtime-bridge.js";
@@ -45,6 +47,9 @@ async function requireTransitionModes({ bridgePath }: { bridgePath: string }) {
  * makes the capability itself a packaging gate.
  */
 const PORTRAIT_ENGINE_CONTEXT_MARKER = "HTSGLContext";
+const PERSON_CUTOUT_NATIVE_METAL_MARKER = "TEMattingBlendEffectV2-native-metal";
+const PERSON_CUTOUT_VISION_FUSION_MARKER = "Vision-person-fusion-v1";
+const VIDEO_OBJECT_ROUTE_MARKER = "video-object-general-seg-v1";
 
 async function requirePortraitEngineGlContext({
 	hostPath,
@@ -59,6 +64,33 @@ async function requirePortraitEngineGlContext({
 	}
 }
 
+async function requirePersonCutoutNativeMetal({
+	bridgePath,
+}: {
+	bridgePath: string;
+}) {
+	const image = await readFile(bridgePath);
+	if (!image.includes(PERSON_CUTOUT_NATIVE_METAL_MARKER)) {
+		throw new Error(
+			`Packaged Jianying person cutout bridge predates native Metal blending: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
+	if (!image.includes(PERSON_CUTOUT_VISION_FUSION_MARKER)) {
+		throw new Error(
+			`Packaged Jianying person cutout bridge predates Vision fusion: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
+}
+
+async function requireVideoObjectRoute({ bridgePath }: { bridgePath: string }) {
+	const image = await readFile(bridgePath);
+	if (!image.includes(VIDEO_OBJECT_ROUTE_MARKER)) {
+		throw new Error(
+			`Packaged Jianying segmentation bridge predates the video-object route: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
+		);
+	}
+}
+
 export async function verifyPackagedJianyingRuntimeBridges({
 	distRoot,
 	projectRoot,
@@ -66,36 +98,58 @@ export async function verifyPackagedJianyingRuntimeBridges({
 	distRoot: string;
 	projectRoot: string;
 }) {
-	const [transitionBridge, textBridge, filterBridge, portraitAdjustmentHost] =
-		await Promise.all([
-			verifyPackagedJianyingRuntimeBridge({
-				bridgeFileName: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
-				distRoot,
-				projectRoot,
-			}),
-			verifyPackagedJianyingRuntimeBridge({
-				bridgeFileName: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
-				distRoot,
-				projectRoot,
-			}),
-			verifyPackagedJianyingRuntimeBridge({
-				bridgeFileName: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
-				distRoot,
-				projectRoot,
-			}),
-			verifyPackagedJianyingRuntimeBridge({
-				bridgeFileName: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
-				distRoot,
-				projectRoot,
-			}),
-		]);
+	const [
+		transitionBridge,
+		textBridge,
+		filterBridge,
+		portraitAdjustmentHost,
+		personCutoutBridge,
+		saliencyBridge,
+	] = await Promise.all([
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+		verifyPackagedJianyingRuntimeBridge({
+			bridgeFileName: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+			distRoot,
+			projectRoot,
+		}),
+	]);
 	await requireTransitionModes({ bridgePath: transitionBridge });
-	await requirePortraitEngineGlContext({ hostPath: portraitAdjustmentHost });
+	await Promise.all([
+		requirePortraitEngineGlContext({ hostPath: portraitAdjustmentHost }),
+		requirePersonCutoutNativeMetal({ bridgePath: personCutoutBridge }),
+		requireVideoObjectRoute({ bridgePath: saliencyBridge }),
+	]);
 	return {
 		transitionBridge,
 		textBridge,
 		filterBridge,
 		portraitAdjustmentHost,
+		personCutoutBridge,
+		saliencyBridge,
 	};
 }
 

--- a/qcut/scripts/verify-packaged-jianying-runtime-bridges.ts
+++ b/qcut/scripts/verify-packaged-jianying-runtime-bridges.ts
@@ -6,37 +6,42 @@ import { JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME } from "../electron/jianying-fil
 import { JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME } from "../electron/jianying-portrait-adjustment-runtime/bridge-resolver.js";
 import { JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME } from "../electron/jianying-person-cutout/bridge-resolver.js";
 import { JIANYING_SALIENCY_BRIDGE_FILE_NAME } from "../electron/jianying-person-cutout/saliency-bridge-resolver.js";
+import {
+  VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+  VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS,
+} from "../electron/jianying-person-cutout/video-object-bach-bridge-resolver.js";
+import { VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME } from "../electron/jianying-person-cutout/video-object-coreml-bridge-resolver.js";
 import { JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME } from "../electron/jianying-text-runtime/bridge-resolver.js";
 import { JIANYING_TRANSITION_BRIDGE_FILE_NAME } from "../electron/jianying-transition/bridge-resolver.js";
 import { verifyPackagedJianyingRuntimeBridge } from "./verify-packaged-jianying-runtime-bridge.js";
 
 const execFileAsync = promisify(execFile);
 const REQUIRED_TRANSITION_BRIDGE_MODES = [
-	"transition-video",
-	"effect-video",
+  "transition-video",
+  "effect-video",
 ] as const;
 
 async function bridgeUsage({ bridgePath }: { bridgePath: string }) {
-	try {
-		const { stdout, stderr } = await execFileAsync(bridgePath, [], {
-			timeout: 10_000,
-		});
-		return `${stdout}${stderr}`;
-	} catch (error) {
-		const processError = error as { stdout?: string; stderr?: string };
-		return `${processError.stdout ?? ""}${processError.stderr ?? ""}`;
-	}
+  try {
+    const { stdout, stderr } = await execFileAsync(bridgePath, [], {
+      timeout: 10_000,
+    });
+    return `${stdout}${stderr}`;
+  } catch (error) {
+    const processError = error as { stdout?: string; stderr?: string };
+    return `${processError.stdout ?? ""}${processError.stderr ?? ""}`;
+  }
 }
 
 async function requireTransitionModes({ bridgePath }: { bridgePath: string }) {
-	const usage = await bridgeUsage({ bridgePath });
-	for (const mode of REQUIRED_TRANSITION_BRIDGE_MODES) {
-		if (!usage.includes(mode)) {
-			throw new Error(
-				`Packaged Jianying transition bridge does not advertise required mode: ${mode}`
-			);
-		}
-	}
+  const usage = await bridgeUsage({ bridgePath });
+  for (const mode of REQUIRED_TRANSITION_BRIDGE_MODES) {
+    if (!usage.includes(mode)) {
+      throw new Error(
+        `Packaged Jianying transition bridge does not advertise required mode: ${mode}`,
+      );
+    }
+  }
 }
 
 /**
@@ -47,119 +52,166 @@ async function requireTransitionModes({ bridgePath }: { bridgePath: string }) {
  * makes the capability itself a packaging gate.
  */
 const PORTRAIT_ENGINE_CONTEXT_MARKER = "HTSGLContext";
-const PERSON_CUTOUT_NATIVE_METAL_MARKER = "TEMattingBlendEffectV2-native-metal";
+const PERSON_CUTOUT_NATIVE_METAL_MARKER =
+  "TEMattingBlendEffectV2-native-metal-canary";
 const PERSON_CUTOUT_VISION_FUSION_MARKER = "Vision-person-fusion-v1";
 const VIDEO_OBJECT_ROUTE_MARKER = "video-object-general-seg-v1";
-
+const VIDEO_OBJECT_ALPHA_QUALITY_MARKER = "video-object-alpha-quality-v1";
+const VIDEO_OBJECT_SAME_MODEL_COREML_MARKER =
+  "video-object-same-model-coreml-v1";
 async function requirePortraitEngineGlContext({
-	hostPath,
+  hostPath,
 }: {
-	hostPath: string;
+  hostPath: string;
 }) {
-	const image = await readFile(hostPath);
-	if (!image.includes(PORTRAIT_ENGINE_CONTEXT_MARKER)) {
-		throw new Error(
-			`Packaged Jianying portrait adjustment host predates the engine GL context fix (no ${PORTRAIT_ENGINE_CONTEXT_MARKER} reference): ${hostPath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
-		);
-	}
+  const image = await readFile(hostPath);
+  if (!image.includes(PORTRAIT_ENGINE_CONTEXT_MARKER)) {
+    throw new Error(
+      `Packaged Jianying portrait adjustment host predates the engine GL context fix (no ${PORTRAIT_ENGINE_CONTEXT_MARKER} reference): ${hostPath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
+    );
+  }
 }
 
 async function requirePersonCutoutNativeMetal({
-	bridgePath,
+  bridgePath,
 }: {
-	bridgePath: string;
+  bridgePath: string;
 }) {
-	const image = await readFile(bridgePath);
-	if (!image.includes(PERSON_CUTOUT_NATIVE_METAL_MARKER)) {
-		throw new Error(
-			`Packaged Jianying person cutout bridge predates native Metal blending: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
-		);
-	}
-	if (!image.includes(PERSON_CUTOUT_VISION_FUSION_MARKER)) {
-		throw new Error(
-			`Packaged Jianying person cutout bridge predates Vision fusion: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
-		);
-	}
+  const image = await readFile(bridgePath);
+  if (!image.includes(PERSON_CUTOUT_NATIVE_METAL_MARKER)) {
+    throw new Error(
+      `Packaged Jianying person cutout bridge predates native Metal canary validation: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
+    );
+  }
+  if (!image.includes(PERSON_CUTOUT_VISION_FUSION_MARKER)) {
+    throw new Error(
+      `Packaged Jianying person cutout bridge predates Vision fusion: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
+    );
+  }
 }
 
 async function requireVideoObjectRoute({ bridgePath }: { bridgePath: string }) {
-	const image = await readFile(bridgePath);
-	if (!image.includes(VIDEO_OBJECT_ROUTE_MARKER)) {
-		throw new Error(
-			`Packaged Jianying segmentation bridge predates the video-object route: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`
-		);
-	}
+  const image = await readFile(bridgePath);
+  if (!image.includes(VIDEO_OBJECT_ROUTE_MARKER)) {
+    throw new Error(
+      `Packaged Jianying segmentation bridge predates the video-object route: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
+    );
+  }
+  if (!image.includes(VIDEO_OBJECT_ALPHA_QUALITY_MARKER)) {
+    throw new Error(
+      `Packaged Jianying segmentation bridge predates the video-object Alpha quality gate: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
+    );
+  }
+}
+
+async function requireSameModelCoreMLRoute({
+  bridgePath,
+}: {
+  bridgePath: string;
+}) {
+  const image = await readFile(bridgePath);
+  if (!image.includes(VIDEO_OBJECT_SAME_MODEL_COREML_MARKER)) {
+    throw new Error(
+      `Packaged Jianying same-model CoreML bridge is stale: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
+    );
+  }
+}
+
+async function requireAuditedBachRoute({ bridgePath }: { bridgePath: string }) {
+  const image = await readFile(bridgePath);
+  for (const marker of VIDEO_OBJECT_BACH_BRIDGE_REQUIRED_MARKERS) {
+    if (image.includes(marker)) continue;
+    throw new Error(
+      `Packaged Jianying Bach bridge is missing audited capability ${marker}: ${bridgePath}. Re-run \`bun run stage-jianying-filter-local-bridge\`.`,
+    );
+  }
 }
 
 export async function verifyPackagedJianyingRuntimeBridges({
-	distRoot,
-	projectRoot,
+  distRoot,
+  projectRoot,
 }: {
-	distRoot: string;
-	projectRoot: string;
+  distRoot: string;
+  projectRoot: string;
 }) {
-	const [
-		transitionBridge,
-		textBridge,
-		filterBridge,
-		portraitAdjustmentHost,
-		personCutoutBridge,
-		saliencyBridge,
-	] = await Promise.all([
-		verifyPackagedJianyingRuntimeBridge({
-			bridgeFileName: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
-			distRoot,
-			projectRoot,
-		}),
-		verifyPackagedJianyingRuntimeBridge({
-			bridgeFileName: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
-			distRoot,
-			projectRoot,
-		}),
-		verifyPackagedJianyingRuntimeBridge({
-			bridgeFileName: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
-			distRoot,
-			projectRoot,
-		}),
-		verifyPackagedJianyingRuntimeBridge({
-			bridgeFileName: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
-			distRoot,
-			projectRoot,
-		}),
-		verifyPackagedJianyingRuntimeBridge({
-			bridgeFileName: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
-			distRoot,
-			projectRoot,
-		}),
-		verifyPackagedJianyingRuntimeBridge({
-			bridgeFileName: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
-			distRoot,
-			projectRoot,
-		}),
-	]);
-	await requireTransitionModes({ bridgePath: transitionBridge });
-	await Promise.all([
-		requirePortraitEngineGlContext({ hostPath: portraitAdjustmentHost }),
-		requirePersonCutoutNativeMetal({ bridgePath: personCutoutBridge }),
-		requireVideoObjectRoute({ bridgePath: saliencyBridge }),
-	]);
-	return {
-		transitionBridge,
-		textBridge,
-		filterBridge,
-		portraitAdjustmentHost,
-		personCutoutBridge,
-		saliencyBridge,
-	};
+  const [
+    transitionBridge,
+    textBridge,
+    filterBridge,
+    portraitAdjustmentHost,
+    personCutoutBridge,
+    saliencyBridge,
+    videoObjectBachBridge,
+    videoObjectCoreMLBridge,
+  ] = await Promise.all([
+    verifyPackagedJianyingRuntimeBridge({
+      bridgeFileName: JIANYING_TRANSITION_BRIDGE_FILE_NAME,
+      distRoot,
+      projectRoot,
+    }),
+    verifyPackagedJianyingRuntimeBridge({
+      bridgeFileName: JIANYING_TEXT_RUNTIME_BRIDGE_FILE_NAME,
+      distRoot,
+      projectRoot,
+    }),
+    verifyPackagedJianyingRuntimeBridge({
+      bridgeFileName: JIANYING_FILTER_LOCAL_BRIDGE_FILE_NAME,
+      distRoot,
+      projectRoot,
+    }),
+    verifyPackagedJianyingRuntimeBridge({
+      bridgeFileName: JIANYING_PORTRAIT_ADJUSTMENT_HOST_FILE_NAME,
+      distRoot,
+      projectRoot,
+    }),
+    verifyPackagedJianyingRuntimeBridge({
+      bridgeFileName: JIANYING_PERSON_CUTOUT_BRIDGE_FILE_NAME,
+      distRoot,
+      projectRoot,
+    }),
+    verifyPackagedJianyingRuntimeBridge({
+      bridgeFileName: JIANYING_SALIENCY_BRIDGE_FILE_NAME,
+      distRoot,
+      projectRoot,
+    }),
+    verifyPackagedJianyingRuntimeBridge({
+      bridgeFileName: VIDEO_OBJECT_BACH_BRIDGE_FILE_NAME,
+      distRoot,
+      projectRoot,
+    }),
+    verifyPackagedJianyingRuntimeBridge({
+      bridgeFileName: VIDEO_OBJECT_COREML_BRIDGE_FILE_NAME,
+      distRoot,
+      projectRoot,
+    }),
+  ]);
+  await requireTransitionModes({ bridgePath: transitionBridge });
+  await Promise.all([
+    requirePortraitEngineGlContext({ hostPath: portraitAdjustmentHost }),
+    requirePersonCutoutNativeMetal({ bridgePath: personCutoutBridge }),
+    requireVideoObjectRoute({ bridgePath: saliencyBridge }),
+    requireAuditedBachRoute({ bridgePath: videoObjectBachBridge }),
+    requireSameModelCoreMLRoute({ bridgePath: videoObjectCoreMLBridge }),
+  ]);
+  return {
+    transitionBridge,
+    textBridge,
+    filterBridge,
+    portraitAdjustmentHost,
+    personCutoutBridge,
+    saliencyBridge,
+    videoObjectBachBridge,
+    videoObjectCoreMLBridge,
+  };
 }
 
 if (import.meta.main) {
-	const projectRoot = path.resolve(import.meta.dir, "..");
-	const bridges = await verifyPackagedJianyingRuntimeBridges({
-		projectRoot,
-		distRoot: path.join(projectRoot, "dist-electron"),
-	});
-	console.log(
-		`Verified packaged Jianying runtime bridges: ${Object.values(bridges).join(", ")}`
-	);
+  const projectRoot = path.resolve(import.meta.dir, "..");
+  const bridges = await verifyPackagedJianyingRuntimeBridges({
+    projectRoot,
+    distRoot: path.join(projectRoot, "dist-electron"),
+  });
+  console.log(
+    `Verified packaged Jianying runtime bridges: ${Object.values(bridges).join(", ")}`,
+  );
 }


### PR DESCRIPTION
## Summary

- add `filter-lab render` and `filter-lab apply` for local image and video outputs
- reuse Filter Lab LUT, native portrait, and multi-pass routing with atomic output protection
- fix large catalog JSON truncation and bypass zero-strength LUT interpolation
- document strict-offline media and desktop UI verification

## Validation

- 43 Vitest files, 258 tests passed
- Electron TypeScript check passed
- Biome passed on the 15 changed TypeScript files
- `git diff --check` passed
- real strict-offline render: 7 PNG files and 2 one-second, 30-frame MP4 files with audio
- desktop UI smoke: Backlight, Blue Hour, and Milk Apricot cards

## Evidence boundary

All 887 catalog cards are cached, 788 are currently loadable, and 99 remain unavailable. This PR does not promote cached-only cards or treat native-local output as Jianying UI parity. No Jianying binaries, models, LUTs, shaders, or test media are committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Filter Lab commands for rendering and applying cached filters to images and videos.
  - Supports native and FFmpeg rendering, intensity, dry runs, progress, cancellation, timeouts, overwrite protection, and audio preservation.
  - Added fine-quality person cutout processing with automatic routing, fallback handling, improved mask tracking, caching, and transparent video export.
  - Added collapsible Smart Body and Manual Body editing sections.

- **Bug Fixes**
  - Preserved original audio when generated mask results lack usable audio.
  - Ensured JSON command failures finish writing output before exiting.
  - Improved localized cutout labels, status messages, and elapsed-time display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->