### PR TITLE
feat: complete Compose resource labs

### DIFF
--- a/qcut/electron/native-pipeline/cli/cli-handlers-compose-plan.ts
+++ b/qcut/electron/native-pipeline/cli/cli-handlers-compose-plan.ts
@@ -10,6 +10,10 @@ import {
 	type ComposeSnapshot,
 } from "../compose/compose-protocol.js";
 import { createComposeProviderAdapter } from "../compose/providers/index.js";
+import {
+	composeResourceQuery,
+	discoverComposeResources,
+} from "../compose/compose-resource-broker.js";
 import { loadComposeJsonArgument } from "./cli-handlers-compose-editor.js";
 import type {
 	CLIResult,
@@ -32,13 +36,32 @@ const MAX_POLL_ATTEMPTS = 120;
 
 export interface ComposePlanDependencies {
 	createAdapter: typeof createComposeProviderAdapter;
+	discoverResources: typeof discoverComposeResources;
 	pollDelayMs: number;
 }
 
 const DEFAULT_DEPENDENCIES: ComposePlanDependencies = {
 	createAdapter: createComposeProviderAdapter,
+	discoverResources: discoverComposeResources,
 	pollDelayMs: 1_000,
 };
+
+function mergeResourceCandidates({
+	existing,
+	discovered,
+}: {
+	existing: ComposeSnapshot["availableResources"];
+	discovered: ComposeSnapshot["availableResources"];
+}): ComposeSnapshot["availableResources"] {
+	const byIdentity = new Map<
+		string,
+		ComposeSnapshot["availableResources"][number]
+	>();
+	for (const resource of [...existing, ...discovered]) {
+		byIdentity.set(`${resource.assetType}:${resource.assetId}`, resource);
+	}
+	return [...byIdentity.values()];
+}
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
@@ -99,13 +122,33 @@ export async function handleComposePlan(
 		if (!options.snapshot) {
 			throw new Error("compose plan needs --snapshot.");
 		}
-		const snapshot = (await loadComposeJsonArgument({
+		let snapshot = (await loadComposeJsonArgument({
 			value: options.snapshot,
 		})) as ComposeSnapshot;
 		const intent = await resolveComposeIntent({ value: options.intent });
 		const providerName = options.provider ?? "local";
 		if (!["qcut", "openrouter", "fal", "local"].includes(providerName)) {
 			throw new Error(`Unknown compose provider: ${providerName}`);
+		}
+		if (providerName === "qcut" || providerName === "openrouter") {
+			const broker = await dependencies.discoverResources({
+				query: composeResourceQuery({
+					snapshot,
+					intentQuery: intent.options.resourceQuery,
+				}),
+			});
+			snapshot = {
+				...snapshot,
+				availableResources: mergeResourceCandidates({
+					existing: snapshot.availableResources,
+					discovered: broker.resources,
+				}),
+				resourceWarnings: [
+					...(snapshot.resourceWarnings ?? []),
+					...broker.warnings,
+				],
+				capabilities: { ...snapshot.capabilities, ...broker.capabilities },
+			};
 		}
 		const adapter = dependencies.createAdapter({
 			provider: providerName as ComposeJob["provider"],

--- a/qcut/electron/native-pipeline/cli/cli-handlers-sounds.ts
+++ b/qcut/electron/native-pipeline/cli/cli-handlers-sounds.ts
@@ -1,5 +1,4 @@
 import { resolve, sep } from "node:path";
-import { getKey } from "../infra/key-manager.js";
 import {
 	searchFreesound,
 	type SoundSearchResult,
@@ -8,6 +7,10 @@ import {
 	downloadSoundEffectsLabAsset,
 	searchSoundEffectsLab,
 } from "../sounds/sound-effects-lab-client.js";
+import {
+	defaultSoundEffectsLabManifestSource,
+	soundEffectsLabAssetsUrl,
+} from "../sounds/sound-effects-lab-config.js";
 import type {
 	CLIResult,
 	CLIRunOptions,
@@ -15,19 +18,6 @@ import type {
 } from "./cli-runner/types.js";
 
 export type SoundSearchSource = "freesound" | "lab" | "all";
-
-const LICENSE_SERVER_URL =
-	process.env.QCUT_LICENSE_SERVER_URL ||
-	"https://qcut-license-server.zdhpeter.workers.dev";
-
-/** True only for URLs on the license server's own origin. */
-function isLicenseServerUrl({ url }: { url: string }): boolean {
-	try {
-		return new URL(url).origin === new URL(LICENSE_SERVER_URL).origin;
-	} catch {
-		return false;
-	}
-}
 
 /**
  * Without an explicit manifest the lab catalog comes from the license server,
@@ -39,17 +29,10 @@ function isLicenseServerUrl({ url }: { url: string }): boolean {
  * hand it to whoever runs that host.
  */
 function labManifestSource({ options }: { options: CLIRunOptions }) {
-	if (options.manifest) return { manifestPath: resolve(options.manifest) };
-	const manifestUrl =
-		options.manifestUrl ??
-		`${LICENSE_SERVER_URL.replace(/\/+$/, "")}/api/sound-effects-lab/private-manifest`;
-	const token = isLicenseServerUrl({ url: manifestUrl })
-		? getKey("QCUT_AUTH_TOKEN")
-		: undefined;
-	return {
-		manifestUrl,
-		...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
-	};
+	return defaultSoundEffectsLabManifestSource({
+		manifestPath: options.manifest,
+		manifestUrl: options.manifestUrl,
+	});
 }
 
 /**
@@ -165,15 +148,14 @@ export async function handleSoundSearch(
 	const returned = results.slice(0, limit);
 
 	if (options.downloadDir) {
-		const assetsUrl = `${LICENSE_SERVER_URL.replace(/\/+$/, "")}/api/sound-effects-lab/assets`;
-		const token = getKey("QCUT_AUTH_TOKEN");
+		const source = labManifestSource({ options });
 		for (const entry of returned) {
 			if (!(entry.objectKey && entry.fileName)) continue;
 			try {
 				entry.localPath = await dependencies.downloadSoundEffectsLabAsset({
 					objectKey: entry.objectKey,
-					assetsUrl,
-					headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+					assetsUrl: soundEffectsLabAssetsUrl(),
+					headers: source.headers,
 					destinationPath: assetDestination({
 						downloadDir: options.downloadDir,
 						fileName: entry.fileName,

--- a/qcut/electron/native-pipeline/compose/compose-asset-resolver.ts
+++ b/qcut/electron/native-pipeline/compose/compose-asset-resolver.ts
@@ -8,7 +8,11 @@ import {
 	readLocalReference,
 	resolveDefaultLocalReferenceRoot,
 } from "../stickers/local-reference-catalog/index.js";
-import { TRANSITION_LAB_RECIPES } from "../transitions/transition-lab-catalog.js";
+import {
+	materializeComposeSoundLabReference,
+	resolveComposeSoundLabReference,
+	resolveComposeTransitionReference,
+} from "./compose-lab-resource-resolver.js";
 import type {
 	ComposeAssetReference,
 	ComposePatch,
@@ -56,17 +60,12 @@ export interface ComposeAssetResolverDependencies {
 		fileName: string;
 		checksumSha256: string;
 	}>;
+	resolveSoundLabReference?: typeof resolveComposeSoundLabReference;
+	materializeSoundLabReference?: typeof materializeComposeSoundLabReference;
+	resolveTransitionReference?: typeof resolveComposeTransitionReference;
 }
 
 const STICKER_LAB_PREFIX = "sticker-lab:";
-const EDITOR_TRANSITION_PRESETS = new Set([
-	"crossfade",
-	"dissolve",
-	"whip-pan-right",
-]);
-const TRANSITION_LAB_RECIPE_IDS = new Set(
-	TRANSITION_LAB_RECIPES.map(({ id }) => id)
-);
 
 async function defaultFindStickerLabItem({
 	batchId,
@@ -247,8 +246,89 @@ export async function resolveComposeAssetReference({
 				},
 			});
 		}
-		case "sound-effect":
-			if (reference.provider === "qcut") {
+		case "sound-effect": {
+			if (
+				reference.provider !== "qcut" ||
+				!reference.assetId.startsWith("sound-effects-lab:")
+			) {
+				return report({
+					operationId,
+					reference,
+					status: reference.provider === "qcut" ? "cloud-only" : "missing",
+					evidence: {
+						backend:
+							reference.provider === "qcut"
+								? "sound-effects-lab"
+								: "local-file",
+						cacheStatus: "none",
+						verification: "unverified",
+						detail:
+							reference.provider === "qcut"
+								? "Use a sound-effects-lab:<id> reference from the authenticated catalog."
+								: "Sound effects need a localPath or a recognized Sound Effects Lab identity.",
+					},
+				});
+			}
+			try {
+				const resolveSound =
+					dependencies.resolveSoundLabReference ??
+					resolveComposeSoundLabReference;
+				const resolution = await resolveSound({ reference });
+				if (!resolution) {
+					return report({
+						operationId,
+						reference,
+						status: "missing",
+						evidence: {
+							backend: "sound-effects-lab",
+							cacheStatus: "none",
+							verification: "unverified",
+							detail: "The asset identity is not a Sound Effects Lab reference.",
+						},
+					});
+				}
+				if (resolution.status === "missing") {
+					return report({
+						operationId,
+						reference,
+						status: "missing",
+						evidence: {
+							backend: "sound-effects-lab",
+							cacheStatus: "none",
+							verification: "unverified",
+							detail: resolution.detail,
+						},
+					});
+				}
+				if (resolution.status === "reference-only") {
+					return report({
+						operationId,
+						reference,
+						status: "unsupported",
+						evidence: {
+							backend: "sound-effects-lab",
+							cacheStatus: "reference-only",
+							verification: "unverified",
+							detail: resolution.detail,
+						},
+					});
+				}
+				return report({
+					operationId,
+					reference,
+					status:
+						resolution.status === "ready" ? "cached" : "downloadable",
+					bytes: resolution.asset.byteSize,
+					evidence: {
+						backend: "sound-effects-lab",
+						cacheStatus:
+							resolution.status === "ready"
+								? "local-catalog"
+								: "authenticated-download",
+						verification: "unverified",
+					},
+				});
+			} catch (error) {
 				return report({
 					operationId,
 					reference,
@@ -257,44 +337,37 @@ export async function resolveComposeAssetReference({
 						backend: "sound-effects-lab",
 						cacheStatus: "none",
 						verification: "unverified",
-						detail:
-							"Needs the private Sound Effects Lab manifest and an allowlisted sign-in.",
+						detail: error instanceof Error ? error.message : String(error),
 					},
 				});
 			}
-			return report({
-				operationId,
-				reference,
-				status: "missing",
-				evidence: {
-					backend: "local-file",
-					cacheStatus: "none",
-					verification: "unverified",
-					detail: "Sound effects need a localPath until a download path lands.",
-				},
-			});
+		}
 		case "transition": {
-			if (EDITOR_TRANSITION_PRESETS.has(reference.assetId)) {
+			const resolveTransition =
+				dependencies.resolveTransitionReference ??
+				resolveComposeTransitionReference;
+			const resolution = await resolveTransition({
+				assetId: reference.assetId,
+			});
+			if (resolution.status === "ready") {
 				return report({
 					operationId,
 					reference,
 					status: "cached",
 					evidence: {
-						backend: "editor-preset",
-						cacheStatus: "builtin",
+						backend: resolution.backend,
+						cacheStatus:
+							resolution.backend === "editor-preset"
+								? "builtin"
+								: resolution.backend === "transition-lab"
+									? "builtin-recipe"
+									: "verified-local-runtime",
 						verification: "unverified",
-					},
-				});
-			}
-			if (TRANSITION_LAB_RECIPE_IDS.has(reference.assetId)) {
-				return report({
-					operationId,
-					reference,
-					status: "cached",
-					evidence: {
-						backend: "transition-lab",
-						cacheStatus: "builtin-recipe",
-						verification: "unverified",
+						...(resolution.backend === "jianying-local"
+							? {
+									detail: `Local runtime admitted package ${resolution.packageHash}.`,
+								}
+							: {}),
 					},
 				});
 			}
@@ -303,10 +376,10 @@ export async function resolveComposeAssetReference({
 				reference,
 				status: "unsupported",
 				evidence: {
-					backend: "editor-preset",
+					backend: resolution.backend,
 					cacheStatus: "none",
 					verification: "unverified",
-					detail: `Unknown transition preset: ${reference.assetId}`,
+					detail: resolution.detail,
 				},
 			});
 		}
@@ -369,28 +442,24 @@ function issueForReport({
 	index: number;
 }): ComposeValidationIssue | null {
 	const path = `operations.${index}.asset`;
-	if (resolved.status === "missing") {
-		return {
-			severity: "error",
-			code: "invalid-asset-reference",
-			path,
-			operationId: resolved.operationId,
-			message: `Asset ${resolved.assetId} (${resolved.assetType}) is not available: ${resolved.evidence.detail ?? "missing"}`,
-			fixHint: "Provide a localPath or cache the asset before applying.",
-		};
-	}
+	const blocksEditorApply =
+		resolved.assetType === "sticker" ||
+		resolved.assetType === "sound-effect" ||
+		resolved.assetType === "transition";
 	if (
-		resolved.status === "unsupported" &&
-		resolved.assetType === "transition"
+		blocksEditorApply &&
+		(resolved.status === "missing" ||
+			resolved.status === "unsupported" ||
+			resolved.status === "cloud-only")
 	) {
 		return {
 			severity: "error",
 			code: "invalid-asset-reference",
 			path,
 			operationId: resolved.operationId,
-			message:
-				resolved.evidence.detail ??
-				`Unsupported transition ${resolved.assetId}`,
+			message: `Asset ${resolved.assetId} (${resolved.assetType}) is not available: ${resolved.evidence.detail ?? "missing"}`,
+			fixHint:
+				"Sign in if required, then cache or download the asset before applying.",
 		};
 	}
 	if (resolved.status === "unsupported" || resolved.status === "cloud-only") {
@@ -453,6 +522,32 @@ export async function materializeComposePatchAssets({
 }): Promise<ComposePatch> {
 	const operations: ComposePatchOperation[] = [];
 	for (const operation of patch.operations) {
+		if (operation.kind === "add-sound-effect" && !operation.asset.localPath) {
+			const materializeSound =
+				dependencies.materializeSoundLabReference ??
+				materializeComposeSoundLabReference;
+			const materialized = await materializeSound({
+				reference: operation.asset,
+				scratchDirectory,
+			});
+			if (materialized) {
+				operations.push({
+					...operation,
+					asset: {
+						...operation.asset,
+						localPath: materialized.localPath,
+						cacheKey: materialized.sha256,
+						provenance: {
+							...operation.asset.provenance,
+							backend: "sound-effects-lab",
+							sha256: materialized.sha256,
+							bytes: materialized.bytes,
+						},
+					},
+				});
+				continue;
+			}
+		}
 		if (
 			operation.kind !== "add-sticker" ||
 			operation.asset.localPath ||

--- a/qcut/electron/native-pipeline/compose/compose-lab-resource-resolver.ts
+++ b/qcut/electron/native-pipeline/compose/compose-lab-resource-resolver.ts
@@ -1,0 +1,302 @@
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import {
+	JIANYING_TRANSITIONS,
+	type JianyingTransitionDefinition,
+} from "../../jianying-transition-catalog.js";
+import {
+	inspectJianyingTransitionRuntime,
+	type JianyingRuntimeInspection,
+} from "../../jianying-transition/runtime-discovery.js";
+import {
+	materializeSoundEffectsLabAsset,
+	resolveSoundEffectsLabAsset,
+	type ResolvedSoundEffectsLabAsset,
+} from "../sounds/sound-effects-lab-client.js";
+import {
+	defaultSoundEffectsLabManifestSource,
+	type SoundEffectsLabManifestSource,
+} from "../sounds/sound-effects-lab-config.js";
+import {
+	TRANSITION_LAB_RECIPES,
+	type TransitionLabRecipe,
+} from "../transitions/transition-lab-catalog.js";
+import type { ComposeAssetReference } from "./compose-protocol.js";
+
+const SOUND_EFFECTS_LAB_PREFIX = "sound-effects-lab:";
+const EDITOR_TRANSITION_PRESETS = new Set([
+	"crossfade",
+	"dissolve",
+	"whip-pan-right",
+]);
+
+export interface ComposeLabResourceDependencies {
+	resolveSound: typeof resolveSoundEffectsLabAsset;
+	materializeSound: typeof materializeSoundEffectsLabAsset;
+	inspectJianyingTransitions: typeof inspectJianyingTransitionRuntime;
+}
+
+const DEFAULT_DEPENDENCIES: ComposeLabResourceDependencies = {
+	resolveSound: resolveSoundEffectsLabAsset,
+	materializeSound: materializeSoundEffectsLabAsset,
+	inspectJianyingTransitions: inspectJianyingTransitionRuntime,
+};
+
+export type ComposeSoundLabResolution =
+	| {
+			status: "ready";
+			asset: ResolvedSoundEffectsLabAsset;
+	  }
+	| {
+			status: "downloadable";
+			asset: ResolvedSoundEffectsLabAsset;
+	  }
+	| {
+			status: "missing";
+			detail: string;
+			asset?: ResolvedSoundEffectsLabAsset;
+	  }
+	| {
+			status: "reference-only";
+			detail: string;
+			asset: ResolvedSoundEffectsLabAsset;
+	  };
+
+export interface MaterializedComposeSound {
+	localPath: string;
+	sha256: string;
+	bytes: number;
+	asset: ResolvedSoundEffectsLabAsset;
+}
+
+export type ComposeTransitionResolution =
+	| {
+			status: "ready";
+			backend: "editor-preset";
+			presetId: string;
+	  }
+	| {
+			status: "ready";
+			backend: "transition-lab";
+			presetId: string;
+			recipe: TransitionLabRecipe;
+	  }
+	| {
+			status: "ready";
+			backend: "jianying-local";
+			presetId: string;
+			packageHash: string;
+			definition: JianyingTransitionDefinition;
+	  }
+	| {
+			status: "unsupported";
+			backend: "editor-preset" | "jianying-local";
+			detail: string;
+	  };
+
+function dependenciesWithDefaults({
+	dependencies,
+}: {
+	dependencies?: Partial<ComposeLabResourceDependencies>;
+}): ComposeLabResourceDependencies {
+	return { ...DEFAULT_DEPENDENCIES, ...dependencies };
+}
+
+export function parseSoundEffectsLabAssetId({
+	assetId,
+}: {
+	assetId: string;
+}): string | null {
+	if (!assetId.startsWith(SOUND_EFFECTS_LAB_PREFIX)) return null;
+	const id = assetId.slice(SOUND_EFFECTS_LAB_PREFIX.length).trim();
+	return id.length > 0 ? id : null;
+}
+
+export async function resolveComposeSoundLabReference({
+	reference,
+	source = defaultSoundEffectsLabManifestSource(),
+	signal,
+	dependencies,
+}: {
+	reference: ComposeAssetReference;
+	source?: SoundEffectsLabManifestSource;
+	signal?: AbortSignal;
+	dependencies?: Partial<ComposeLabResourceDependencies>;
+}): Promise<ComposeSoundLabResolution | null> {
+	if (reference.assetType !== "sound-effect" || reference.provider !== "qcut") {
+		return null;
+	}
+	const assetId = parseSoundEffectsLabAssetId({ assetId: reference.assetId });
+	if (!assetId) return null;
+	const resolvedDependencies = dependenciesWithDefaults({ dependencies });
+	const asset = await resolvedDependencies.resolveSound({
+		assetId,
+		source,
+		signal,
+	});
+	if (!asset) {
+		return {
+			status: "missing",
+			detail: `Sound Effects Lab asset ${assetId} is not in the authenticated catalog.`,
+		};
+	}
+	if (!asset.reusable) {
+		return {
+			status: "reference-only",
+			detail: `Sound Effects Lab asset ${assetId} is reference-only and cannot be copied into QCut.`,
+			asset,
+		};
+	}
+	if (asset.localPath) return { status: "ready", asset };
+	if (asset.objectKey && asset.fileName) {
+		return { status: "downloadable", asset };
+	}
+	return {
+		status: "missing",
+		detail: `Sound Effects Lab asset ${assetId} has no readable source.`,
+		asset,
+	};
+}
+
+function safeFileComponent({ value }: { value: string }): string {
+	return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function soundExtension({ asset }: { asset: ResolvedSoundEffectsLabAsset }): string {
+	const fileExtension = asset.fileName ? extname(asset.fileName) : "";
+	if (fileExtension) return fileExtension.toLocaleLowerCase();
+	const mimeExtensions: Record<string, string> = {
+		"audio/aac": ".aac",
+		"audio/flac": ".flac",
+		"audio/m4a": ".m4a",
+		"audio/mp4": ".m4a",
+		"audio/mpeg": ".mp3",
+		"audio/ogg": ".ogg",
+		"audio/wav": ".wav",
+		"audio/x-wav": ".wav",
+	};
+	return asset.mimeType ? (mimeExtensions[asset.mimeType] ?? ".audio") : ".audio";
+}
+
+export async function materializeComposeSoundLabReference({
+	reference,
+	scratchDirectory,
+	source = defaultSoundEffectsLabManifestSource(),
+	signal,
+	dependencies,
+}: {
+	reference: ComposeAssetReference;
+	scratchDirectory: string;
+	source?: SoundEffectsLabManifestSource;
+	signal?: AbortSignal;
+	dependencies?: Partial<ComposeLabResourceDependencies>;
+}): Promise<MaterializedComposeSound | null> {
+	const resolution = await resolveComposeSoundLabReference({
+		reference,
+		source,
+		signal,
+		dependencies,
+	});
+	if (!resolution) return null;
+	if (resolution.status === "missing" || resolution.status === "reference-only") {
+		throw new Error(resolution.detail);
+	}
+	const resolvedDependencies = dependenciesWithDefaults({ dependencies });
+	const destinationPath = join(
+		scratchDirectory,
+		`${safeFileComponent({ value: reference.assetId })}${soundExtension({ asset: resolution.asset })}`
+	);
+	const localPath = await resolvedDependencies.materializeSound({
+		asset: resolution.asset,
+		destinationPath,
+		source,
+		signal,
+	});
+	const [bytes, file] = await Promise.all([readFile(localPath), stat(localPath)]);
+	return {
+		localPath,
+		sha256: createHash("sha256").update(bytes).digest("hex"),
+		bytes: file.size,
+		asset: resolution.asset,
+	};
+}
+
+function findJianyingDefinition({
+	assetId,
+}: {
+	assetId: string;
+}): JianyingTransitionDefinition | undefined {
+	return JIANYING_TRANSITIONS.find((transition) => transition.id === assetId);
+}
+
+function verifiedJianyingPackage({
+	definition,
+	inspection,
+}: {
+	definition: JianyingTransitionDefinition;
+	inspection: JianyingRuntimeInspection;
+}): boolean {
+	const status = inspection.status.transitions.find(
+		(transition) => transition.id === definition.id
+	);
+	const packagePath = inspection.packagePaths.get(definition.id);
+	return Boolean(
+		status?.available &&
+		packagePath &&
+		basename(packagePath).toLocaleLowerCase() ===
+			definition.metadataMd5.toLocaleLowerCase()
+	);
+}
+
+export async function resolveComposeTransitionReference({
+	assetId,
+	dependencies,
+}: {
+	assetId: string;
+	dependencies?: Partial<ComposeLabResourceDependencies>;
+}): Promise<ComposeTransitionResolution> {
+	if (EDITOR_TRANSITION_PRESETS.has(assetId)) {
+		return { status: "ready", backend: "editor-preset", presetId: assetId };
+	}
+	const recipe = TRANSITION_LAB_RECIPES.find((entry) => entry.id === assetId);
+	if (recipe) {
+		return {
+			status: "ready",
+			backend: "transition-lab",
+			presetId: recipe.id,
+			recipe,
+		};
+	}
+	const definition = findJianyingDefinition({ assetId });
+	if (!definition) {
+		return {
+			status: "unsupported",
+			backend: "editor-preset",
+			detail: `Unknown transition preset: ${assetId}`,
+		};
+	}
+	if (definition.runtimeKind !== "transition-segment") {
+		return {
+			status: "unsupported",
+			backend: "jianying-local",
+			detail: `${definition.localizedName} requires AI generation and is not a local two-input transition.`,
+		};
+	}
+	const resolvedDependencies = dependenciesWithDefaults({ dependencies });
+	const inspection = await resolvedDependencies.inspectJianyingTransitions();
+	if (!verifiedJianyingPackage({ definition, inspection })) {
+		return {
+			status: "unsupported",
+			backend: "jianying-local",
+			detail: `Jianying transition ${definition.localizedName} is not available in the verified local runtime.`,
+		};
+	}
+	return {
+		status: "ready",
+		backend: "jianying-local",
+		presetId: definition.id,
+		packageHash: definition.metadataMd5,
+		definition,
+	};
+}

--- a/qcut/electron/native-pipeline/compose/compose-protocol.ts
+++ b/qcut/electron/native-pipeline/compose/compose-protocol.ts
@@ -27,10 +27,30 @@ export type ComposeAssetType =
 	| "transition"
 	| "generated-media";
 
+export type ComposeAssetAvailability =
+	| "ready"
+	| "downloadable"
+	| "reference-only"
+	| "unavailable";
+
+export interface ComposeAssetCapabilities {
+	preview: boolean;
+	editorApply: boolean;
+	editorExport: boolean;
+	headlessRender: boolean;
+	requiresAuth?: boolean;
+	requiresLocalRuntime?: boolean;
+}
+
 export interface ComposeAssetReference {
 	provider: ComposeProvider;
 	assetType: ComposeAssetType;
 	assetId: string;
+	displayName?: string;
+	tags?: string[];
+	duration?: number;
+	availability?: ComposeAssetAvailability;
+	capabilities?: ComposeAssetCapabilities;
 	cacheKey?: string;
 	localPath?: string;
 	license?: "commercial-ok" | "personal-only" | "unknown";
@@ -91,7 +111,14 @@ export interface ComposeSnapshot {
 	beats: ComposeSnapshotBeat[];
 	shots: ComposeSnapshotShot[];
 	availableResources: ComposeAssetReference[];
-	capabilities: { headlessRender: boolean; editorApply: boolean };
+	resourceWarnings?: string[];
+	capabilities: {
+		headlessRender: boolean;
+		editorApply: boolean;
+		editorExport?: boolean;
+		resourceBroker?: boolean;
+		jianyingLocalTransitions?: boolean;
+	};
 }
 
 export interface ComposeBasePatchOperation {
@@ -128,6 +155,15 @@ export interface ComposeAddStickerOperation extends ComposeBasePatchOperation {
 	/** Size normalized to the shorter project-canvas dimension (0..1). */
 	width?: number;
 	height?: number;
+	rotation?: number;
+	opacity?: number;
+	maintainAspectRatio?: boolean;
+	animationInType?: "none" | "fade" | "slide" | "scale" | "bounce";
+	animationInDuration?: number;
+	animationOutType?: "none" | "fade" | "slide" | "scale";
+	animationOutDuration?: number;
+	animationLoopType?: "none" | "pulse" | "float" | "spin" | "bounce";
+	animationLoopIntensity?: number;
 }
 
 export interface ComposeAddSoundEffectOperation
@@ -135,6 +171,11 @@ export interface ComposeAddSoundEffectOperation
 	kind: "add-sound-effect";
 	asset: ComposeAssetReference;
 	volume: number;
+	trimStart?: number;
+	trimEnd?: number;
+	fadeIn?: number;
+	fadeOut?: number;
+	playbackRate?: number;
 }
 
 export interface ComposeUpdateMediaZoomOperation
@@ -487,6 +528,117 @@ function validateStickerGeometry({
 			});
 		}
 	}
+	if (
+		operation.rotation !== undefined &&
+		!Number.isFinite(operation.rotation)
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-sticker-geometry",
+			path: `${path}.rotation`,
+			operationId: operation.id,
+			message: "Sticker rotation must be finite.",
+		});
+	}
+	if (
+		operation.opacity !== undefined &&
+		(!Number.isFinite(operation.opacity) ||
+			operation.opacity < 0 ||
+			operation.opacity > 1)
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-sticker-geometry",
+			path: `${path}.opacity`,
+			operationId: operation.id,
+			message: "Sticker opacity must be between 0 and 1.",
+		});
+	}
+	for (const key of ["animationInDuration", "animationOutDuration"] as const) {
+		const value = operation[key];
+		if (
+			value !== undefined &&
+			(!Number.isFinite(value) || value < 0 || value > operation.duration)
+		) {
+			issues.push({
+				severity: "error",
+				code: "invalid-sticker-geometry",
+				path: `${path}.${key}`,
+				operationId: operation.id,
+				message: "Sticker animation timing must fit inside the operation.",
+			});
+		}
+	}
+	if (
+		operation.animationLoopIntensity !== undefined &&
+		(!Number.isFinite(operation.animationLoopIntensity) ||
+			operation.animationLoopIntensity < 0 ||
+			operation.animationLoopIntensity > 2)
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-sticker-geometry",
+			path: `${path}.animationLoopIntensity`,
+			operationId: operation.id,
+			message: "Sticker loop intensity must be between 0 and 2.",
+		});
+	}
+}
+
+function validateSoundSettings({
+	operation,
+	path,
+	issues,
+}: {
+	operation: Extract<ComposePatchOperation, { kind: "add-sound-effect" }>;
+	path: string;
+	issues: ComposeValidationIssue[];
+}): void {
+	if (
+		!Number.isFinite(operation.volume) ||
+		operation.volume < 0 ||
+		operation.volume > 1
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-range",
+			path: `${path}.volume`,
+			operationId: operation.id,
+			message: "Sound-effect volume must be between 0 and 1.",
+		});
+	}
+	for (const key of ["trimStart", "trimEnd", "fadeIn", "fadeOut"] as const) {
+		const value = operation[key];
+		if (
+			value !== undefined &&
+			(!Number.isFinite(value) ||
+				value < 0 ||
+				((key === "fadeIn" || key === "fadeOut") && value > operation.duration))
+		) {
+			issues.push({
+				severity: "error",
+				code: "invalid-range",
+				path: `${path}.${key}`,
+				operationId: operation.id,
+				message:
+					"Sound trims must be non-negative and fades must fit inside the operation.",
+			});
+		}
+	}
+	if (
+		operation.playbackRate !== undefined &&
+		(!Number.isFinite(operation.playbackRate) ||
+			operation.playbackRate < 0.25 ||
+			operation.playbackRate > 4)
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-range",
+			path: `${path}.playbackRate`,
+			operationId: operation.id,
+			message: "Sound-effect playbackRate must be between 0.25 and 4.",
+		});
+	}
 }
 
 function requireTargetElement({
@@ -643,6 +795,9 @@ export function validateComposePatch({
 		}
 		if (operation.kind === "add-sticker") {
 			validateStickerGeometry({ operation, path, issues });
+		}
+		if (operation.kind === "add-sound-effect") {
+			validateSoundSettings({ operation, path, issues });
 		}
 		if (operation.kind === "add-text-overlay" && operation.asset) {
 			validateAssetReference({

--- a/qcut/electron/native-pipeline/compose/compose-resource-broker.ts
+++ b/qcut/electron/native-pipeline/compose/compose-resource-broker.ts
@@ -1,0 +1,350 @@
+import {
+	JIANYING_TRANSITIONS,
+	type JianyingTransitionDefinition,
+} from "../../jianying-transition-catalog.js";
+import { inspectJianyingTransitionRuntime } from "../../jianying-transition/runtime-discovery.js";
+import { resolveStickerLabRootOverride } from "../cli/sticker-lab-root.js";
+import {
+	discoverLocalReferences,
+	type LocalStickerLabDiscovery,
+} from "../stickers/local-reference-catalog/index.js";
+import {
+	listSoundEffectsLabAssets,
+	type ResolvedSoundEffectsLabAsset,
+} from "../sounds/sound-effects-lab-client.js";
+import {
+	defaultSoundEffectsLabManifestSource,
+	hasSoundEffectsLabCredentials,
+} from "../sounds/sound-effects-lab-config.js";
+import { TRANSITION_LAB_RECIPES } from "../transitions/transition-lab-catalog.js";
+import type {
+	ComposeAssetReference,
+	ComposeSnapshot,
+} from "./compose-protocol.js";
+
+const DEFAULT_PER_TYPE_LIMIT = 24;
+const MAX_PER_TYPE_LIMIT = 100;
+
+export interface ComposeResourceBrokerResult {
+	resources: ComposeAssetReference[];
+	warnings: string[];
+	capabilities: {
+		resourceBroker: true;
+		jianyingLocalTransitions: boolean;
+	};
+}
+
+export interface ComposeResourceBrokerDependencies {
+	discoverStickers: typeof discoverLocalReferences;
+	listSounds: typeof listSoundEffectsLabAssets;
+	inspectJianyingTransitions: typeof inspectJianyingTransitionRuntime;
+}
+
+const DEFAULT_DEPENDENCIES: ComposeResourceBrokerDependencies = {
+	discoverStickers: discoverLocalReferences,
+	listSounds: listSoundEffectsLabAssets,
+	inspectJianyingTransitions: inspectJianyingTransitionRuntime,
+};
+
+function errorMessage({ error }: { error: unknown }): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function normalizedLimit({ value }: { value?: number }): number {
+	if (!(typeof value === "number" && Number.isFinite(value) && value > 0)) {
+		return DEFAULT_PER_TYPE_LIMIT;
+	}
+	return Math.min(MAX_PER_TYPE_LIMIT, Math.floor(value));
+}
+
+function queryTerms({ query }: { query: string }): string[] {
+	const words = query.toLocaleLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+	const terms = new Set<string>();
+	for (const word of words) {
+		if (word.length > 1) terms.add(word);
+		if (!/[\u3400-\u9fff]/u.test(word)) continue;
+		for (let index = 0; index + 1 < word.length; index += 1) {
+			terms.add(word.slice(index, index + 2));
+		}
+	}
+	return [...terms].slice(0, 40);
+}
+
+function candidateScore({
+	query,
+	terms,
+	resource,
+}: {
+	query: string;
+	terms: string[];
+	resource: ComposeAssetReference;
+}): number {
+	const haystack = [
+		resource.displayName ?? "",
+		resource.assetId,
+		...(resource.tags ?? []),
+	]
+		.join(" ")
+		.toLocaleLowerCase();
+	const normalizedQuery = query.trim().toLocaleLowerCase();
+	let score = normalizedQuery && haystack.includes(normalizedQuery) ? 20 : 0;
+	for (const term of terms) {
+		if (haystack.includes(term)) score += term.length + 2;
+	}
+	return score;
+}
+
+function selectCandidates({
+	query,
+	resources,
+	limit,
+}: {
+	query: string;
+	resources: ComposeAssetReference[];
+	limit: number;
+}): ComposeAssetReference[] {
+	const terms = queryTerms({ query });
+	return resources
+		.map((resource, index) => ({
+			index,
+			resource,
+			score: candidateScore({ query, terms, resource }),
+		}))
+		.sort(
+			(left, right) =>
+				right.score - left.score ||
+				left.index - right.index ||
+				left.resource.assetId.localeCompare(right.resource.assetId)
+		)
+		.slice(0, limit)
+		.map(({ resource }) => resource);
+}
+
+function stickerResources({
+	discovery,
+}: {
+	discovery: LocalStickerLabDiscovery;
+}): ComposeAssetReference[] {
+	return discovery.catalogs.flatMap((catalog) =>
+		catalog.categories.flatMap((category) =>
+			category.items.map((item) => ({
+				provider: "local" as const,
+				assetType: "sticker" as const,
+				assetId: `sticker-lab:${catalog.batchId}:${item.id}`,
+				displayName: item.displayName,
+				tags: [category.label, category.sourcePanel, item.sourceKind],
+				availability: "ready" as const,
+				license: "personal-only" as const,
+				capabilities: {
+					preview: true,
+					editorApply: true,
+					editorExport: true,
+					headlessRender: item.runtimePackage === undefined,
+				},
+				provenance: {
+					backend: "sticker-lab",
+					batchId: catalog.batchId,
+					categoryId: category.id,
+					sourceKind: item.sourceKind,
+					animated: item.playback.kind === "animated",
+				},
+			}))
+		)
+	);
+}
+
+function soundResource({
+	asset,
+}: {
+	asset: ResolvedSoundEffectsLabAsset;
+}): ComposeAssetReference {
+	return {
+		provider: "qcut",
+		assetType: "sound-effect",
+		assetId: `sound-effects-lab:${asset.id}`,
+		displayName: asset.name,
+		tags: asset.tags,
+		duration: asset.durationSeconds ?? undefined,
+		availability: asset.localPath ? "ready" : "downloadable",
+		license: "commercial-ok",
+		capabilities: {
+			preview: true,
+			editorApply: true,
+			editorExport: true,
+			headlessRender: true,
+			requiresAuth: !asset.localPath,
+		},
+		provenance: {
+			backend: "sound-effects-lab",
+			provider: asset.provider,
+			redistribution: asset.redistribution,
+		},
+	};
+}
+
+function qcutTransitionResources(): ComposeAssetReference[] {
+	return TRANSITION_LAB_RECIPES.map((recipe) => ({
+		provider: "local",
+		assetType: "transition",
+		assetId: recipe.id,
+		displayName: recipe.localizedName,
+		tags: [recipe.name, recipe.clip.type, recipe.clip.direction ?? ""].filter(
+			(tag) => tag.length > 0
+		),
+		duration: recipe.defaultDuration,
+		availability: "ready",
+		license: "commercial-ok",
+		capabilities: {
+			preview: true,
+			editorApply: true,
+			editorExport: true,
+			headlessRender: false,
+		},
+		provenance: {
+			backend: "transition-lab",
+			origin: recipe.shader.origin,
+		},
+	}));
+}
+
+function jianyingTransitionResource({
+	transition,
+}: {
+	transition: JianyingTransitionDefinition;
+}): ComposeAssetReference {
+	return {
+		provider: "local",
+		assetType: "transition",
+		assetId: transition.id,
+		displayName: transition.localizedName,
+		tags: [
+			transition.name,
+			transition.group,
+			transition.family,
+			transition.preview.type,
+		],
+		duration: transition.defaultDuration,
+		availability: "ready",
+		license: "personal-only",
+		capabilities: {
+			preview: true,
+			editorApply: true,
+			editorExport: true,
+			headlessRender: false,
+			requiresLocalRuntime: true,
+		},
+		provenance: {
+			backend: "jianying-local",
+			group: transition.group,
+			access: transition.access,
+			runtimeKind: transition.runtimeKind,
+		},
+	};
+}
+
+export function composeResourceQuery({
+	snapshot,
+	intentQuery,
+}: {
+	snapshot: Pick<ComposeSnapshot, "captions" | "shots">;
+	intentQuery?: unknown;
+}): string {
+	if (typeof intentQuery === "string" && intentQuery.trim()) {
+		return intentQuery.trim().slice(0, 500);
+	}
+	return [
+		...snapshot.captions.map((caption) => caption.text),
+		...snapshot.shots.map((shot) => shot.label ?? ""),
+	]
+		.join(" ")
+		.trim()
+		.slice(0, 500);
+}
+
+export async function discoverComposeResources({
+	query = "",
+	perTypeLimit,
+	signal,
+	dependencies = DEFAULT_DEPENDENCIES,
+}: {
+	query?: string;
+	perTypeLimit?: number;
+	signal?: AbortSignal;
+	dependencies?: ComposeResourceBrokerDependencies;
+} = {}): Promise<ComposeResourceBrokerResult> {
+	const limit = normalizedLimit({ value: perTypeLimit });
+	const warnings: string[] = [];
+	const stickerPromise = dependencies
+		.discoverStickers({
+			rootPath: resolveStickerLabRootOverride({}),
+		})
+		.catch((error: unknown) => {
+			warnings.push(`Sticker Lab: ${errorMessage({ error })}`);
+			return null;
+		});
+	const soundSource = defaultSoundEffectsLabManifestSource();
+	const soundPromise = hasSoundEffectsLabCredentials({ source: soundSource })
+		? dependencies
+				.listSounds({ source: soundSource, signal })
+				.catch((error: unknown) => {
+					warnings.push(`Sound Effects Lab: ${errorMessage({ error })}`);
+					return [];
+				})
+		: Promise.resolve([]);
+	const transitionPromise = dependencies
+		.inspectJianyingTransitions()
+		.catch((error: unknown) => {
+			warnings.push(`Jianying transitions: ${errorMessage({ error })}`);
+			return null;
+		});
+
+	const [stickerDiscovery, sounds, transitionInspection] = await Promise.all([
+		stickerPromise,
+		soundPromise,
+		transitionPromise,
+	]);
+	const reusableSounds = sounds.filter((asset) => asset.reusable);
+	const restrictedSoundCount = sounds.length - reusableSounds.length;
+	if (restrictedSoundCount > 0) {
+		warnings.push(
+			`Sound Effects Lab omitted ${restrictedSoundCount} reference-only asset(s) from Compose candidates.`
+		);
+	}
+	const availableTransitionIds = new Set(
+		transitionInspection?.status.transitions
+			.filter((transition) => transition.available)
+			.map((transition) => transition.id) ?? []
+	);
+	const jianyingTransitions = JIANYING_TRANSITIONS.filter((transition) =>
+		availableTransitionIds.has(transition.id)
+	).map((transition) => jianyingTransitionResource({ transition }));
+
+	const resources = [
+		...selectCandidates({
+			query,
+			resources: stickerDiscovery
+				? stickerResources({ discovery: stickerDiscovery })
+				: [],
+			limit,
+		}),
+		...selectCandidates({
+			query,
+			resources: reusableSounds.map((asset) => soundResource({ asset })),
+			limit,
+		}),
+		...selectCandidates({
+			query,
+			resources: [...qcutTransitionResources(), ...jianyingTransitions],
+			limit,
+		}),
+	];
+
+	return {
+		resources,
+		warnings,
+		capabilities: {
+			resourceBroker: true,
+			jianyingLocalTransitions: jianyingTransitions.length > 0,
+		},
+	};
+}

--- a/qcut/electron/native-pipeline/compose/compose-snapshot.ts
+++ b/qcut/electron/native-pipeline/compose/compose-snapshot.ts
@@ -7,6 +7,10 @@ import {
 	type ComposeSnapshotCaption,
 	type ComposeSnapshotMedia,
 } from "./compose-protocol.js";
+import {
+	composeResourceQuery,
+	discoverComposeResources,
+} from "./compose-resource-broker.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -90,19 +94,21 @@ async function resolveActiveProjectId({
 
 /**
  * Reads the live editor over the Claude HTTP bridge and produces a
- * ComposeSnapshot. Beats, shots, and available resources stay empty until the
- * corresponding analyzers and resolvers join the pipeline.
+ * ComposeSnapshot. Resource candidates contain public identities and matching
+ * metadata only; local paths and private package hashes stay on the machine.
  */
 export async function captureComposeSnapshot({
 	client,
 	projectId,
 	snapshotId = randomUUID(),
 	createdAt = new Date().toISOString(),
+	discoverResources = discoverComposeResources,
 }: {
 	client: EditorApiClient;
 	projectId?: string;
 	snapshotId?: string;
 	createdAt?: string;
+	discoverResources?: typeof discoverComposeResources;
 }): Promise<ComposeSnapshot> {
 	const resolvedProjectId =
 		projectId ?? (await resolveActiveProjectId({ client }));
@@ -196,6 +202,9 @@ export async function captureComposeSnapshot({
 		},
 		duration: timelineEnd > 0 ? timelineEnd : 1,
 	};
+	const resourceBroker = await discoverResources({
+		query: composeResourceQuery({ snapshot: { captions, shots: [] } }),
+	});
 
 	return {
 		schemaVersion: COMPOSE_PROTOCOL_VERSION,
@@ -211,7 +220,15 @@ export async function captureComposeSnapshot({
 		captions,
 		beats: [],
 		shots: [],
-		availableResources: [],
-		capabilities: { headlessRender: true, editorApply: true },
+		availableResources: resourceBroker.resources,
+		...(resourceBroker.warnings.length > 0
+			? { resourceWarnings: resourceBroker.warnings }
+			: {}),
+		capabilities: {
+			headlessRender: true,
+			editorApply: true,
+			editorExport: true,
+			...resourceBroker.capabilities,
+		},
 	};
 }

--- a/qcut/electron/native-pipeline/compose/providers/compose-model-response.ts
+++ b/qcut/electron/native-pipeline/compose/providers/compose-model-response.ts
@@ -1,0 +1,506 @@
+import type {
+	ComposeAssetReference,
+	ComposeAssetType,
+	ComposePatchOperation,
+	ComposeSnapshot,
+} from "../compose-protocol.js";
+
+const KNOWN_OPERATION_KINDS = new Set([
+	"add-caption",
+	"add-text-overlay",
+	"add-sticker",
+	"add-sound-effect",
+	"update-media-zoom",
+	"upsert-transition",
+]);
+const BUILTIN_TRANSITION_PRESETS = new Set(["crossfade", "dissolve"]);
+const STICKER_ANIMATION_IN_TYPES = new Set([
+	"none",
+	"fade",
+	"slide",
+	"scale",
+	"bounce",
+] as const);
+const STICKER_ANIMATION_OUT_TYPES = new Set([
+	"none",
+	"fade",
+	"slide",
+	"scale",
+] as const);
+const STICKER_ANIMATION_LOOP_TYPES = new Set([
+	"none",
+	"pulse",
+	"float",
+	"spin",
+	"bounce",
+] as const);
+
+type StickerAnimationIn =
+	| "none"
+	| "fade"
+	| "slide"
+	| "scale"
+	| "bounce";
+type StickerAnimationOut = "none" | "fade" | "slide" | "scale";
+type StickerAnimationLoop = "none" | "pulse" | "float" | "spin" | "bounce";
+
+interface SanitizeContext {
+	projectDuration: number;
+	resources: ComposeAssetReference[];
+	targets: Set<string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField({
+	record,
+	key,
+}: {
+	record: Record<string, unknown>;
+	key: string;
+}): string | undefined {
+	const value = record[key];
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function finiteField({
+	record,
+	key,
+}: {
+	record: Record<string, unknown>;
+	key: string;
+}): number | undefined {
+	const value = record[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function boundedField({
+	record,
+	key,
+	min,
+	max,
+}: {
+	record: Record<string, unknown>;
+	key: string;
+	min: number;
+	max: number;
+}): number | undefined {
+	const value = finiteField({ record, key });
+	return value !== undefined && value >= min && value <= max
+		? value
+		: undefined;
+}
+
+function enumField<T extends string>({
+	record,
+	key,
+	allowed,
+}: {
+	record: Record<string, unknown>;
+	key: string;
+	allowed: ReadonlySet<T>;
+}): T | undefined {
+	const value = stringField({ record, key });
+	return value && allowed.has(value as T) ? (value as T) : undefined;
+}
+
+function portableAssetReference({
+	resource,
+}: {
+	resource: ComposeAssetReference;
+}): ComposeAssetReference {
+	return {
+		provider: resource.provider,
+		assetType: resource.assetType,
+		assetId: resource.assetId,
+		...(resource.displayName ? { displayName: resource.displayName } : {}),
+		...(resource.duration !== undefined ? { duration: resource.duration } : {}),
+		...(resource.license ? { license: resource.license } : {}),
+	};
+}
+
+function isUsableResource({
+	resource,
+}: {
+	resource: ComposeAssetReference;
+}): boolean {
+	return (
+		resource.availability !== "unavailable" &&
+		resource.availability !== "reference-only" &&
+		resource.capabilities?.editorApply !== false
+	);
+}
+
+function resolveAllowedAsset({
+	candidate,
+	expectedType,
+	resources,
+}: {
+	candidate: unknown;
+	expectedType: ComposeAssetType;
+	resources: ComposeAssetReference[];
+}): ComposeAssetReference | undefined {
+	const candidateRecord = isRecord(candidate) ? candidate : undefined;
+	const assetId =
+		typeof candidate === "string"
+			? candidate.trim()
+			: candidateRecord
+				? stringField({ record: candidateRecord, key: "assetId" })
+				: undefined;
+	if (!assetId) return;
+	const provider = candidateRecord
+		? stringField({ record: candidateRecord, key: "provider" })
+		: undefined;
+	const assetType = candidateRecord
+		? stringField({ record: candidateRecord, key: "assetType" })
+		: undefined;
+	if (assetType && assetType !== expectedType) return;
+
+	const matches = resources.filter(
+		(resource) =>
+			resource.assetType === expectedType &&
+			resource.assetId === assetId &&
+			(!provider || resource.provider === provider) &&
+			isUsableResource({ resource })
+	);
+	return matches.length === 1
+		? portableAssetReference({ resource: matches[0] })
+		: undefined;
+}
+
+function targetExists({
+	trackId,
+	elementId,
+	context,
+}: {
+	trackId: string;
+	elementId: string;
+	context: SanitizeContext;
+}): boolean {
+	return context.targets.has(`${trackId}:${elementId}`);
+}
+
+function sanitizeBase({
+	operation,
+	index,
+	context,
+}: {
+	operation: Record<string, unknown>;
+	index: number;
+	context: SanitizeContext;
+}):
+	| {
+			id: string;
+			kind: string;
+			startTime: number;
+			duration: number;
+			reason?: string;
+	  }
+	| undefined {
+	const kind = stringField({ record: operation, key: "kind" });
+	const startTime = finiteField({ record: operation, key: "startTime" });
+	const duration = finiteField({ record: operation, key: "duration" });
+	if (
+		!kind ||
+		!KNOWN_OPERATION_KINDS.has(kind) ||
+		startTime === undefined ||
+		startTime < 0 ||
+		duration === undefined ||
+		duration <= 0 ||
+		startTime + duration > context.projectDuration + 0.001
+	) {
+		return;
+	}
+	const reason = stringField({ record: operation, key: "reason" });
+	return {
+		id: `openrouter:${kind}:${index}`,
+		kind,
+		startTime,
+		duration,
+		...(reason ? { reason } : {}),
+	};
+}
+
+function sanitizeSticker({
+	operation,
+	base,
+	context,
+}: {
+	operation: Record<string, unknown>;
+	base: NonNullable<ReturnType<typeof sanitizeBase>>;
+	context: SanitizeContext;
+}): ComposePatchOperation | undefined {
+	const asset = resolveAllowedAsset({
+		candidate: operation.asset ?? operation.assetId,
+		expectedType: "sticker",
+		resources: context.resources,
+	});
+	if (!asset) return;
+	const x = boundedField({ record: operation, key: "x", min: 0, max: 1 });
+	const y = boundedField({ record: operation, key: "y", min: 0, max: 1 });
+	const width = boundedField({
+		record: operation,
+		key: "width",
+		min: 0,
+		max: 1,
+	});
+	const height = boundedField({
+		record: operation,
+		key: "height",
+		min: 0,
+		max: 1,
+	});
+	const rotation = finiteField({ record: operation, key: "rotation" });
+	const opacity = boundedField({
+		record: operation,
+		key: "opacity",
+		min: 0,
+		max: 1,
+	});
+	const animationInType = enumField<StickerAnimationIn>({
+		record: operation,
+		key: "animationInType",
+		allowed: STICKER_ANIMATION_IN_TYPES,
+	});
+	const animationOutType = enumField<StickerAnimationOut>({
+		record: operation,
+		key: "animationOutType",
+		allowed: STICKER_ANIMATION_OUT_TYPES,
+	});
+	const animationLoopType = enumField<StickerAnimationLoop>({
+		record: operation,
+		key: "animationLoopType",
+		allowed: STICKER_ANIMATION_LOOP_TYPES,
+	});
+	const animationInDuration = boundedField({
+		record: operation,
+		key: "animationInDuration",
+		min: 0,
+		max: base.duration,
+	});
+	const animationOutDuration = boundedField({
+		record: operation,
+		key: "animationOutDuration",
+		min: 0,
+		max: base.duration,
+	});
+	const animationLoopIntensity = boundedField({
+		record: operation,
+		key: "animationLoopIntensity",
+		min: 0,
+		max: 2,
+	});
+	return {
+		...base,
+		kind: "add-sticker",
+		asset,
+		...(x !== undefined ? { x } : {}),
+		...(y !== undefined ? { y } : {}),
+		...(width !== undefined ? { width } : {}),
+		...(height !== undefined ? { height } : {}),
+		...(rotation !== undefined ? { rotation } : {}),
+		...(opacity !== undefined ? { opacity } : {}),
+		...(typeof operation.maintainAspectRatio === "boolean"
+			? { maintainAspectRatio: operation.maintainAspectRatio }
+			: {}),
+		...(animationInType ? { animationInType } : {}),
+		...(animationInDuration !== undefined ? { animationInDuration } : {}),
+		...(animationOutType ? { animationOutType } : {}),
+		...(animationOutDuration !== undefined ? { animationOutDuration } : {}),
+		...(animationLoopType ? { animationLoopType } : {}),
+		...(animationLoopIntensity !== undefined
+			? { animationLoopIntensity }
+			: {}),
+	};
+}
+
+function sanitizeSound({
+	operation,
+	base,
+	context,
+}: {
+	operation: Record<string, unknown>;
+	base: NonNullable<ReturnType<typeof sanitizeBase>>;
+	context: SanitizeContext;
+}): ComposePatchOperation | undefined {
+	const asset = resolveAllowedAsset({
+		candidate: operation.asset ?? operation.assetId,
+		expectedType: "sound-effect",
+		resources: context.resources,
+	});
+	const volume = boundedField({
+		record: operation,
+		key: "volume",
+		min: 0,
+		max: 1,
+	});
+	if (!(asset && volume !== undefined)) return;
+	const trimStart = boundedField({
+		record: operation,
+		key: "trimStart",
+		min: 0,
+		max: Number.MAX_SAFE_INTEGER,
+	});
+	const trimEnd = boundedField({
+		record: operation,
+		key: "trimEnd",
+		min: 0,
+		max: Number.MAX_SAFE_INTEGER,
+	});
+	const fadeIn = boundedField({
+		record: operation,
+		key: "fadeIn",
+		min: 0,
+		max: base.duration,
+	});
+	const fadeOut = boundedField({
+		record: operation,
+		key: "fadeOut",
+		min: 0,
+		max: base.duration,
+	});
+	const playbackRate = boundedField({
+		record: operation,
+		key: "playbackRate",
+		min: 0.25,
+		max: 4,
+	});
+	if (
+		asset.duration !== undefined &&
+		(trimStart ?? 0) + (trimEnd ?? 0) + base.duration > asset.duration + 0.001
+	) {
+		return;
+	}
+	return {
+		...base,
+		kind: "add-sound-effect",
+		asset,
+		volume,
+		...(trimStart !== undefined ? { trimStart } : {}),
+		...(trimEnd !== undefined ? { trimEnd } : {}),
+		...(fadeIn !== undefined ? { fadeIn } : {}),
+		...(fadeOut !== undefined ? { fadeOut } : {}),
+		...(playbackRate !== undefined ? { playbackRate } : {}),
+	};
+}
+
+function sanitizeOperation({
+	operation,
+	index,
+	context,
+}: {
+	operation: Record<string, unknown>;
+	index: number;
+	context: SanitizeContext;
+}): ComposePatchOperation | undefined {
+	const base = sanitizeBase({ operation, index, context });
+	if (!base) return;
+
+	switch (base.kind) {
+		case "add-caption": {
+			const text = stringField({ record: operation, key: "text" });
+			const language = stringField({ record: operation, key: "language" });
+			return text && language
+				? { ...base, kind: "add-caption", text, language }
+				: undefined;
+		}
+		case "add-text-overlay": {
+			const text = stringField({ record: operation, key: "text" });
+			const textTemplateId = stringField({
+				record: operation,
+				key: "textTemplateId",
+			});
+			return text && textTemplateId
+				? { ...base, kind: "add-text-overlay", text, textTemplateId }
+				: undefined;
+		}
+		case "add-sticker":
+			return sanitizeSticker({ operation, base, context });
+		case "add-sound-effect":
+			return sanitizeSound({ operation, base, context });
+		case "update-media-zoom": {
+			const trackId = stringField({ record: operation, key: "trackId" });
+			const elementId = stringField({ record: operation, key: "elementId" });
+			const fromScale = finiteField({ record: operation, key: "fromScale" });
+			const toScale = finiteField({ record: operation, key: "toScale" });
+			return trackId &&
+				elementId &&
+				fromScale !== undefined &&
+				toScale !== undefined &&
+				targetExists({ trackId, elementId, context })
+				? {
+						...base,
+						kind: "update-media-zoom",
+						trackId,
+						elementId,
+						fromScale,
+						toScale,
+					}
+				: undefined;
+		}
+		case "upsert-transition": {
+			const trackId = stringField({ record: operation, key: "trackId" });
+			const fromElementId = stringField({
+				record: operation,
+				key: "fromElementId",
+			});
+			const toElementId = stringField({
+				record: operation,
+				key: "toElementId",
+			});
+			const presetId = stringField({ record: operation, key: "presetId" });
+			if (
+				!(trackId && fromElementId && toElementId && presetId) ||
+				!targetExists({ trackId, elementId: fromElementId, context }) ||
+				!targetExists({ trackId, elementId: toElementId, context })
+			) {
+				return;
+			}
+			const asset = BUILTIN_TRANSITION_PRESETS.has(presetId)
+				? undefined
+				: resolveAllowedAsset({
+						candidate: operation.asset ?? presetId,
+						expectedType: "transition",
+						resources: context.resources,
+					});
+			if (!BUILTIN_TRANSITION_PRESETS.has(presetId) && !asset) return;
+			return {
+				...base,
+				kind: "upsert-transition",
+				trackId,
+				fromElementId,
+				toElementId,
+				presetId: asset?.assetId ?? presetId,
+				...(asset ? { asset } : {}),
+			};
+		}
+	}
+}
+
+export function sanitizeComposeModelOperations({
+	value,
+	snapshot,
+}: {
+	value: unknown;
+	snapshot: ComposeSnapshot;
+}): ComposePatchOperation[] {
+	if (!isRecord(value) || !Array.isArray(value.operations)) {
+		throw new Error("The model response has no operations array.");
+	}
+	const context: SanitizeContext = {
+		projectDuration: snapshot.project.duration,
+		resources: snapshot.availableResources,
+		targets: new Set(
+			snapshot.media.map(({ trackId, elementId }) => `${trackId}:${elementId}`)
+		),
+	};
+	const operations: ComposePatchOperation[] = [];
+	for (const [index, candidate] of value.operations.entries()) {
+		if (!isRecord(candidate)) continue;
+		const operation = sanitizeOperation({ operation: candidate, index, context });
+		if (operation) operations.push(operation);
+	}
+	return operations;
+}

--- a/qcut/electron/native-pipeline/compose/providers/openrouter-compose-provider.ts
+++ b/qcut/electron/native-pipeline/compose/providers/openrouter-compose-provider.ts
@@ -1,5 +1,4 @@
 import type {
-	ComposeIntent,
 	ComposeJobError,
 	ComposePatch,
 	ComposePatchOperation,
@@ -13,18 +12,11 @@ import {
 	transitionComposeJob,
 	type ComposeProviderAdapter,
 } from "./compose-provider.js";
+import { sanitizeComposeModelOperations } from "./compose-model-response.js";
 
 const OPENROUTER_COMPLETIONS_URL =
 	"https://openrouter.ai/api/v1/chat/completions";
 const DEFAULT_MODEL = "google/gemini-3.7-flash";
-const KNOWN_OPERATION_KINDS = new Set([
-	"add-caption",
-	"add-text-overlay",
-	"add-sticker",
-	"add-sound-effect",
-	"update-media-zoom",
-	"upsert-transition",
-]);
 
 export interface OpenRouterComposeProviderDependencies {
 	fetchImpl?: typeof fetch;
@@ -36,18 +28,33 @@ export interface OpenRouterComposeProviderDependencies {
 
 function systemPrompt(): string {
 	return [
-		"You plan QCut timeline patches. Respond with a JSON object:",
-		'{"operations": [...]}. Each operation needs kind, startTime, duration.',
-		'Kinds: "add-text-overlay" (text, textTemplateId), "add-caption" (text,',
-		'language), "upsert-transition" (trackId, fromElementId, toElementId,',
-		'presetId of "crossfade"|"dissolve"), "update-media-zoom" (trackId,',
-		"elementId, fromScale, toScale). Only reference elementIds present in",
-		"the snapshot. Respond with JSON only, no prose.",
+		"You plan a QCut timeline patch. Respond with JSON only:",
+		'{"operations": [...]}. Every operation needs kind, startTime, duration.',
+		'Use "add-text-overlay" (text, textTemplateId), "add-caption" (text, language),',
+		'"add-sticker" (asset, optional x/y/width/height/rotation/opacity and animation fields),',
+		'"add-sound-effect" (asset, volume 0..1, optional trimStart/trimEnd/fadeIn/fadeOut),',
+		'"upsert-transition" (trackId, fromElementId, toElementId, presetId), or',
+		'"update-media-zoom" (trackId, elementId, fromScale, toScale).',
+		"For sticker, sound-effect, and non-builtin transition assets, copy provider,",
+		"assetType, and assetId exactly from availableResources. Never invent an asset ID.",
+		"Only target elementIds and trackIds present in the snapshot. Keep effects sparse,",
+		"avoid overlaps, and keep every operation inside the project duration.",
 	].join(" ");
 }
 
 /** The upload payload carries timeline structure only — never local paths. */
 function snapshotSummary({ snapshot }: { snapshot: ComposeSnapshot }): string {
+	const availableResources = snapshot.availableResources.map((resource) => ({
+		provider: resource.provider,
+		assetType: resource.assetType,
+		assetId: resource.assetId,
+		displayName: resource.displayName,
+		tags: resource.tags,
+		duration: resource.duration,
+		availability: resource.availability,
+		license: resource.license,
+		capabilities: resource.capabilities,
+	}));
 	return JSON.stringify({
 		project: snapshot.project,
 		media: snapshot.media.map(
@@ -64,6 +71,8 @@ function snapshotSummary({ snapshot }: { snapshot: ComposeSnapshot }): string {
 		captions: snapshot.captions,
 		beats: snapshot.beats,
 		shots: snapshot.shots,
+		availableResources,
+		capabilities: snapshot.capabilities,
 	});
 }
 
@@ -115,37 +124,6 @@ function extractJson({ content }: { content: string }): unknown {
 	return JSON.parse(unfenced);
 }
 
-function sanitizeOperations({
-	value,
-}: {
-	value: unknown;
-}): ComposePatchOperation[] {
-	const record = value as { operations?: unknown };
-	if (!Array.isArray(record?.operations)) {
-		throw new Error("The model response has no operations array.");
-	}
-	const operations: ComposePatchOperation[] = [];
-	for (const [index, candidate] of record.operations.entries()) {
-		if (typeof candidate !== "object" || candidate === null) continue;
-		const operation = candidate as Record<string, unknown>;
-		const kind = operation.kind;
-		if (typeof kind !== "string" || !KNOWN_OPERATION_KINDS.has(kind)) {
-			continue;
-		}
-		if (
-			typeof operation.startTime !== "number" ||
-			typeof operation.duration !== "number"
-		) {
-			continue;
-		}
-		operations.push({
-			...(operation as unknown as ComposePatchOperation),
-			id: `openrouter:${kind}:${index}`,
-		});
-	}
-	return operations;
-}
-
 /**
  * Plans a patch with an OpenRouter-routed model. The request carries a
  * path-free snapshot summary; the API key lives only in the request header
@@ -174,7 +152,7 @@ export function createOpenRouterComposeProvider({
 						{ role: "system", content: systemPrompt() },
 						{
 							role: "user",
-							content: `Intent: ${intent.kind}. Snapshot: ${snapshotSummary({ snapshot })}`,
+							content: `Intent: ${intent.kind}. Options: ${JSON.stringify(intent.options)}. Snapshot: ${snapshotSummary({ snapshot })}`,
 						},
 					],
 				};
@@ -258,8 +236,9 @@ export function createOpenRouterComposeProvider({
 			}
 			let operations: ComposePatchOperation[];
 			try {
-				operations = sanitizeOperations({
+				operations = sanitizeComposeModelOperations({
 					value: extractJson({ content }),
+					snapshot,
 				});
 			} catch (error) {
 				return transitionComposeJob({

--- a/qcut/electron/native-pipeline/sounds/sound-effects-lab-client.ts
+++ b/qcut/electron/native-pipeline/sounds/sound-effects-lab-client.ts
@@ -1,6 +1,14 @@
+import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { SoundSearchResult } from "./freesound-client.js";
+import {
+	defaultSoundEffectsLabManifestSource,
+	soundEffectsLabAssetsUrl,
+	type SoundEffectsLabManifestSource,
+} from "./sound-effects-lab-config.js";
+
+export type { SoundEffectsLabManifestSource } from "./sound-effects-lab-config.js";
 
 /**
  * The renderer owns the authoritative zod schema for this manifest
@@ -14,8 +22,21 @@ interface ManifestItem {
 	title?: unknown;
 	duration?: unknown;
 	fileName?: unknown;
+	filePath?: unknown;
+	byteSize?: unknown;
+	contentSha256?: unknown;
+	mimeType?: unknown;
 	categoryIds?: unknown;
-	asset?: { objectKey?: unknown };
+	asset?: {
+		objectKey?: unknown;
+		byteSize?: unknown;
+		checksumSha256?: unknown;
+	};
+	source?: {
+		provider?: unknown;
+		redistribution?: unknown;
+		license?: unknown;
+	};
 }
 
 interface ManifestCategory {
@@ -46,12 +67,21 @@ function categoryLabels({
 	return labels;
 }
 
-export interface SoundEffectsLabManifestSource {
-	/** Absolute path to a manifest JSON file. */
-	manifestPath?: string;
-	/** URL of the private manifest, served by the license server. */
-	manifestUrl?: string;
-	headers?: Record<string, string>;
+export interface ResolvedSoundEffectsLabAsset {
+	id: string;
+	name: string;
+	durationSeconds: number | null;
+	tags: string[];
+	categoryIds: string[];
+	fileName?: string;
+	localPath?: string;
+	objectKey?: string;
+	byteSize?: number;
+	checksumSha256?: string;
+	mimeType?: string;
+	provider: "freesound" | "jianying-reference" | "unknown";
+	redistribution: "allowed" | "prohibited" | "unknown";
+	reusable: boolean;
 }
 
 async function readManifestJson({
@@ -69,10 +99,16 @@ async function readManifestJson({
 	if (!source.manifestUrl) {
 		throw new Error("Provide --manifest or --manifest-url");
 	}
-	const response = await fetchImpl(source.manifestUrl, {
+	let response = await fetchImpl(source.manifestUrl, {
 		headers: source.headers,
 		signal,
 	});
+	if (response.status === 404 && source.fallbackManifestUrl) {
+		response = await fetchImpl(source.fallbackManifestUrl, {
+			headers: source.headers,
+			signal,
+		});
+	}
 	if (response.status === 401 || response.status === 403) {
 		throw new Error(
 			"The Sound Effects Lab catalog is private. Sign in with an allowlisted account: qcut system login"
@@ -86,12 +122,120 @@ async function readManifestJson({
 	return response.json();
 }
 
-/**
- * Writes one catalog asset to disk. The manifest marks this audio
- * `internal-reference` with `redistribution: prohibited`, so this deliberately
- * only materialises to a caller-chosen local path and never uploads or copies
- * anything into the repository.
- */
+function finitePositiveNumber({
+	value,
+}: {
+	value: unknown;
+}): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0
+		? value
+		: undefined;
+}
+
+function resolvedAsset({
+	entry,
+	labels,
+}: {
+	entry: ManifestItem;
+	labels: Map<string, string>;
+}): ResolvedSoundEffectsLabAsset | null {
+	const name = stringValue({ value: entry.title });
+	const id = stringValue({ value: entry.id });
+	if (!(name && id)) return null;
+	const categoryIds = stringArray({ value: entry.categoryIds });
+	const tags = categoryIds
+		.map((categoryId) => labels.get(categoryId))
+		.filter((label): label is string => label !== undefined);
+	const sourceProvider = stringValue({ value: entry.source?.provider });
+	const redistribution = stringValue({ value: entry.source?.redistribution });
+	const provider =
+		sourceProvider === "freesound" || sourceProvider === "jianying-reference"
+			? sourceProvider
+			: "unknown";
+	const normalizedRedistribution =
+		redistribution === "allowed" || redistribution === "prohibited"
+			? redistribution
+			: "unknown";
+	const checksumSha256 =
+		stringValue({ value: entry.contentSha256 }) ??
+		stringValue({ value: entry.asset?.checksumSha256 });
+	return {
+		id,
+		name,
+		durationSeconds: typeof entry.duration === "number" ? entry.duration : null,
+		tags,
+		categoryIds,
+		fileName: stringValue({ value: entry.fileName }),
+		localPath: stringValue({ value: entry.filePath }),
+		objectKey: stringValue({ value: entry.asset?.objectKey }),
+		byteSize:
+			finitePositiveNumber({ value: entry.byteSize }) ??
+			finitePositiveNumber({ value: entry.asset?.byteSize }),
+		checksumSha256,
+		mimeType: stringValue({ value: entry.mimeType }),
+		provider,
+		redistribution: normalizedRedistribution,
+		reusable:
+			provider === "freesound" && normalizedRedistribution === "allowed",
+	};
+}
+
+async function readResolvedAssets({
+	source,
+	signal,
+	fetchImpl,
+}: {
+	source: SoundEffectsLabManifestSource;
+	signal?: AbortSignal;
+	fetchImpl: typeof fetch;
+}): Promise<ResolvedSoundEffectsLabAsset[]> {
+	const manifest = await readManifestJson({ source, signal, fetchImpl });
+	if (typeof manifest !== "object" || manifest === null) {
+		throw new Error("Sound Effects Lab manifest is not a JSON object");
+	}
+	const record = manifest as { items?: unknown; categories?: unknown };
+	if (!Array.isArray(record.items)) {
+		throw new Error("Sound Effects Lab manifest has no items array");
+	}
+	const labels = categoryLabels({
+		categories: Array.isArray(record.categories)
+			? (record.categories as ManifestCategory[])
+			: [],
+	});
+	return (record.items as ManifestItem[]).flatMap((entry) => {
+		const asset = resolvedAsset({ entry, labels });
+		return asset ? [asset] : [];
+	});
+}
+
+export async function listSoundEffectsLabAssets({
+	source = defaultSoundEffectsLabManifestSource(),
+	signal,
+	fetchImpl = fetch,
+}: {
+	source?: SoundEffectsLabManifestSource;
+	signal?: AbortSignal;
+	fetchImpl?: typeof fetch;
+} = {}): Promise<ResolvedSoundEffectsLabAsset[]> {
+	return readResolvedAssets({ source, signal, fetchImpl });
+}
+
+export async function resolveSoundEffectsLabAsset({
+	assetId,
+	source = defaultSoundEffectsLabManifestSource(),
+	signal,
+	fetchImpl = fetch,
+}: {
+	assetId: string;
+	source?: SoundEffectsLabManifestSource;
+	signal?: AbortSignal;
+	fetchImpl?: typeof fetch;
+}): Promise<ResolvedSoundEffectsLabAsset | null> {
+	const assets = await readResolvedAssets({ source, signal, fetchImpl });
+	return assets.find((asset) => asset.id === assetId) ?? null;
+}
+
+/** Writes one authenticated catalog asset to a caller-chosen local path. */
 export async function downloadSoundEffectsLabAsset({
 	objectKey,
 	assetsUrl,
@@ -99,6 +243,8 @@ export async function downloadSoundEffectsLabAsset({
 	destinationPath,
 	signal,
 	fetchImpl = fetch,
+	expectedByteSize,
+	expectedChecksumSha256,
 }: {
 	objectKey: string;
 	assetsUrl: string;
@@ -106,6 +252,8 @@ export async function downloadSoundEffectsLabAsset({
 	destinationPath: string;
 	signal?: AbortSignal;
 	fetchImpl?: typeof fetch;
+	expectedByteSize?: number;
+	expectedChecksumSha256?: string;
 }): Promise<string> {
 	const url = `${assetsUrl}?objectKey=${encodeURIComponent(objectKey)}`;
 	const response = await fetchImpl(url, { headers, signal });
@@ -119,12 +267,73 @@ export async function downloadSoundEffectsLabAsset({
 			`Unable to fetch the Sound Effects Lab asset (status ${response.status})`
 		);
 	}
+	const bytes = new Uint8Array(await response.arrayBuffer());
+	if (expectedByteSize !== undefined && bytes.byteLength !== expectedByteSize) {
+		throw new Error(
+			`Sound Effects Lab asset size mismatch (expected ${expectedByteSize}, got ${bytes.byteLength})`
+		);
+	}
+	if (expectedChecksumSha256) {
+		const digest = createHash("sha256").update(bytes).digest("hex");
+		if (digest !== expectedChecksumSha256.toLowerCase()) {
+			throw new Error("Sound Effects Lab asset checksum mismatch");
+		}
+	}
 	await mkdir(dirname(destinationPath), { recursive: true });
-	await writeFile(
-		destinationPath,
-		new Uint8Array(await response.arrayBuffer())
-	);
+	await writeFile(destinationPath, bytes);
 	return destinationPath;
+}
+
+export async function materializeSoundEffectsLabAsset({
+	asset,
+	destinationPath,
+	source = defaultSoundEffectsLabManifestSource(),
+	signal,
+	fetchImpl = fetch,
+}: {
+	asset: ResolvedSoundEffectsLabAsset;
+	destinationPath: string;
+	source?: SoundEffectsLabManifestSource;
+	signal?: AbortSignal;
+	fetchImpl?: typeof fetch;
+}): Promise<string> {
+	if (!asset.reusable) {
+		throw new Error(
+			`Sound Effects Lab asset ${asset.id} is reference-only and cannot be added to a QCut project`
+		);
+	}
+	if (asset.localPath) {
+		const bytes = await readFile(asset.localPath);
+		if (asset.byteSize !== undefined && bytes.byteLength !== asset.byteSize) {
+			throw new Error(`Sound Effects Lab asset size mismatch: ${asset.id}`);
+		}
+		if (asset.checksumSha256) {
+			const digest = createHash("sha256").update(bytes).digest("hex");
+			if (digest !== asset.checksumSha256.toLowerCase()) {
+				throw new Error(
+					`Sound Effects Lab asset checksum mismatch: ${asset.id}`
+				);
+			}
+		}
+		await mkdir(dirname(destinationPath), { recursive: true });
+		await writeFile(destinationPath, bytes);
+		return destinationPath;
+	}
+	if (!(asset.objectKey && asset.fileName)) {
+		throw new Error(
+			`Sound Effects Lab asset has no readable source: ${asset.id}`
+		);
+	}
+	return downloadSoundEffectsLabAsset({
+		objectKey: asset.objectKey,
+		assetsUrl: soundEffectsLabAssetsUrl(),
+		headers: source.headers,
+		destinationPath,
+		signal,
+		fetchImpl,
+		expectedByteSize: asset.byteSize,
+		expectedChecksumSha256: asset.checksumSha256,
+	});
 }
 
 function matches({
@@ -154,40 +363,20 @@ export async function searchSoundEffectsLab({
 	signal?: AbortSignal;
 	fetchImpl?: typeof fetch;
 }): Promise<SoundSearchResult[]> {
-	const manifest = await readManifestJson({ source, signal, fetchImpl });
-	if (typeof manifest !== "object" || manifest === null) {
-		throw new Error("Sound Effects Lab manifest is not a JSON object");
-	}
-	const record = manifest as { items?: unknown; categories?: unknown };
-	if (!Array.isArray(record.items)) {
-		throw new Error("Sound Effects Lab manifest has no items array");
-	}
-	const labels = categoryLabels({
-		categories: Array.isArray(record.categories)
-			? (record.categories as ManifestCategory[])
-			: [],
-	});
-
+	const assets = await readResolvedAssets({ source, signal, fetchImpl });
 	const results: SoundSearchResult[] = [];
-	for (const entry of record.items as ManifestItem[]) {
-		const title = stringValue({ value: entry.title });
-		const id = stringValue({ value: entry.id });
-		if (!(title && id)) continue;
-		const categoryIds = stringArray({ value: entry.categoryIds });
-		const categoryNames = categoryIds
-			.map((categoryId) => labels.get(categoryId))
-			.filter((label): label is string => label !== undefined);
-		if (!matches({ query, title, labels: categoryNames })) continue;
+	for (const asset of assets) {
+		if (!matches({ query, title: asset.name, labels: asset.tags })) continue;
 		results.push({
 			source: "sound-effects-lab",
-			id,
-			name: title,
-			durationSeconds:
-				typeof entry.duration === "number" ? entry.duration : null,
-			tags: categoryNames,
-			categoryIds,
-			fileName: stringValue({ value: entry.fileName }),
-			objectKey: stringValue({ value: entry.asset?.objectKey }),
+			id: asset.id,
+			name: asset.name,
+			durationSeconds: asset.durationSeconds,
+			tags: asset.tags,
+			categoryIds: asset.categoryIds,
+			fileName: asset.fileName,
+			objectKey: asset.objectKey,
+			license: asset.reusable ? "CC0-1.0" : "reference-only",
 		});
 		if (results.length >= limit) break;
 	}

--- a/qcut/electron/native-pipeline/sounds/sound-effects-lab-config.ts
+++ b/qcut/electron/native-pipeline/sounds/sound-effects-lab-config.ts
@@ -1,0 +1,68 @@
+import { resolve } from "node:path";
+import { getKey } from "../infra/key-manager.js";
+
+export const SOUND_EFFECTS_LAB_LICENSE_SERVER_URL =
+	process.env.QCUT_LICENSE_SERVER_URL ||
+	"https://qcut-license-server.zdhpeter.workers.dev";
+
+export interface SoundEffectsLabManifestSource {
+	/** Absolute path to a manifest JSON file. */
+	manifestPath?: string;
+	/** URL of the private manifest, served by the license server. */
+	manifestUrl?: string;
+	fallbackManifestUrl?: string;
+	headers?: Record<string, string>;
+}
+
+export function isSoundEffectsLabServerUrl({ url }: { url: string }): boolean {
+	try {
+		return (
+			new URL(url).origin ===
+			new URL(SOUND_EFFECTS_LAB_LICENSE_SERVER_URL).origin
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function defaultSoundEffectsLabManifestSource({
+	manifestPath,
+	manifestUrl,
+}: {
+	manifestPath?: string;
+	manifestUrl?: string;
+} = {}): SoundEffectsLabManifestSource {
+	const requestedPath =
+		manifestPath ?? process.env.QCUT_SOUND_EFFECTS_LAB_MANIFEST_PATH;
+	if (requestedPath) return { manifestPath: resolve(requestedPath) };
+
+	const serverUrl = SOUND_EFFECTS_LAB_LICENSE_SERVER_URL.replace(/\/+$/, "");
+	const requestedUrl =
+		manifestUrl ??
+		process.env.QCUT_SOUND_EFFECTS_LAB_MANIFEST_URL ??
+		`${serverUrl}/api/sound-effects-lab/private-manifest/enriched?includeAliases=1`;
+	const token = isSoundEffectsLabServerUrl({ url: requestedUrl })
+		? getKey("QCUT_AUTH_TOKEN")
+		: undefined;
+	return {
+		manifestUrl: requestedUrl,
+		...(requestedUrl.includes("/private-manifest/enriched")
+			? {
+					fallbackManifestUrl: `${serverUrl}/api/sound-effects-lab/private-manifest`,
+				}
+			: {}),
+		...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+	};
+}
+
+export function soundEffectsLabAssetsUrl(): string {
+	return `${SOUND_EFFECTS_LAB_LICENSE_SERVER_URL.replace(/\/+$/, "")}/api/sound-effects-lab/assets`;
+}
+
+export function hasSoundEffectsLabCredentials({
+	source = defaultSoundEffectsLabManifestSource(),
+}: {
+	source?: SoundEffectsLabManifestSource;
+} = {}): boolean {
+	return Boolean(source.manifestPath || source.headers?.Authorization);
+}

--- a/qcut/packages/editor-core/src/compose/compose-types.ts
+++ b/qcut/packages/editor-core/src/compose/compose-types.ts
@@ -39,10 +39,30 @@ export type ComposeAssetType =
 
 export type ComposeAssetLicense = "commercial-ok" | "personal-only" | "unknown";
 
+export type ComposeAssetAvailability =
+	| "ready"
+	| "downloadable"
+	| "reference-only"
+	| "unavailable";
+
+export interface ComposeAssetCapabilities {
+	preview: boolean;
+	editorApply: boolean;
+	editorExport: boolean;
+	headlessRender: boolean;
+	requiresAuth?: boolean;
+	requiresLocalRuntime?: boolean;
+}
+
 export interface ComposeAssetReference {
 	provider: ComposeProvider;
 	assetType: ComposeAssetType;
 	assetId: string;
+	displayName?: string;
+	tags?: string[];
+	duration?: number;
+	availability?: ComposeAssetAvailability;
+	capabilities?: ComposeAssetCapabilities;
 	cacheKey?: string;
 	localPath?: string;
 	license?: ComposeAssetLicense;
@@ -102,6 +122,9 @@ export interface ComposeSnapshotShot {
 export interface ComposeSnapshotCapabilities {
 	headlessRender: boolean;
 	editorApply: boolean;
+	editorExport?: boolean;
+	resourceBroker?: boolean;
+	jianyingLocalTransitions?: boolean;
 }
 
 export interface ComposeSnapshot {
@@ -115,6 +138,7 @@ export interface ComposeSnapshot {
 	beats: ComposeSnapshotBeat[];
 	shots: ComposeSnapshotShot[];
 	availableResources: ComposeAssetReference[];
+	resourceWarnings?: string[];
 	capabilities: ComposeSnapshotCapabilities;
 }
 
@@ -187,6 +211,15 @@ export interface ComposeAddStickerOperation extends ComposeBasePatchOperation {
 	/** Size normalized to the shorter project-canvas dimension (0..1). */
 	width?: number;
 	height?: number;
+	rotation?: number;
+	opacity?: number;
+	maintainAspectRatio?: boolean;
+	animationInType?: "none" | "fade" | "slide" | "scale" | "bounce";
+	animationInDuration?: number;
+	animationOutType?: "none" | "fade" | "slide" | "scale";
+	animationOutDuration?: number;
+	animationLoopType?: "none" | "pulse" | "float" | "spin" | "bounce";
+	animationLoopIntensity?: number;
 }
 
 export interface ComposeAddSoundEffectOperation
@@ -194,6 +227,11 @@ export interface ComposeAddSoundEffectOperation
 	kind: "add-sound-effect";
 	asset: ComposeAssetReference;
 	volume: number;
+	trimStart?: number;
+	trimEnd?: number;
+	fadeIn?: number;
+	fadeOut?: number;
+	playbackRate?: number;
 }
 
 export interface ComposeUpdateMediaZoomOperation

--- a/qcut/packages/editor-core/src/compose/compose-validation.ts
+++ b/qcut/packages/editor-core/src/compose/compose-validation.ts
@@ -205,6 +205,117 @@ function validateStickerGeometry({
 			});
 		}
 	}
+	if (
+		operation.rotation !== undefined &&
+		!Number.isFinite(operation.rotation)
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-sticker-geometry",
+			path: `${path}.rotation`,
+			operationId: operation.id,
+			message: "Sticker rotation must be finite.",
+		});
+	}
+	if (
+		operation.opacity !== undefined &&
+		(!Number.isFinite(operation.opacity) ||
+			operation.opacity < 0 ||
+			operation.opacity > 1)
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-sticker-geometry",
+			path: `${path}.opacity`,
+			operationId: operation.id,
+			message: "Sticker opacity must be between 0 and 1.",
+		});
+	}
+	for (const key of ["animationInDuration", "animationOutDuration"] as const) {
+		const value = operation[key];
+		if (
+			value !== undefined &&
+			(!Number.isFinite(value) || value < 0 || value > operation.duration)
+		) {
+			issues.push({
+				severity: "error",
+				code: "invalid-sticker-geometry",
+				path: `${path}.${key}`,
+				operationId: operation.id,
+				message: "Sticker animation timing must fit inside the operation.",
+			});
+		}
+	}
+	if (
+		operation.animationLoopIntensity !== undefined &&
+		(!Number.isFinite(operation.animationLoopIntensity) ||
+			operation.animationLoopIntensity < 0 ||
+			operation.animationLoopIntensity > 2)
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-sticker-geometry",
+			path: `${path}.animationLoopIntensity`,
+			operationId: operation.id,
+			message: "Sticker loop intensity must be between 0 and 2.",
+		});
+	}
+}
+
+function validateSoundSettings({
+	operation,
+	path,
+	issues,
+}: {
+	operation: Extract<ComposePatchOperation, { kind: "add-sound-effect" }>;
+	path: string;
+	issues: ComposeValidationIssue[];
+}): void {
+	if (
+		!Number.isFinite(operation.volume) ||
+		operation.volume < 0 ||
+		operation.volume > 1
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-range",
+			path: `${path}.volume`,
+			operationId: operation.id,
+			message: "Sound-effect volume must be between 0 and 1.",
+		});
+	}
+	for (const key of ["trimStart", "trimEnd", "fadeIn", "fadeOut"] as const) {
+		const value = operation[key];
+		if (
+			value !== undefined &&
+			(!Number.isFinite(value) ||
+				value < 0 ||
+				((key === "fadeIn" || key === "fadeOut") && value > operation.duration))
+		) {
+			issues.push({
+				severity: "error",
+				code: "invalid-range",
+				path: `${path}.${key}`,
+				operationId: operation.id,
+				message:
+					"Sound trims must be non-negative and fades must fit inside the operation.",
+			});
+		}
+	}
+	if (
+		operation.playbackRate !== undefined &&
+		(!Number.isFinite(operation.playbackRate) ||
+			operation.playbackRate < 0.25 ||
+			operation.playbackRate > 4)
+	) {
+		issues.push({
+			severity: "error",
+			code: "invalid-range",
+			path: `${path}.playbackRate`,
+			operationId: operation.id,
+			message: "Sound-effect playbackRate must be between 0.25 and 4.",
+		});
+	}
 }
 
 function mediaByElementId({
@@ -370,6 +481,9 @@ export function validateComposePatch({
 		}
 		if (operation.kind === "add-sticker") {
 			validateStickerGeometry({ operation, path, issues });
+		}
+		if (operation.kind === "add-sound-effect") {
+			validateSoundSettings({ operation, path, issues });
 		}
 		if (operation.kind === "add-text-overlay" && operation.asset) {
 			validateAssetReference({


### PR DESCRIPTION
## Summary

Complete Sticker Lab, Transition Lab, Sound Effects Lab, and the shared Compose control plane through one validated resource-broker and editor apply/export path.

## Work in progress

- [x] Extend shared Compose resource and operation contracts
- [x] Add path-free local resource discovery and cloud candidate selection
- [x] Constrain cloud model output to admitted assets and timeline targets
- [ ] Materialize and validate Sticker Lab and Sound Effects Lab assets
- [ ] Gate and apply QCut/Jianying transition runtimes
- [ ] Wire advanced controls through editor apply/read-back
- [ ] Verify real cloud plan, editor apply, export, and screenshots end to end

Supersedes #441 because that branch was concurrently reused by unrelated tracking work.