### PR TITLE
perf(tracking): keep fulfilled planar sidecars cached during export

### DIFF
--- a/qcut/apps/web/src/lib/tracking/__tests__/planar-tracking-result-loader.test.ts
+++ b/qcut/apps/web/src/lib/tracking/__tests__/planar-tracking-result-loader.test.ts
@@ -77,7 +77,7 @@ function store({
 describe("planar tracking result loader", () => {
 	beforeEach(() => clearPlanarTrackingSidecarCache());
 
-	it("deduplicates in-flight reads and evicts the fulfilled promise", async () => {
+	it("deduplicates in-flight reads and keeps the fulfilled result", async () => {
 		const read = vi.fn(async () => result());
 		const resultStore = store({ read });
 		const first = loadPlanarTrackingSidecar({
@@ -94,6 +94,9 @@ describe("planar tracking result loader", () => {
 		await expect(first).resolves.toBe(sidecar);
 		expect(read).toHaveBeenCalledOnce();
 
+		// A settled read is retained. Previously the entry was evicted here, so
+		// every later caller re-read, re-hashed and re-parsed the sidecar; during
+		// export that meant one full read per rendered frame.
 		await expect(
 			loadPlanarTrackingSidecar({
 				projectId: "project",
@@ -101,7 +104,89 @@ describe("planar tracking result loader", () => {
 				resultStore,
 			})
 		).resolves.toBe(sidecar);
+		expect(read).toHaveBeenCalledOnce();
+	});
+
+	it("serves many sequential callers from one read", async () => {
+		const read = vi.fn(async () => result());
+		const resultStore = store({ read });
+		// Mirrors an export: each frame awaits the previous one, so the in-flight
+		// window never spans two frames and only a real result cache can help.
+		for (let frame = 0; frame < 60; frame += 1) {
+			await expect(
+				loadPlanarTrackingSidecar({
+					projectId: "project",
+					reference,
+					resultStore,
+				})
+			).resolves.toBe(sidecar);
+		}
+		expect(read).toHaveBeenCalledOnce();
+	});
+
+	it("re-reads when the tracking result hash changes", async () => {
+		const read = vi.fn(async () => result());
+		const resultStore = store({ read });
+		await loadPlanarTrackingSidecar({
+			projectId: "project",
+			reference,
+			resultStore,
+		});
+		// A re-tracked surface writes a new sha256, which is part of the key, so
+		// a cached entry can never be served for changed tracking data.
+		await loadPlanarTrackingSidecar({
+			projectId: "project",
+			reference: { ...reference, resultSha256: "d".repeat(64) },
+			resultStore,
+		});
 		expect(read).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps separate entries per project", async () => {
+		const read = vi.fn(async () => result());
+		const resultStore = store({ read });
+		await loadPlanarTrackingSidecar({
+			projectId: "project-a",
+			reference,
+			resultStore,
+		});
+		await loadPlanarTrackingSidecar({
+			projectId: "project-b",
+			reference,
+			resultStore,
+		});
+		expect(read).toHaveBeenCalledTimes(2);
+	});
+
+	it("bounds how many sidecars it retains", async () => {
+		const read = vi.fn(async () => result());
+		const resultStore = store({ read });
+		// Nine distinct results, one more than the retention bound.
+		const keys = Array.from({ length: 9 }, (_, index) =>
+			String(index).repeat(64).slice(0, 64)
+		);
+		for (const resultSha256 of keys) {
+			await loadPlanarTrackingSidecar({
+				projectId: "project",
+				reference: { ...reference, resultSha256 },
+				resultStore,
+			});
+		}
+		expect(read).toHaveBeenCalledTimes(9);
+		// The most recent entry is still cached.
+		await loadPlanarTrackingSidecar({
+			projectId: "project",
+			reference: { ...reference, resultSha256: keys[8] },
+			resultStore,
+		});
+		expect(read).toHaveBeenCalledTimes(9);
+		// The oldest was dropped and must be re-read.
+		await loadPlanarTrackingSidecar({
+			projectId: "project",
+			reference: { ...reference, resultSha256: keys[0] },
+			resultStore,
+		});
+		expect(read).toHaveBeenCalledTimes(10);
 	});
 
 	it("evicts failed reads so a repaired sidecar can be retried", async () => {

--- a/qcut/apps/web/src/lib/tracking/planar-tracking-result-loader.ts
+++ b/qcut/apps/web/src/lib/tracking/planar-tracking-result-loader.ts
@@ -8,6 +8,31 @@ import { getPlanarTrackingResultStore } from "./planar-result-store";
 
 const sidecarPromises = new Map<string, Promise<PlanarTrackingSidecarV1>>();
 
+/**
+ * Most recently used keys, oldest first. The cached sidecars are keyed by
+ * content hash and are never mutated, so retaining them is safe; this bound
+ * only stops a long editing session from holding every tracking result it has
+ * ever opened.
+ */
+const cacheOrder: string[] = [];
+const MAX_CACHED_SIDECARS = 8;
+
+function touchCacheEntry({ key }: { key: string }): void {
+	const index = cacheOrder.indexOf(key);
+	if (index !== -1) cacheOrder.splice(index, 1);
+	cacheOrder.push(key);
+	while (cacheOrder.length > MAX_CACHED_SIDECARS) {
+		const evicted = cacheOrder.shift();
+		if (evicted !== undefined) sidecarPromises.delete(evicted);
+	}
+}
+
+function dropCacheEntry({ key }: { key: string }): void {
+	sidecarPromises.delete(key);
+	const index = cacheOrder.indexOf(key);
+	if (index !== -1) cacheOrder.splice(index, 1);
+}
+
 function resultCacheKey({
 	projectId,
 	reference,
@@ -36,7 +61,10 @@ export function loadPlanarTrackingSidecar({
 	}
 	const key = resultCacheKey({ projectId, reference });
 	const existing = sidecarPromises.get(key);
-	if (existing) return existing;
+	if (existing) {
+		touchCacheEntry({ key });
+		return existing;
+	}
 	const pending = resultStore
 		.read({
 			expectedSha256: reference.resultSha256,
@@ -45,14 +73,19 @@ export function loadPlanarTrackingSidecar({
 		})
 		.then(({ sidecar }) => sidecar);
 	sidecarPromises.set(key, pending);
-	const evict = (): void => {
-		if (sidecarPromises.get(key) === pending) sidecarPromises.delete(key);
-	};
-	void pending.then(evict, evict);
+	touchCacheEntry({ key });
+	// A fulfilled sidecar is kept: the key contains the result's SHA-256, so a
+	// re-tracked surface produces a different key and can never be served a
+	// stale entry. A rejected read is dropped so a repaired sidecar can be
+	// retried rather than the failure being cached forever.
+	void pending.catch(() => {
+		if (sidecarPromises.get(key) === pending) dropCacheEntry({ key });
+	});
 	return pending;
 }
 
 export function clearPlanarTrackingSidecarCache(): void {
+	cacheOrder.length = 0;
 	sidecarPromises.clear();
 }
 

--- a/qcut/apps/web/src/test/e2e/helpers/planar-sidecar-read-probe.ts
+++ b/qcut/apps/web/src/test/e2e/helpers/planar-sidecar-read-probe.ts
@@ -1,0 +1,194 @@
+/**
+ * Planar tracking sidecar read probe.
+ *
+ * Counts how many times the tracking sidecar is actually fetched, verified and
+ * parsed during playback, seeking and export.
+ *
+ * The wrapper is installed in the MAIN process, around the registered
+ * `planar-tracking-storage:read` invoke handler. Wrapping the renderer-side
+ * bridge does not work: `contextBridge` freezes the exposed object, so
+ * assigning to `electronAPI.planarTrackingStorage.read` silently does nothing
+ * and every measurement reads zero. Production code is untouched either way.
+ */
+
+import type { ElectronApplication } from "@playwright/test";
+
+export const PLANAR_READ_CHANNEL = "planar-tracking-storage:read";
+
+export interface SidecarReadStats {
+	/** Number of completed reads since the last reset. */
+	reads: number;
+	/** Wall time spent inside those reads, in milliseconds. */
+	totalMs: number;
+	/** Slowest single read, in milliseconds. */
+	maxMs: number;
+	/** Distinct resultUri values that were read. */
+	uris: string[];
+	/** Sample counts of the sidecars returned. */
+	sampleCounts: number[];
+	/** Reads since install, ignoring resets. */
+	totalEver: number;
+	/** True when the probe is installed and counting. */
+	installed: boolean;
+}
+
+interface ProbeState {
+	maxMs: number;
+	reads: number;
+	sampleCounts: number[];
+	totalEver: number;
+	totalMs: number;
+	uris: string[];
+}
+
+const PROBE_KEY = "__planarSidecarReadProbe";
+
+/**
+ * Installs the counting wrapper around the main-process invoke handler.
+ * Throws if the handler cannot be found or wrapped, rather than silently
+ * reporting zero reads.
+ */
+export async function installSidecarReadProbe({
+	electronApp,
+}: {
+	electronApp: ElectronApplication;
+}): Promise<void> {
+	await electronApp.evaluate(
+		({ ipcMain }, { channel, probeKey }) => {
+			const globalStore = globalThis as unknown as Record<string, unknown>;
+
+			// Electron keeps invoke handlers in an internal map. This is a private
+			// field, so verify it looks right before relying on it.
+			const handlers = (
+				ipcMain as unknown as {
+					_invokeHandlers?: Map<string, (...args: unknown[]) => unknown>;
+				}
+			)._invokeHandlers;
+			if (!handlers || typeof handlers.get !== "function") {
+				throw new Error(
+					"Sidecar read probe: ipcMain._invokeHandlers is unavailable"
+				);
+			}
+
+			const existing = globalStore[probeKey] as
+				| { original?: (...args: unknown[]) => unknown }
+				| undefined;
+			// Restore first so repeated installs never nest wrappers.
+			if (existing?.original) handlers.set(channel, existing.original);
+
+			const original = handlers.get(channel);
+			if (typeof original !== "function") {
+				throw new Error(
+					`Sidecar read probe: no invoke handler registered for ${channel}`
+				);
+			}
+
+			const state = {
+				maxMs: 0,
+				original,
+				reads: 0,
+				sampleCounts: [] as number[],
+				totalEver: 0,
+				totalMs: 0,
+				uris: [] as string[],
+			};
+			globalStore[probeKey] = state;
+
+			handlers.set(channel, async (...args: unknown[]) => {
+				const startedAt = Date.now();
+				const response = (await state.original(...args)) as {
+					sidecar?: { samples?: unknown[] };
+				};
+				const elapsed = Date.now() - startedAt;
+				state.reads += 1;
+				state.totalEver += 1;
+				state.totalMs += elapsed;
+				if (elapsed > state.maxMs) state.maxMs = elapsed;
+				const request = args[1] as { resultUri?: string } | undefined;
+				const uri = request?.resultUri;
+				if (uri && !state.uris.includes(uri)) state.uris.push(uri);
+				const sampleCount = response?.sidecar?.samples?.length;
+				if (typeof sampleCount === "number") {
+					state.sampleCounts.push(sampleCount);
+				}
+				return response;
+			});
+
+			if (handlers.get(channel) === original) {
+				throw new Error(
+					"Sidecar read probe could not be installed: handler map is not writable"
+				);
+			}
+		},
+		{ channel: PLANAR_READ_CHANNEL, probeKey: PROBE_KEY }
+	);
+}
+
+/** Zeroes the counters without removing the wrapper. */
+export async function resetSidecarReadProbe({
+	electronApp,
+}: {
+	electronApp: ElectronApplication;
+}): Promise<void> {
+	await electronApp.evaluate((_electron, probeKey) => {
+		const state = (globalThis as unknown as Record<string, unknown>)[
+			probeKey
+		] as ProbeState | undefined;
+		if (!state) return;
+		state.maxMs = 0;
+		state.reads = 0;
+		state.sampleCounts = [];
+		state.totalMs = 0;
+		state.uris = [];
+	}, PROBE_KEY);
+}
+
+/** Reads the current counters. */
+export async function readSidecarReadProbe({
+	electronApp,
+}: {
+	electronApp: ElectronApplication;
+}): Promise<SidecarReadStats> {
+	return await electronApp.evaluate((_electron, probeKey) => {
+		const state = (globalThis as unknown as Record<string, unknown>)[
+			probeKey
+		] as ProbeState | undefined;
+		if (!state) {
+			return {
+				installed: false,
+				maxMs: 0,
+				reads: 0,
+				sampleCounts: [],
+				totalEver: 0,
+				totalMs: 0,
+				uris: [],
+			};
+		}
+		return {
+			installed: true,
+			maxMs: state.maxMs,
+			reads: state.reads,
+			sampleCounts: [...state.sampleCounts],
+			totalEver: state.totalEver,
+			totalMs: state.totalMs,
+			uris: [...state.uris],
+		};
+	}, PROBE_KEY);
+}
+
+/** Formats a stats line for the test log. */
+export function formatSidecarStats({
+	label,
+	stats,
+}: {
+	label: string;
+	stats: SidecarReadStats;
+}): string {
+	const samples = stats.sampleCounts[0];
+	return (
+		`[planar-bench] ${label.padEnd(30)} reads=${String(stats.reads).padStart(4)} ` +
+		`totalMs=${stats.totalMs.toFixed(1).padStart(8)} maxMs=${stats.maxMs.toFixed(1).padStart(6)} ` +
+		`uris=${stats.uris.length} everSinceInstall=${stats.totalEver}` +
+		(typeof samples === "number" ? ` samplesPerRead=${samples}` : "")
+	);
+}

--- a/qcut/apps/web/src/test/e2e/helpers/planar-sticker-bench-scenarios.ts
+++ b/qcut/apps/web/src/test/e2e/helpers/planar-sticker-bench-scenarios.ts
@@ -1,0 +1,608 @@
+/**
+ * Scenario setup and invariant capture for the planar sticker render benchmark.
+ *
+ * Builds three comparable timelines on one project — no sticker, a plain
+ * untracked sticker, and a real planar-tracked sticker — and captures the
+ * geometry a caching change must not alter.
+ */
+
+import { expect, type Page } from "@playwright/test";
+
+export const PLANAR_BENCH = {
+	durationSeconds: 2,
+	fixtureHeight: 240,
+	fixtureWidth: 320,
+	stickerSize: 18,
+} as const;
+
+export interface PlanarBenchSetup {
+	mediaElementId: string;
+	projectId: string;
+	stickerElementId: string;
+	stickerId: string;
+	stickerTrackId: string;
+}
+
+/**
+ * Geometry of the rendered sticker at one fixed time, expressed as fractions
+ * of the preview surface so it is independent of preview zoom.
+ */
+export interface StickerQuadSample {
+	time: number;
+	visible: boolean;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	transform: string;
+}
+
+interface BenchHarnessWindow {
+	__playbackStore: {
+		getState: () => {
+			seek: (time: number) => void;
+			play: () => void;
+			pause: () => void;
+		};
+	};
+	__projectStore: { getState: () => { activeProject?: { id: string } } };
+	__timelineStore: { getState: () => Record<string, any> };
+	stickerTest: {
+		getStores: () => {
+			media: { mediaItems: Array<Record<string, any>> };
+			stickers: Record<string, any>;
+			timeline: Record<string, any>;
+		};
+	};
+	stickerTestReady: Promise<void>;
+}
+
+/**
+ * Adds only the source video, giving a no-sticker control timeline.
+ */
+export async function addPlanarSourceVideo({
+	page,
+}: {
+	page: Page;
+}): Promise<{ mediaElementId: string; projectId: string }> {
+	return await page.evaluate(async (bench) => {
+		const harness = window as unknown as BenchHarnessWindow;
+		await harness.stickerTestReady;
+		const stores = harness.stickerTest.getStores();
+		const video = stores.media.mediaItems.find(
+			(item: { type: string }) => item.type === "video"
+		);
+		const timeline = stores.timeline;
+		const mediaTrack = timeline.tracks.find(
+			(track: { isMain?: boolean; type: string }) =>
+				track.isMain || track.type === "media"
+		);
+		const projectId = harness.__projectStore.getState().activeProject?.id;
+		if (!video || !mediaTrack || !projectId) {
+			throw new Error("Planar benchmark media or project was not ready");
+		}
+		const mediaElementId = timeline.addElementToTrack(
+			mediaTrack.id,
+			{
+				duration: video.duration ?? bench.durationSeconds,
+				mediaId: video.id,
+				name: video.name,
+				startTime: 0,
+				trimEnd: 0,
+				trimStart: 0,
+				type: "media",
+			},
+			{ pushHistory: false, selectElement: false }
+		);
+		if (!mediaElementId) throw new Error("Could not add planar source video");
+		harness.__playbackStore.getState().seek(0);
+		return { mediaElementId, projectId };
+	}, PLANAR_BENCH);
+}
+
+/**
+ * Adds an overlay sticker over the source video. The sticker starts untracked;
+ * `runRealTracking` promotes it to a planar-tracked sticker.
+ */
+export async function addBenchSticker({ page }: { page: Page }): Promise<{
+	stickerElementId: string;
+	stickerId: string;
+	stickerTrackId: string;
+}> {
+	return await page.evaluate(async (bench) => {
+		const harness = window as unknown as BenchHarnessWindow;
+		await harness.stickerTestReady;
+		const stores = harness.stickerTest.getStores();
+		const video = stores.media.mediaItems.find(
+			(item: { type: string }) => item.type === "video"
+		);
+		const image = stores.media.mediaItems.find(
+			(item: { type: string }) => item.type === "image"
+		);
+		const timeline = stores.timeline;
+		if (!video || !image) {
+			throw new Error("Planar benchmark sticker media was not ready");
+		}
+
+		const stickerId = stores.stickers.addOverlaySticker(image.id, {
+			maintainAspectRatio: true,
+			opacity: 1,
+			position: { x: 50, y: 50 },
+			rotation: 0,
+			size: { height: bench.stickerSize, width: bench.stickerSize },
+		});
+		const stickerTrackId = timeline.insertTrackAt("sticker", 0);
+		const stickerElementId = timeline.addElementToTrack(
+			stickerTrackId,
+			{
+				duration: video.duration ?? bench.durationSeconds,
+				height: bench.stickerSize,
+				maintainAspectRatio: true,
+				mediaId: image.id,
+				name: "Planar benchmark marker",
+				opacity: 1,
+				rotation: 0,
+				startTime: 0,
+				stickerId,
+				trimEnd: 0,
+				trimStart: 0,
+				type: "sticker",
+				width: bench.stickerSize,
+				x: 50,
+				y: 50,
+				zIndex: 1,
+			},
+			{ pushHistory: false, selectElement: false }
+		);
+		if (!stickerElementId) {
+			throw new Error("Could not add planar benchmark sticker");
+		}
+		stores.stickers.selectSticker(stickerId);
+		timeline.setSelectedElements([
+			{ elementId: stickerElementId, trackId: stickerTrackId },
+		]);
+		harness.__playbackStore.getState().seek(0);
+		return { stickerElementId, stickerId, stickerTrackId };
+	}, PLANAR_BENCH);
+}
+
+/**
+ * Dismisses the export panel and re-selects the sticker so the properties
+ * panel is showing again. Exporting leaves its own panel open, which hides the
+ * sticker properties the tracking flow needs.
+ */
+export async function focusStickerForTracking({
+	page,
+	stickerElementId,
+	stickerId,
+	stickerTrackId,
+}: {
+	page: Page;
+	stickerElementId: string;
+	stickerId: string;
+	stickerTrackId: string;
+}): Promise<void> {
+	await page.keyboard.press("Escape");
+	await page.evaluate(
+		(target) => {
+			const harness = window as unknown as BenchHarnessWindow;
+			const stores = harness.stickerTest.getStores();
+			stores.stickers.selectSticker(target.stickerId);
+			harness.__timelineStore.getState().setSelectedElements([
+				{
+					elementId: target.stickerElementId,
+					trackId: target.stickerTrackId,
+				},
+			]);
+		},
+		{ stickerElementId, stickerId, stickerTrackId }
+	);
+	await expect(page.getByTestId("sticker-properties")).toBeVisible({
+		timeout: 30_000,
+	});
+}
+
+/**
+ * Drives the real tracking job through the properties panel, producing a
+ * genuine sidecar on disk. Returns once the job reports completion.
+ */
+export async function runRealTracking({ page }: { page: Page }): Promise<void> {
+	const stickerProperties = page.getByTestId("sticker-properties");
+	await expect(stickerProperties).toBeVisible();
+	await stickerProperties.getByRole("tab").nth(3).click();
+	const planarProperties = page.getByTestId(
+		"sticker-planar-tracking-properties"
+	);
+	await expect(planarProperties).toBeVisible();
+	await planarProperties
+		.getByRole("button", { name: /编辑跟踪平面|Edit tracking plane/ })
+		.click();
+	await expect(
+		page.getByTestId("planar-tracking-selection-overlay")
+	).toBeVisible();
+	await planarProperties
+		.getByRole("button", { name: /开始跟踪|Start tracking/ })
+		.click();
+	const jobStatus = page.getByTestId("planar-tracking-job-status");
+	await expect(jobStatus).toBeVisible({ timeout: 180_000 });
+	await expect(jobStatus).toHaveText(/^(跟踪完成|Tracking complete)$/, {
+		timeout: 180_000,
+	});
+}
+
+/**
+ * Reads the committed tracking binding and reference. Used to prove the
+ * sticker really is planar-tracked before any tracked-scenario measurement.
+ */
+export async function readTrackingBinding({
+	page,
+	stickerElementId,
+	mediaElementId,
+}: {
+	page: Page;
+	stickerElementId: string;
+	mediaElementId: string;
+}): Promise<{
+	mode: string | undefined;
+	referenceStatus: string | undefined;
+	resultSha256: string | undefined;
+	resultUri: string | undefined;
+	sampleCount: number | undefined;
+	sourceElementId: string | undefined;
+}> {
+	return await page.evaluate(
+		(target) => {
+			const timeline = (
+				window as unknown as BenchHarnessWindow
+			).__timelineStore.getState();
+			const elements = timeline.tracks.flatMap(
+				(track: { elements: unknown[] }) => track.elements
+			);
+			const sticker = elements.find(
+				(element: { id: string }) => element.id === target.stickerElementId
+			);
+			const media = elements.find(
+				(element: { id: string }) => element.id === target.mediaElementId
+			);
+			const binding = sticker?.tracking;
+			const reference = media?.surfaceTrackings?.find(
+				(candidate: { id: string }) =>
+					candidate.id === binding?.surfaceTrackingId
+			);
+			return {
+				mode: binding?.mode,
+				referenceStatus: reference?.status,
+				resultSha256: reference?.resultSha256,
+				resultUri: reference?.resultUri,
+				sampleCount: reference?.sampleCount,
+				sourceElementId: binding?.sourceElementId,
+			};
+		},
+		{ mediaElementId, stickerElementId }
+	);
+}
+
+/**
+ * Reads the persisted sidecar through the app's own storage bridge and returns
+ * the tracked quad centre at each requested time (nearest sample).
+ *
+ * This is the run-independent anchor for the geometry gate: the rendered
+ * sticker must follow these centres regardless of preview zoom, which varies
+ * between runs.
+ */
+export async function readSidecarQuadCentres({
+	page,
+	projectId,
+	resultUri,
+	expectedSha256,
+	times,
+}: {
+	page: Page;
+	projectId: string;
+	resultUri: string;
+	expectedSha256: string;
+	times: readonly number[];
+}): Promise<Array<{ time: number; x: number; y: number }>> {
+	return await page.evaluate(
+		async (input) => {
+			const storage = (
+				window as unknown as {
+					electronAPI?: {
+						planarTrackingStorage?: {
+							read: (request: {
+								expectedSha256: string;
+								projectId: string;
+								resultUri: string;
+							}) => Promise<{ sidecar: { samples: unknown[] } }>;
+						};
+					};
+				}
+			).electronAPI?.planarTrackingStorage;
+			if (!storage) throw new Error("Planar storage bridge unavailable");
+			const { sidecar } = await storage.read({
+				expectedSha256: input.expectedSha256,
+				projectId: input.projectId,
+				resultUri: input.resultUri,
+			});
+			const samples = sidecar.samples as Array<{
+				ptsUs: number;
+				quad?: {
+					topLeft: { x: number; y: number };
+					topRight: { x: number; y: number };
+					bottomRight: { x: number; y: number };
+					bottomLeft: { x: number; y: number };
+				};
+			}>;
+			return input.times.map((time) => {
+				const targetUs = time * 1_000_000;
+				let nearest = samples[0];
+				for (const sample of samples) {
+					if (
+						Math.abs(sample.ptsUs - targetUs) <
+						Math.abs(nearest.ptsUs - targetUs)
+					) {
+						nearest = sample;
+					}
+				}
+				const quad = nearest?.quad;
+				if (!quad) return { time, x: Number.NaN, y: Number.NaN };
+				return {
+					time,
+					x:
+						(quad.topLeft.x +
+							quad.topRight.x +
+							quad.bottomRight.x +
+							quad.bottomLeft.x) /
+						4,
+					y:
+						(quad.topLeft.y +
+							quad.topRight.y +
+							quad.bottomRight.y +
+							quad.bottomLeft.y) /
+						4,
+				};
+			});
+		},
+		{ expectedSha256, projectId, resultUri, times: [...times] }
+	);
+}
+
+/**
+ * Measures how the cost of one sidecar read scales with sample count.
+ *
+ * The benchmark fixture is a 2 second clip, so its sidecar is tiny and the
+ * per-frame reads it eliminates look cheap. Real tracking runs are far longer,
+ * and each read hashes and parses the whole file, so this writes synthetic
+ * sidecars of increasing size and times a real read of each.
+ */
+export async function measureReadCostBySize({
+	page,
+	projectId,
+	sampleCounts,
+}: {
+	page: Page;
+	projectId: string;
+	sampleCounts: readonly number[];
+}): Promise<Array<{ samples: number; bytes: number; readMs: number }>> {
+	return await page.evaluate(
+		async (input) => {
+			const storage = (
+				window as unknown as {
+					electronAPI?: {
+						planarTrackingStorage?: {
+							write: (request: unknown) => Promise<{
+								resultSha256: string;
+								resultUri: string;
+							}>;
+							read: (request: unknown) => Promise<unknown>;
+						};
+					};
+				}
+			).electronAPI?.planarTrackingStorage;
+			if (!storage) throw new Error("Planar storage bridge unavailable");
+
+			const results: Array<{
+				samples: number;
+				bytes: number;
+				readMs: number;
+			}> = [];
+			for (const sampleCount of input.sampleCounts) {
+				const quad = {
+					bottomLeft: { x: 0.2, y: 0.8 },
+					bottomRight: { x: 0.8, y: 0.8 },
+					topLeft: { x: 0.2, y: 0.2 },
+					topRight: { x: 0.8, y: 0.2 },
+				};
+				const sidecar = {
+					coordinateSpace: "source-display-normalized",
+					direction: "both",
+					provider: {
+						id: "opencv-wasm",
+						parametersHash: "a".repeat(64),
+						version: "bench",
+					},
+					samples: Array.from({ length: sampleCount }, (_unused, index) => ({
+						confidence: 0.9,
+						ptsUs: index * 33_333,
+						quad,
+						status: "tracked",
+					})),
+					schemaVersion: 1,
+					seed: { ptsUs: 0, quad },
+					source: {
+						contentSha256: "b".repeat(64),
+						displayHeight: 240,
+						displayWidth: 320,
+						mediaId: "bench-media",
+					},
+					timebase: "microseconds",
+				};
+				const written = await storage.write({
+					projectId: input.projectId,
+					sidecar,
+					trackingId: `bench-size-${sampleCount}`,
+				});
+				const startedAt = performance.now();
+				await storage.read({
+					expectedSha256: written.resultSha256,
+					projectId: input.projectId,
+					resultUri: written.resultUri,
+				});
+				results.push({
+					bytes: JSON.stringify(sidecar).length,
+					readMs: performance.now() - startedAt,
+					samples: sampleCount,
+				});
+			}
+			return results;
+		},
+		{ projectId, sampleCounts: [...sampleCounts] }
+	);
+}
+
+/** Rounds to 6 decimals so float noise does not defeat equality checks. */
+function round6(value: number): number {
+	return Number(value.toFixed(6));
+}
+
+/** Waits two animation frames so a seek is reflected in the DOM. */
+async function settleFrames({ page }: { page: Page }): Promise<void> {
+	await page.evaluate(
+		() =>
+			new Promise<void>((resolve) => {
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+			})
+	);
+}
+
+/**
+ * Captures the rendered sticker geometry at fixed times. These samples are the
+ * invariant fixture: a caching change must reproduce them exactly.
+ */
+export async function captureQuadSamples({
+	page,
+	stickerId,
+	times,
+}: {
+	page: Page;
+	stickerId: string;
+	times: readonly number[];
+}): Promise<StickerQuadSample[]> {
+	const samples: StickerQuadSample[] = [];
+	for (const time of times) {
+		await page.evaluate((seekTime) => {
+			(window as unknown as BenchHarnessWindow).__playbackStore
+				.getState()
+				.seek(seekTime);
+		}, time);
+		await settleFrames({ page });
+
+		const locator = page.locator(
+			`[data-sticker-id="${stickerId}"][data-sticker-render-mode="visual"]`
+		);
+		const count = await locator.count();
+		if (count === 0) {
+			samples.push({
+				height: 0,
+				time,
+				transform: "",
+				visible: false,
+				width: 0,
+				x: 0,
+				y: 0,
+			});
+			continue;
+		}
+		const box = await locator.boundingBox();
+		const transform = await locator.evaluate(
+			(node) => getComputedStyle(node as HTMLElement).transform
+		);
+		// Normalize against the preview surface. Raw screen pixels depend on the
+		// preview's zoom, which varies between runs and would make the fixture
+		// look like a geometry change when only the layout differed.
+		const surface = await locator.evaluate((node) => {
+			const panel = (node as HTMLElement).closest(
+				'[data-testid="preview-panel"]'
+			);
+			const host = (panel ??
+				(node as HTMLElement).offsetParent) as HTMLElement | null;
+			if (!host) return null;
+			const rect = host.getBoundingClientRect();
+			return { height: rect.height, width: rect.width, x: rect.x, y: rect.y };
+		});
+		const denomWidth = surface?.width || 1;
+		const denomHeight = surface?.height || 1;
+		samples.push({
+			height: round6((box?.height ?? 0) / denomHeight),
+			time,
+			transform,
+			visible: Boolean(box),
+			width: round6((box?.width ?? 0) / denomWidth),
+			x: round6(((box?.x ?? 0) - (surface?.x ?? 0)) / denomWidth),
+			y: round6(((box?.y ?? 0) - (surface?.y ?? 0)) / denomHeight),
+		});
+	}
+	return samples;
+}
+
+/** Plays the timeline for a fixed wall-clock window. */
+export async function playForSeconds({
+	page,
+	seconds,
+}: {
+	page: Page;
+	seconds: number;
+}): Promise<void> {
+	await page.evaluate((duration) => {
+		const playback = (
+			window as unknown as BenchHarnessWindow
+		).__playbackStore.getState();
+		playback.seek(0);
+		playback.play();
+		return new Promise<void>((resolve) => {
+			setTimeout(() => {
+				(window as unknown as BenchHarnessWindow).__playbackStore
+					.getState()
+					.pause();
+				resolve();
+			}, duration * 1000);
+		});
+	}, seconds);
+}
+
+/** Seeks to each time in turn, settling frames between. */
+export async function seekThrough({
+	page,
+	times,
+}: {
+	page: Page;
+	times: readonly number[];
+}): Promise<void> {
+	for (const time of times) {
+		await page.evaluate((seekTime) => {
+			(window as unknown as BenchHarnessWindow).__playbackStore
+				.getState()
+				.seek(seekTime);
+		}, time);
+		await settleFrames({ page });
+	}
+}
+
+/** Removes the sticker element, leaving a no-sticker control timeline. */
+export async function removeStickerElement({
+	page,
+	setup,
+}: {
+	page: Page;
+	setup: PlanarBenchSetup;
+}): Promise<void> {
+	await page.evaluate((target) => {
+		const timeline = (
+			window as unknown as BenchHarnessWindow
+		).__timelineStore.getState();
+		timeline.removeElementFromTrack(
+			target.stickerTrackId,
+			target.stickerElementId
+		);
+	}, setup);
+}

--- a/qcut/apps/web/src/test/e2e/planar-sticker-render-benchmark.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/planar-sticker-render-benchmark.e2e.ts
@@ -1,0 +1,358 @@
+/**
+ * Planar tracking sticker render benchmark.
+ *
+ * Measures how often the tracking sidecar is fetched, verified and parsed
+ * across three comparable timelines — no sticker, a plain untracked sticker,
+ * and a real planar-tracked sticker — over continuous playback, seeking, and a
+ * real export.
+ *
+ * The export is run through the muxer engine on purpose. That is the canvas
+ * per-frame engine, and it is the one force-selected when a timeline carries a
+ * Sticker Lab runtime sticker; the default desktop CLI engine bakes tracking
+ * geometry into the filter graph and loads the sidecar once per sticker, so it
+ * cannot show this cost.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { expect } from "@playwright/test";
+import {
+	createTestProject,
+	startElectronApp,
+	stubExportSaveDialog,
+	test as qcutTest,
+	uploadTestMedia,
+} from "./helpers/electron-helpers";
+import {
+	createPlanarTrackingWorkspace,
+	type PlanarTrackingWorkspace,
+} from "./helpers/planar-tracking-video-fixture";
+import {
+	formatSidecarStats,
+	installSidecarReadProbe,
+	readSidecarReadProbe,
+	resetSidecarReadProbe,
+	type SidecarReadStats,
+} from "./helpers/planar-sidecar-read-probe";
+import {
+	addBenchSticker,
+	addPlanarSourceVideo,
+	captureQuadSamples,
+	focusStickerForTracking,
+	measureReadCostBySize,
+	readSidecarQuadCentres,
+	readTrackingBinding,
+	PLANAR_BENCH,
+	playForSeconds,
+	runRealTracking,
+	seekThrough,
+	type StickerQuadSample,
+} from "./helpers/planar-sticker-bench-scenarios";
+
+const EVIDENCE_DIR = path.resolve("output/playwright/planar-sticker-bench");
+
+/** Fixed times used for both the seek workload and the geometry fixture. */
+const QUAD_TIMES = [0, 0.4, 0.8, 1.2, 1.6] as const;
+const PLAYBACK_SECONDS = 2;
+
+interface ScenarioMeasurement {
+	scenario: string;
+	playback: SidecarReadStats;
+	seek: SidecarReadStats;
+	exportStats: SidecarReadStats;
+	exportWallMs: number;
+	exportedFrames: number;
+}
+
+const test = qcutTest.extend<{ planarWorkspace: PlanarTrackingWorkspace }>({
+	// biome-ignore lint/correctness/noEmptyPattern: Playwright fixtures require empty destructuring
+	planarWorkspace: async ({}, use) => {
+		const workspace = await createPlanarTrackingWorkspace();
+		try {
+			await use(workspace);
+		} finally {
+			await rm(workspace.rootDirectory, { force: true, recursive: true });
+		}
+	},
+	electronApp: async ({ planarWorkspace }, use) => {
+		const electronApp = await startElectronApp({
+			userDataDirectory: planarWorkspace.profileDirectory,
+		});
+		await electronApp.evaluate(({ app }, documentsDirectory) => {
+			app.setPath("documents", documentsDirectory);
+		}, planarWorkspace.documentsDirectory);
+		try {
+			await use(electronApp);
+		} finally {
+			await electronApp.close();
+		}
+	},
+});
+
+test.use({ captureScreenshotVideo: false });
+test.setTimeout(900_000);
+
+test.describe("planar sticker render benchmark", () => {
+	test("measures sidecar loads across playback, seek and export", async ({
+		electronApp,
+		page,
+		planarWorkspace,
+	}) => {
+		await mkdir(EVIDENCE_DIR, { recursive: true });
+		const consoleLines: string[] = [];
+		page.on("console", (message) => consoleLines.push(message.text()));
+		await electronApp.evaluate(({ BrowserWindow }) => {
+			BrowserWindow.getAllWindows()[0]?.setSize(1600, 1000);
+		});
+		await createTestProject(page, "Planar Sticker Render Benchmark");
+		await uploadTestMedia(page, planarWorkspace.videoPath);
+		await uploadTestMedia(
+			page,
+			path.resolve("apps/web/src/test/e2e/fixtures/media/sample-image.png")
+		);
+
+		// In Electron the factory returns the CLI engine before honouring a
+		// requested engine, and the CLI path bakes tracking geometry into the
+		// filter graph (one sidecar load per sticker). This existing debug switch
+		// selects the canvas per-frame engine instead, which is the path the
+		// muxer also uses and the one this benchmark is about. It adds no work of
+		// its own, unlike forcing the muxer via a filter stack.
+		await page.evaluate(() => {
+			localStorage.setItem("qcut_force_regular_engine", "true");
+		});
+
+		const { mediaElementId, projectId } = await addPlanarSourceVideo({ page });
+		expect(projectId).toBeTruthy();
+		await installSidecarReadProbe({ electronApp });
+
+		const measurements: ScenarioMeasurement[] = [];
+
+		const measureScenario = async ({
+			scenario,
+		}: {
+			scenario: string;
+		}): Promise<ScenarioMeasurement> => {
+			await resetSidecarReadProbe({ electronApp });
+			await playForSeconds({ page, seconds: PLAYBACK_SECONDS });
+			const playback = await readSidecarReadProbe({ electronApp });
+
+			await resetSidecarReadProbe({ electronApp });
+			await seekThrough({ page, times: QUAD_TIMES });
+			const seek = await readSidecarReadProbe({ electronApp });
+
+			const outputPath = path.join(EVIDENCE_DIR, `${scenario}.mp4`);
+			await stubExportSaveDialog({ electronApp, outputPath });
+			await ensureExportActions({ page });
+			await resetSidecarReadProbe({ electronApp });
+			const startedAt = Date.now();
+			await runMuxerExport({ page, outputPath });
+			const exportWallMs = Date.now() - startedAt;
+			const exportStats = await readSidecarReadProbe({ electronApp });
+
+			// An export that silently did nothing would report zero reads and look
+			// like a win, so prove the file was written and note which engine ran.
+			await expect
+				.poll(() => existsSync(outputPath), { timeout: 120_000 })
+				.toBe(true);
+			const engineLine = [...consoleLines]
+				.reverse()
+				.find((line) => line.includes("EXPORT ENGINE SELECTION:"));
+			console.log(
+				`[planar-bench] ${scenario} engine=${engineLine?.trim() ?? "(not logged)"}`
+			);
+
+			const measurement: ScenarioMeasurement = {
+				exportStats,
+				exportWallMs,
+				exportedFrames: Math.ceil(PLANAR_BENCH.durationSeconds * 30),
+				playback,
+				scenario,
+				seek,
+			};
+			console.log(
+				formatSidecarStats({ label: `${scenario} playback`, stats: playback })
+			);
+			console.log(
+				formatSidecarStats({ label: `${scenario} seek`, stats: seek })
+			);
+			console.log(
+				formatSidecarStats({ label: `${scenario} export`, stats: exportStats })
+			);
+			console.log(
+				`[planar-bench] ${scenario.padEnd(30)} exportWallMs=${exportWallMs} ` +
+					`expectedFrames=${measurement.exportedFrames} ` +
+					`readsPerFrame=${(exportStats.reads / measurement.exportedFrames).toFixed(2)}`
+			);
+			return measurement;
+		};
+
+		// Scenario 1: no sticker at all.
+		measurements.push(await measureScenario({ scenario: "no-sticker" }));
+
+		// Scenario 2: a plain, untracked sticker.
+		const sticker = await addBenchSticker({ page });
+		measurements.push(await measureScenario({ scenario: "plain-sticker" }));
+		const plainQuads = await captureQuadSamples({
+			page,
+			stickerId: sticker.stickerId,
+			times: QUAD_TIMES,
+		});
+
+		// Scenario 3: the same sticker, now really planar-tracked.
+		await focusStickerForTracking({ page, ...sticker });
+		await runRealTracking({ page });
+
+		// Prove the binding really committed before measuring it. Without this
+		// the tracked scenario can silently degrade into a second plain-sticker
+		// run and the benchmark would report zero reads as if that were a win.
+		const binding = await readTrackingBinding({
+			mediaElementId,
+			page,
+			stickerElementId: sticker.stickerElementId,
+		});
+		console.log(`[planar-bench] BINDING=${JSON.stringify(binding)}`);
+		expect(binding.mode).toBe("planar");
+		expect(binding.referenceStatus).toBe("ready");
+		expect(binding.resultSha256).toMatch(/^[a-f\d]{64}$/);
+		expect(binding.sourceElementId).toBe(mediaElementId);
+		expect(binding.sampleCount ?? 0).toBeGreaterThanOrEqual(20);
+
+		measurements.push(await measureScenario({ scenario: "planar-tracked" }));
+		const trackedQuads = await captureQuadSamples({
+			page,
+			stickerId: sticker.stickerId,
+			times: QUAD_TIMES,
+		});
+
+		console.log(`[planar-bench] QUADS_PLAIN=${JSON.stringify(plainQuads)}`);
+		console.log(`[planar-bench] QUADS_TRACKED=${JSON.stringify(trackedQuads)}`);
+
+		const tracked = measurements.find((m) => m.scenario === "planar-tracked");
+		const plain = measurements.find((m) => m.scenario === "plain-sticker");
+		const control = measurements.find((m) => m.scenario === "no-sticker");
+		if (!tracked || !plain || !control) throw new Error("Missing scenario");
+
+		// Untracked timelines must never touch the tracking store.
+		expect(control.exportStats.reads).toBe(0);
+		expect(control.playback.reads).toBe(0);
+		expect(plain.exportStats.reads).toBe(0);
+		expect(plain.playback.reads).toBe(0);
+
+		// The tracked sticker must actually be tracked, and its geometry must
+		// move over time — otherwise this benchmark proves nothing.
+		expect(trackedQuads.every((sample) => sample.visible)).toBe(true);
+		const distinctPositions = new Set(
+			trackedQuads.map(
+				(sample) => `${sample.x.toFixed(2)}x${sample.y.toFixed(2)}`
+			)
+		);
+		expect(distinctPositions.size).toBeGreaterThan(1);
+
+		// The probe must have been active.
+		expect(tracked.exportStats.installed).toBe(true);
+
+		// Geometry invariant, anchored to the sidecar rather than to screen
+		// pixels. Preview zoom differs between runs, so absolute positions are
+		// not comparable across builds; displacement *ratios* are, because they
+		// cancel any uniform scale and offset. If caching changed which sample a
+		// frame resolves to, this profile would break.
+		const centres = await readSidecarQuadCentres({
+			expectedSha256: binding.resultSha256 ?? "",
+			page,
+			projectId,
+			resultUri: binding.resultUri ?? "",
+			times: QUAD_TIMES,
+		});
+		console.log(`[planar-bench] SIDECAR_CENTRES=${JSON.stringify(centres)}`);
+
+		const ratios = (values: number[]): number[] => {
+			const first = values[0];
+			const span = values[values.length - 1] - first;
+			return values.map((value) => (value - first) / span);
+		};
+		const renderedX = ratios(trackedQuads.map((sample) => sample.x));
+		const sidecarX = ratios(centres.map((centre) => centre.x));
+		console.log(
+			`[planar-bench] PROFILE_RENDERED_X=${JSON.stringify(renderedX.map((v) => Number(v.toFixed(4))))}`
+		);
+		console.log(
+			`[planar-bench] PROFILE_SIDECAR_X=${JSON.stringify(sidecarX.map((v) => Number(v.toFixed(4))))}`
+		);
+		for (const [index, expected] of sidecarX.entries()) {
+			expect(renderedX[index]).toBeCloseTo(expected, 1);
+		}
+
+		// How much work one avoided read represents at realistic tracking sizes.
+		const readCosts = await measureReadCostBySize({
+			page,
+			projectId,
+			sampleCounts: [24, 300, 1800, 5400],
+		});
+		for (const cost of readCosts) {
+			console.log(
+				`[planar-bench] read-cost samples=${String(cost.samples).padStart(5)} ` +
+					`bytes=${String(cost.bytes).padStart(8)} readMs=${cost.readMs.toFixed(2)}`
+			);
+		}
+		expect(readCosts).toHaveLength(4);
+	});
+});
+
+/** Opens the export panel so `__exportActions` is registered. */
+async function ensureExportActions({
+	page,
+}: {
+	page: import("@playwright/test").Page;
+}): Promise<void> {
+	const registered = await page.evaluate(() =>
+		Boolean(
+			(window as unknown as { __exportActions?: unknown }).__exportActions
+		)
+	);
+	if (registered) return;
+	await page.locator('[data-testid="export-button"]').click();
+	await expect
+		.poll(
+			() =>
+				page.evaluate(() =>
+					Boolean(
+						(window as unknown as { __exportActions?: unknown }).__exportActions
+					)
+				),
+			{ timeout: 60_000 }
+		)
+		.toBe(true);
+}
+
+/** Runs one export through the muxer (canvas per-frame) engine. */
+async function runMuxerExport({
+	page,
+	outputPath,
+}: {
+	page: import("@playwright/test").Page;
+	outputPath: string;
+}): Promise<void> {
+	await page.evaluate(async (target) => {
+		const actions = (
+			window as unknown as {
+				__exportActions?: {
+					exportLocalVideo: (
+						options: Record<string, unknown>
+					) => Promise<unknown>;
+				};
+			}
+		).__exportActions;
+		if (!actions) throw new Error("Export actions are not registered");
+		await actions.exportLocalVideo({
+			engine: "muxer",
+			filename: "planar-bench.mp4",
+			format: "mp4",
+			frameRate: 30,
+			height: 720,
+			outputPath: target,
+			quality: "720p",
+			width: 1280,
+		});
+	}, outputPath);
+}


### PR DESCRIPTION
## 摘要
平面跟踪贴纸性能任务。\`planar-tracking-result-loader\` 的缓存条目在 promise settle 时即被逐出（in-flight 去重而非结果缓存），导致画布导出引擎（muxer/standard，贴纸运行时会强制走此路径）**每帧**做一次 IPC + 磁盘读 + SHA-256 + JSON parse。

## 数据（主进程 IPC 探针，真实跟踪 sidecar）
- 优化前：导出 60 帧 = **60 reads（1.00/帧）**；优化后 **0**（整会话 1 次）
- 读取成本随 sidecar 线性：5400 样本约 35ms/次 → 60s@30fps 导出旧行为约 **20.7s 纯冗余哈希/解析**
- 预览/播放路径本就只加载一次（0 re-reads），未改动
- 失败读仍被逐出（保留"修复后可重试"语义）；key 含 resultSha256 不会读到过期数据；8 条 LRU 上限
- 几何门禁锚定 sidecar 位移比例（预览缩放跨 run 不稳，绝对坐标不可比）

## 备注
- 首个探针因 contextBridge 冻结而静默测得全 0，已改为主进程 wrap 并加装载失败即抛错
- 现有 planar-tracking-real E2E 通过；tracking 142/142、stickers 382/382

🤖 Generated with [Claude Code](https://claude.com/claude-code)