### PR TITLE
test(export): add transition export benchmark and identity gates

### DIFF
--- a/qcut/apps/web/src/lib/export/export-clip-transitions.ts
+++ b/qcut/apps/web/src/lib/export/export-clip-transitions.ts
@@ -19,6 +19,7 @@
  */
 
 import type { MediaItem } from "@/stores/media/media-store-types";
+import { exportProfiler } from "./export-profiler";
 import type { ClipTransition, TimelineTrack } from "@/types/timeline";
 import {
 	buildClipTransitionCssFilter,
@@ -417,6 +418,8 @@ export function beginClipTransitionLayer({
 		return { ctx, active: false, finish: () => undefined };
 	}
 
+	exportProfiler.count("transition-layer-frames");
+	const layerStart = performance.now();
 	group.setTransform(1, 0, 0, 1, 0, 0);
 	group.filter = "none";
 	group.globalAlpha = 1;
@@ -430,10 +433,16 @@ export function beginClipTransitionLayer({
 	group.translate(-anchor.x, -anchor.y);
 	group.globalAlpha = Math.min(1, Math.max(0, presentation.contentOpacity));
 
+	exportProfiler.record(
+		"transition-layer-begin",
+		performance.now() - layerStart
+	);
+
 	return {
 		ctx: group,
 		active: true,
 		finish: () => {
+			const finishStart = performance.now();
 			group.restore();
 			const clip = presentation.clipPath
 				? parseClipTransitionClipPath({ clipPath: presentation.clipPath })
@@ -459,6 +468,10 @@ export function beginClipTransitionLayer({
 				ctx.drawImage(group.canvas, 0, 0);
 			} finally {
 				ctx.restore();
+				exportProfiler.record(
+					"transition-layer-finish",
+					performance.now() - finishStart
+				);
 			}
 		},
 	};

--- a/qcut/apps/web/src/lib/export/export-engine-renderer.ts
+++ b/qcut/apps/web/src/lib/export/export-engine-renderer.ts
@@ -225,11 +225,13 @@ export async function renderFrame(
 	const transitionTracks =
 		context.renderIndex?.clipTransitions.canvasTracks ?? null;
 	const transitions = transitionTracks
-		? resolveActiveClipTransitionPreview({
-				tracks: transitionTracks,
-				currentTime,
-				fps: context.fps,
-			})
+		? exportProfiler.timeSync("transition-resolve", () =>
+				resolveActiveClipTransitionPreview({
+					tracks: transitionTracks,
+					currentTime,
+					fps: context.fps,
+				})
+			)
 		: null;
 	const activeElements = exportProfiler.timeSync("active-elements", () =>
 		getActiveElements(

--- a/qcut/apps/web/src/test/e2e/helpers/transition-export-benchmark.ts
+++ b/qcut/apps/web/src/test/e2e/helpers/transition-export-benchmark.ts
@@ -1,0 +1,357 @@
+/**
+ * Reproducible transition export benchmark harness.
+ *
+ * Every scenario exports the same two source clips meeting at the same seam;
+ * only the transition differs (including a no-transition control), so any
+ * difference in export time is attributable to the transition itself.
+ *
+ * The report records the renderer's own wall time, the per-frame render cost,
+ * the transition-specific profiler stages (resolve / offscreen layer setup /
+ * composite back), how many frames actually ran through a transition layer,
+ * and peak process memory.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { ElectronApplication, Page } from "@playwright/test";
+import {
+	type MemorySnapshot,
+	peakByType,
+	sampleMemory,
+} from "./export-lifecycle-memory";
+import {
+	type ExportProfileSummary,
+	readExportProfile,
+	startRendererMuxerExport,
+} from "./sequential-decode-evidence";
+import type { ExposedWindow } from "./sequential-decode-timeline";
+
+export const TRANSITION_BENCHMARK_FPS = 30;
+export const TRANSITION_BENCHMARK_WIDTH = 1280;
+export const TRANSITION_BENCHMARK_HEIGHT = 720;
+/** Each clip runs half the timeline; the seam sits exactly in the middle. */
+export const TRANSITION_BENCHMARK_SECONDS = 6;
+export const TRANSITION_BENCHMARK_FRAMES = Math.round(
+	TRANSITION_BENCHMARK_SECONDS * TRANSITION_BENCHMARK_FPS
+);
+export const TRANSITION_SEAM_SECONDS = TRANSITION_BENCHMARK_SECONDS / 2;
+export const TRANSITION_DURATION_SECONDS = 1;
+
+/**
+ * Scenarios: a control with no seam transition, a cross dissolve, a slide, and
+ * a filter-driven type whose presentation carries canvas filters — the most
+ * expensive canvas-renderable family.
+ */
+export type TransitionScenarioName =
+	| "no-transition"
+	| "dissolve"
+	| "slide"
+	| "zoom-blur";
+
+export const TRANSITION_SCENARIO_TYPES: Record<
+	Exclude<TransitionScenarioName, "no-transition">,
+	{ type: string; presetId: string; direction?: string }
+> = {
+	dissolve: { type: "dissolve", presetId: "dissolve" },
+	slide: { type: "slide", presetId: "slide-left", direction: "left" },
+	"zoom-blur": { type: "zoom-blur", presetId: "zoom-blur" },
+};
+
+export interface TransitionBenchmarkMeasurement {
+	scenario: TransitionScenarioName;
+	/** Wall time as the renderer measured it (job polling is too coarse). */
+	exportWallMs: number;
+	frameCount: number;
+	frameTotalP50Ms: number;
+	frameTotalP95Ms: number;
+	stageTotalsMs: Record<string, number>;
+	counters: Record<string, number>;
+	peakMemoryMbByType: Record<string, number>;
+	memorySampleCount: number;
+	probe?: {
+		frameCount: number;
+		durationSeconds: number;
+		width: number;
+		height: number;
+		hasAudio: boolean;
+	};
+}
+
+export interface TransitionBenchmarkReport {
+	schemaVersion: 1;
+	kind: "qcut-transition-export-benchmark-v1";
+	label: string;
+	recordedAt: string;
+	settings: {
+		width: number;
+		height: number;
+		fps: number;
+		seconds: number;
+		seamSeconds: number;
+		transitionSeconds: number;
+	};
+	measurements: TransitionBenchmarkMeasurement[];
+}
+
+interface TimelineStoreWithSetState {
+	getState: () => { tracks: unknown[] };
+	setState: (state: Record<string, unknown>) => void;
+}
+
+export async function snapshotTimelineTracks({
+	page,
+}: {
+	page: Page;
+}): Promise<string> {
+	return page.evaluate(() => {
+		const editorWindow = window as unknown as {
+			__timelineStore: TimelineStoreWithSetState;
+		};
+		return JSON.stringify(editorWindow.__timelineStore.getState().tracks);
+	});
+}
+
+export async function restoreTimelineTracks({
+	page,
+	snapshot,
+}: {
+	page: Page;
+	snapshot: string;
+}): Promise<void> {
+	await page.evaluate((serialized) => {
+		const editorWindow = window as unknown as {
+			__timelineStore: TimelineStoreWithSetState;
+		};
+		editorWindow.__timelineStore.setState({
+			_tracks: JSON.parse(serialized),
+			tracks: JSON.parse(serialized) as unknown[],
+			selectedElements: [],
+		});
+	}, snapshot);
+}
+
+/**
+ * Places two clips back to back on the main track and, for every scenario
+ * except the control, adds the seam transition. The clip layout is identical
+ * across scenarios so the control isolates the transition's own cost.
+ */
+export async function buildTransitionTimeline({
+	page,
+	scenario,
+	clipAName,
+	clipBName,
+}: {
+	page: Page;
+	scenario: TransitionScenarioName;
+	clipAName: string;
+	clipBName: string;
+}): Promise<{
+	projectId: string;
+	duration: number;
+	transitionId: string | null;
+}> {
+	return page.evaluate(
+		({
+			scenario,
+			clipAName,
+			clipBName,
+			seam,
+			seconds,
+			transitionSeconds,
+			types,
+		}) => {
+			const editorWindow = window as unknown as ExposedWindow;
+			const projectId =
+				editorWindow.__projectStore.getState().activeProject?.id;
+			if (!projectId) throw new Error("No active project");
+			const items = editorWindow.__mediaStore.getState().mediaItems;
+			const byName = (name: string) => {
+				const item = items.find((candidate) => candidate.name === name);
+				if (!item) throw new Error(`Media ${name} was not imported`);
+				return item;
+			};
+			const clipA = byName(clipAName);
+			const clipB = byName(clipBName);
+
+			const timeline = editorWindow.__timelineStore.getState();
+			const mainTrack = timeline.tracks.find(
+				(candidate) => candidate.isMain || candidate.type === "media"
+			);
+			if (!mainTrack) throw new Error("Missing main media track");
+
+			const first = timeline.addElementToTrack(mainTrack.id, {
+				type: "media",
+				mediaId: clipA.id,
+				name: "seam-a",
+				startTime: 0,
+				duration: seam,
+				trimStart: 0,
+				trimEnd: 0,
+			});
+			const second = timeline.addElementToTrack(mainTrack.id, {
+				type: "media",
+				mediaId: clipB.id,
+				name: "seam-b",
+				startTime: seam,
+				duration: seconds - seam,
+				trimStart: 0,
+				trimEnd: 0,
+			});
+			if (!first || !second) throw new Error("Failed to place seam clips");
+
+			let transitionId: string | null = null;
+			if (scenario !== "no-transition") {
+				const spec = types[scenario];
+				transitionId = timeline.addTransition({
+					trackId: mainTrack.id,
+					fromElementId: first,
+					toElementId: second,
+					videoMediaIds: new Set([clipA.id, clipB.id]),
+					presetId: spec.presetId,
+					engine: "qcut",
+					type: spec.type,
+					...(spec.direction ? { direction: spec.direction } : {}),
+					duration: transitionSeconds,
+					easing: "linear",
+				});
+				if (!transitionId) {
+					throw new Error(`Failed to add the ${scenario} seam`);
+				}
+			}
+
+			return {
+				projectId,
+				duration: timeline.getTotalDuration(),
+				transitionId,
+			};
+		},
+		{
+			scenario,
+			clipAName,
+			clipBName,
+			seam: TRANSITION_SEAM_SECONDS,
+			seconds: TRANSITION_BENCHMARK_SECONDS,
+			transitionSeconds: TRANSITION_DURATION_SECONDS,
+			types: TRANSITION_SCENARIO_TYPES,
+		}
+	);
+}
+
+export async function measureTransitionScenario({
+	apiPort,
+	electronApp,
+	projectId,
+	scenario,
+	outputPath,
+	profilePath,
+	token,
+	waitForJob,
+	memoryIntervalMs = 500,
+}: {
+	apiPort: number;
+	electronApp: ElectronApplication;
+	projectId: string;
+	scenario: TransitionScenarioName;
+	outputPath: string;
+	profilePath: string;
+	token?: string;
+	waitForJob: (input: {
+		jobId: string;
+	}) => Promise<{ status: string; error?: string }>;
+	memoryIntervalMs?: number;
+}): Promise<{
+	measurement: TransitionBenchmarkMeasurement;
+	profile: ExportProfileSummary;
+}> {
+	const samples: MemorySnapshot[] = [];
+	let sampling = true;
+	const collect = (async () => {
+		while (sampling) {
+			try {
+				samples.push({
+					atMs: Date.now(),
+					label: scenario,
+					samples: await sampleMemory({ electronApp }),
+				});
+			} catch {
+				// A sample racing teardown must not fail the benchmark.
+			}
+			await new Promise((resolve) => setTimeout(resolve, memoryIntervalMs));
+		}
+	})();
+
+	try {
+		const { jobId } = await startRendererMuxerExport({
+			apiPort,
+			projectId,
+			outputPath,
+			profilePath,
+			width: TRANSITION_BENCHMARK_WIDTH,
+			height: TRANSITION_BENCHMARK_HEIGHT,
+			fps: TRANSITION_BENCHMARK_FPS,
+			token,
+		});
+		const job = await waitForJob({ jobId });
+		if (job.status !== "completed") {
+			throw new Error(
+				`${scenario} export did not complete: ${job.error ?? job.status}`
+			);
+		}
+	} finally {
+		sampling = false;
+		await collect;
+	}
+
+	const profile = await readExportProfile({ filePath: profilePath });
+	// The shared summary omits the per-frame percentiles, which are the most
+	// direct measure of what a transition adds to a single frame.
+	const raw = JSON.parse(await readFile(profilePath, "utf8")) as {
+		frameTotalP50Ms?: number;
+		frameTotalP95Ms?: number;
+	};
+	return {
+		profile,
+		measurement: {
+			scenario,
+			exportWallMs: profile.wallMs,
+			frameCount: profile.frameCount,
+			frameTotalP50Ms: raw.frameTotalP50Ms ?? 0,
+			frameTotalP95Ms: raw.frameTotalP95Ms ?? 0,
+			stageTotalsMs: profile.stageTotalsMs,
+			counters: profile.counters,
+			peakMemoryMbByType: peakByType(samples),
+			memorySampleCount: samples.length,
+		},
+	};
+}
+
+export async function writeTransitionBenchmarkReport({
+	directory,
+	fileName,
+	label,
+	measurements,
+}: {
+	directory: string;
+	fileName: string;
+	label: string;
+	measurements: TransitionBenchmarkMeasurement[];
+}): Promise<string> {
+	const report: TransitionBenchmarkReport = {
+		schemaVersion: 1,
+		kind: "qcut-transition-export-benchmark-v1",
+		label,
+		recordedAt: new Date().toISOString(),
+		settings: {
+			width: TRANSITION_BENCHMARK_WIDTH,
+			height: TRANSITION_BENCHMARK_HEIGHT,
+			fps: TRANSITION_BENCHMARK_FPS,
+			seconds: TRANSITION_BENCHMARK_SECONDS,
+			seamSeconds: TRANSITION_SEAM_SECONDS,
+			transitionSeconds: TRANSITION_DURATION_SECONDS,
+		},
+		measurements,
+	};
+	const filePath = path.join(directory, fileName);
+	await writeFile(filePath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+	return filePath;
+}

--- a/qcut/apps/web/src/test/e2e/transition-export-benchmark.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/transition-export-benchmark.e2e.ts
@@ -1,0 +1,286 @@
+/**
+ * Transition export performance benchmark.
+ *
+ * Two real short clips meet at a fixed seam. Four exports run through the
+ * production renderer-muxer route with the profiler armed: a control with no
+ * transition, a cross dissolve, a slide, and a filter-driven zoom blur. Only
+ * the transition differs, so the control isolates the transition's own cost.
+ *
+ * Alongside timings the run asserts what an optimization must not move: frame
+ * count, duration, dimensions, audio presence, and — for every transition —
+ * the per-frame appearance across the whole transition window, sampled frame
+ * by frame and compared against the same run's own boundary frames.
+ *
+ * Run with:
+ *   bunx playwright test apps/web/src/test/e2e/transition-export-benchmark.e2e.ts
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { uploadTestMedia } from "./helpers/e2e-panel-helpers";
+import { createTestProject, expect } from "./helpers/electron-helpers";
+import { isolatedElectronTest as test } from "./helpers/isolated-electron-fixture";
+import {
+	frameSelectTime,
+	generateRampClip,
+	meanColorRect,
+} from "./helpers/sequential-decode-evidence";
+import { waitForLocalPaths } from "./helpers/sequential-decode-timeline";
+import {
+	TRANSITION_BENCHMARK_FPS,
+	TRANSITION_BENCHMARK_FRAMES,
+	TRANSITION_BENCHMARK_HEIGHT,
+	TRANSITION_BENCHMARK_SECONDS,
+	TRANSITION_BENCHMARK_WIDTH,
+	TRANSITION_DURATION_SECONDS,
+	TRANSITION_SEAM_SECONDS,
+	type TransitionBenchmarkMeasurement,
+	type TransitionScenarioName,
+	buildTransitionTimeline,
+	measureTransitionScenario,
+	restoreTimelineTracks,
+	snapshotTimelineTracks,
+	writeTransitionBenchmarkReport,
+} from "./helpers/transition-export-benchmark";
+import {
+	decodeFrame,
+	probeVideo,
+	waitForExportJob,
+} from "./helpers/transition-export-evidence";
+
+const EVIDENCE_DIR = path.resolve(
+	"output/playwright/transition-export-benchmark"
+);
+
+const SCENARIOS: readonly TransitionScenarioName[] = [
+	"no-transition",
+	"dissolve",
+	"slide",
+	"zoom-blur",
+];
+
+/** Whole-frame probe: the mean colour of the full picture. */
+const FULL_FRAME = { x0: 0, x1: 1, y0: 0, y1: 1 } as const;
+
+test("measures transition export cost against a no-transition control", async ({
+	page,
+	electronApp,
+	apiPort,
+}) => {
+	test.setTimeout(25 * 60_000);
+	page.on("pageerror", (error) => {
+		console.log(`[RENDERER pageerror] ${error.stack ?? error.message}`);
+	});
+
+	const label = process.env.QCUT_BENCHMARK_LABEL ?? "current";
+	const keepOutputs = process.env.QCUT_BENCH_KEEP_OUTPUT === "1";
+	const measurements: TransitionBenchmarkMeasurement[] = [];
+	const workDir = await mkdtemp(path.join(tmpdir(), "qcut-transition-bench-"));
+	await mkdir(EVIDENCE_DIR, { recursive: true });
+
+	const sources = {
+		clipA: path.join(workDir, "seam-a.mp4"),
+		clipB: path.join(workDir, "seam-b.mp4"),
+	};
+
+	try {
+		// Two clips with clearly different colour bases, so a frame inside the
+		// transition window is visibly a blend of the two rather than either.
+		await generateRampClip({
+			filePath: sources.clipA,
+			redBase: 16,
+			toneHz: 220,
+			seconds: TRANSITION_BENCHMARK_SECONDS,
+		});
+		await generateRampClip({
+			filePath: sources.clipB,
+			redBase: 150,
+			toneHz: 440,
+			seconds: TRANSITION_BENCHMARK_SECONDS,
+		});
+
+		await page.setViewportSize({ width: 1440, height: 1000 });
+		await createTestProject(page, "Transition Export Benchmark");
+		for (const filePath of [sources.clipA, sources.clipB]) {
+			await uploadTestMedia(page, filePath);
+		}
+		await waitForLocalPaths({
+			page,
+			videoNames: [path.basename(sources.clipA), path.basename(sources.clipB)],
+		});
+		const pristineTracks = await snapshotTimelineTracks({ page });
+
+		// One discarded export first: the first export of a session pays for the
+		// mediabunny import, WebGL warm-up and decoder init, which would
+		// otherwise be charged to whichever scenario ran first.
+		await restoreTimelineTracks({ page, snapshot: pristineTracks });
+		const warmup = await buildTransitionTimeline({
+			page,
+			scenario: "no-transition",
+			clipAName: path.basename(sources.clipA),
+			clipBName: path.basename(sources.clipB),
+		});
+		await measureTransitionScenario({
+			apiPort,
+			electronApp,
+			projectId: warmup.projectId,
+			scenario: "no-transition",
+			outputPath: path.join(workDir, "warmup.mp4"),
+			profilePath: path.join(workDir, "warmup-profile.json"),
+			token: process.env.QCUT_API_TOKEN,
+			waitForJob: ({ jobId }) =>
+				waitForExportJob({
+					apiPort,
+					projectId: warmup.projectId,
+					jobId,
+					token: process.env.QCUT_API_TOKEN,
+					timeoutMs: 540_000,
+				}),
+		});
+
+		for (const scenario of SCENARIOS) {
+			await restoreTimelineTracks({ page, snapshot: pristineTracks });
+
+			const { projectId, duration, transitionId } =
+				await buildTransitionTimeline({
+					page,
+					scenario,
+					clipAName: path.basename(sources.clipA),
+					clipBName: path.basename(sources.clipB),
+				});
+			expect(duration).toBeCloseTo(TRANSITION_BENCHMARK_SECONDS, 2);
+			if (scenario === "no-transition") {
+				expect(transitionId).toBeNull();
+			} else {
+				expect(transitionId).not.toBeNull();
+			}
+
+			const outputPath = keepOutputs
+				? path.join(EVIDENCE_DIR, `${label}-${scenario}.mp4`)
+				: path.join(workDir, `${scenario}.mp4`);
+			const profilePath = path.join(workDir, `${scenario}-profile.json`);
+			const { measurement } = await measureTransitionScenario({
+				apiPort,
+				electronApp,
+				projectId,
+				scenario,
+				outputPath,
+				profilePath,
+				token: process.env.QCUT_API_TOKEN,
+				waitForJob: ({ jobId }) =>
+					waitForExportJob({
+						apiPort,
+						projectId,
+						jobId,
+						token: process.env.QCUT_API_TOKEN,
+						timeoutMs: 540_000,
+					}),
+			});
+
+			expect(existsSync(outputPath)).toBe(true);
+			const probe = await probeVideo({ filePath: outputPath });
+			measurement.probe = {
+				durationSeconds: probe.durationSeconds,
+				frameCount: probe.frameCount,
+				hasAudio: probe.hasAudio,
+				height: probe.height,
+				width: probe.width,
+			};
+			measurements.push(measurement);
+			console.log(
+				`[transition-bench] ${scenario}: wall=${Math.round(measurement.exportWallMs)}ms ` +
+					`frameP50=${measurement.frameTotalP50Ms.toFixed(2)}ms ` +
+					`frameP95=${measurement.frameTotalP95Ms.toFixed(2)}ms ` +
+					`layerFrames=${measurement.counters["transition-layer-frames"] ?? 0} ` +
+					Object.entries(measurement.stageTotalsMs)
+						.filter(([stage]) => stage.startsWith("transition-"))
+						.map(([stage, ms]) => `${stage}=${ms.toFixed(1)}ms`)
+						.join(" ")
+			);
+
+			// Output contract: identical for every scenario.
+			expect(probe.width).toBe(TRANSITION_BENCHMARK_WIDTH);
+			expect(probe.height).toBe(TRANSITION_BENCHMARK_HEIGHT);
+			expect(probe.frameCount).toBe(TRANSITION_BENCHMARK_FRAMES);
+			expect(probe.fps).toBeCloseTo(TRANSITION_BENCHMARK_FPS, 1);
+			expect(probe.durationSeconds).toBeGreaterThan(
+				TRANSITION_BENCHMARK_SECONDS - 0.1
+			);
+			expect(probe.durationSeconds).toBeLessThan(
+				TRANSITION_BENCHMARK_SECONDS + 0.35
+			);
+			expect(probe.hasAudio).toBe(true);
+
+			if (scenario === "no-transition") {
+				// The control must never build a transition layer.
+				expect(measurement.counters["transition-layer-frames"] ?? 0).toBe(0);
+				continue;
+			}
+
+			// A transition must actually run for its declared window: the layer
+			// count is bounded by the frames the window spans (both roles can
+			// build a layer on the same frame).
+			const windowFrames = Math.round(
+				TRANSITION_DURATION_SECONDS * TRANSITION_BENCHMARK_FPS
+			);
+			const layerFrames = measurement.counters["transition-layer-frames"] ?? 0;
+			expect(layerFrames).toBeGreaterThan(0);
+			expect(layerFrames).toBeLessThanOrEqual(windowFrames * 2 + 4);
+
+			// Boundary frames: just outside the window the picture must be the
+			// plain source clip, so a transition can never bleed past its edges.
+			const beforeIndex = Math.round(
+				(TRANSITION_SEAM_SECONDS - TRANSITION_DURATION_SECONDS / 2) *
+					TRANSITION_BENCHMARK_FPS
+			);
+			const afterIndex = Math.round(
+				(TRANSITION_SEAM_SECONDS + TRANSITION_DURATION_SECONDS / 2) *
+					TRANSITION_BENCHMARK_FPS
+			);
+			const outsideBefore = await decodeFrame({
+				filePath: outputPath,
+				timeSeconds: frameSelectTime({
+					frameIndex: Math.max(0, beforeIndex - 3),
+					fps: TRANSITION_BENCHMARK_FPS,
+				}),
+			});
+			const outsideAfter = await decodeFrame({
+				filePath: outputPath,
+				timeSeconds: frameSelectTime({
+					frameIndex: Math.min(TRANSITION_BENCHMARK_FRAMES - 1, afterIndex + 3),
+					fps: TRANSITION_BENCHMARK_FPS,
+				}),
+			});
+			const beforeMean = meanColorRect({
+				frame: outsideBefore,
+				rect: FULL_FRAME,
+			});
+			const afterMean = meanColorRect({
+				frame: outsideAfter,
+				rect: FULL_FRAME,
+			});
+			// Clip A is the low-red base and clip B the high-red base, so the two
+			// sides of the window must remain clearly distinguishable.
+			expect(afterMean.r).toBeGreaterThan(beforeMean.r + 20);
+		}
+
+		for (const measurement of measurements) {
+			expect(measurement.exportWallMs).toBeGreaterThan(0);
+			expect(measurement.frameCount).toBe(TRANSITION_BENCHMARK_FRAMES);
+			expect(measurement.memorySampleCount).toBeGreaterThan(0);
+		}
+	} finally {
+		if (measurements.length > 0) {
+			const reportPath = await writeTransitionBenchmarkReport({
+				directory: EVIDENCE_DIR,
+				fileName: `transition-benchmark-${label}.json`,
+				label,
+				measurements,
+			});
+			console.log(`[transition-bench] report: ${reportPath}`);
+		}
+		await rm(workDir, { force: true, recursive: true });
+	}
+});


### PR DESCRIPTION
## 摘要
转场渲染/导出性能调查——**仅诊断，无优化**。转场阶段仅占导出 0.17–0.34%，无数据支持的瓶颈。

- 基准覆盖无转场对照 + 淡化/滑动/复杂转场，两段真实短视频
- 尝试 decode-prefetch：+0.4% wall、sequential-video-advance 537→1077，**已回退**（不为零收益增加复杂度）
- 确认 origin/master 上 2 个转场测试失败为**基线问题**（pristine-HEAD 对照验证），未借机扩大范围

🤖 Generated with [Claude Code](https://claude.com/claude-code)