### PR TITLE
test(export): benchmark the default CLI export path

### DIFF
--- a/qcut/apps/web/src/test/e2e/cli-export-benchmark.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/cli-export-benchmark.e2e.ts
@@ -1,0 +1,314 @@
+/**
+ * Desktop default (CLI / FFmpeg) export benchmark.
+ *
+ * Four timelines are exported through the renderer automation bridge with the
+ * engine the desktop export panel pins by default. The renderer's own
+ * engine-selection log is captured and asserted, so a run that silently fell
+ * back to another engine fails instead of reporting numbers for the wrong path.
+ *
+ * Each export is verified with ffprobe (frame count, duration, geometry, and
+ * for the audio scenario the sample rate and channel layout) plus key-frame
+ * pixel probes, so a faster export that changed the picture or the audio
+ * cannot pass.
+ *
+ * Run with:
+ *   bunx playwright test apps/web/src/test/e2e/cli-export-benchmark.e2e.ts
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	CLI_BENCHMARK_FPS,
+	CLI_BENCHMARK_FRAMES,
+	CLI_BENCHMARK_HEIGHT,
+	CLI_BENCHMARK_SECONDS,
+	CLI_BENCHMARK_WIDTH,
+	type CliBenchmarkMeasurement,
+	type CliScenarioName,
+	buildCliTimeline,
+	generateCliStill,
+	generateSilentClip,
+	measureCliExport,
+	probeExportedAudio,
+	probeVideoElementLoad,
+	resolveSelectedEngine,
+	restoreTimelineTracks,
+	snapshotTimelineTracks,
+	writeCliBenchmarkReport,
+} from "./helpers/cli-export-benchmark";
+import { uploadTestMedia } from "./helpers/e2e-panel-helpers";
+import { createTestProject, expect } from "./helpers/electron-helpers";
+import { isolatedElectronTest as test } from "./helpers/isolated-electron-fixture";
+import {
+	frameSelectTime,
+	generateRampClip,
+	meanColorRect,
+} from "./helpers/sequential-decode-evidence";
+import { waitForLocalPaths } from "./helpers/sequential-decode-timeline";
+import { decodeFrame, probeVideo } from "./helpers/transition-export-evidence";
+
+const EVIDENCE_DIR = path.resolve("output/playwright/cli-export-benchmark");
+
+const SCENARIOS: readonly CliScenarioName[] = [
+	"single-video",
+	"sequential-clips",
+	"image-text-overlay",
+	"video-with-audio",
+	"large-library",
+];
+
+/** Central patch, used to prove each export still renders real picture. */
+const FRAME_REGION = { x0: 0.3, x1: 0.7, y0: 0.3, y1: 0.7 } as const;
+
+test("measures the desktop default CLI export path", async ({
+	page,
+	electronApp,
+}) => {
+	test.setTimeout(30 * 60_000);
+	page.on("pageerror", (error) => {
+		console.log(`[RENDERER pageerror] ${error.stack ?? error.message}`);
+	});
+
+	// The factory logs its resolved choice ungated. That line — not the panel's
+	// "auto" selection — is what proves which engine actually ran.
+	const engineLog: string[] = [];
+	// Console arrival times turn the renderer's own progress chatter into a
+	// crude stage profile: the largest silent gap is where the export spent
+	// its time, which is enough to localize a slow path without arming the
+	// profiler (the automation bridge cannot arm it on this route).
+	const consoleTrail: Array<{ atMs: number; text: string }> = [];
+	page.on("console", (message) => {
+		const text = message.text();
+		consoleTrail.push({ atMs: Date.now(), text });
+		if (text.includes("EXPORT ENGINE SELECTION:")) engineLog.push(text);
+	});
+
+	const label = process.env.QCUT_BENCHMARK_LABEL ?? "current";
+	const keepOutputs = process.env.QCUT_BENCH_KEEP_OUTPUT === "1";
+	const measurements: CliBenchmarkMeasurement[] = [];
+	const workDir = await mkdtemp(path.join(tmpdir(), "qcut-cli-bench-"));
+	await mkdir(EVIDENCE_DIR, { recursive: true });
+
+	const sources = {
+		videoA: path.join(workDir, "cli-a.mp4"),
+		videoB: path.join(workDir, "cli-b.mp4"),
+		audioVideo: path.join(workDir, "cli-audio.mp4"),
+		image: path.join(workDir, "cli-still.png"),
+	};
+
+	try {
+		// Silent clips everywhere except the audio scenario, so "has audio" is a
+		// property of the timeline rather than an accident of the fixtures.
+		await generateSilentClip({
+			filePath: sources.videoA,
+			seconds: CLI_BENCHMARK_SECONDS + 2,
+		});
+		await generateSilentClip({
+			filePath: sources.videoB,
+			seconds: CLI_BENCHMARK_SECONDS + 2,
+			pattern: "smptebars",
+		});
+		await generateRampClip({
+			filePath: sources.audioVideo,
+			redBase: 16,
+			toneHz: 220,
+			seconds: CLI_BENCHMARK_SECONDS + 2,
+		});
+		await generateCliStill({ filePath: sources.image });
+
+		await page.setViewportSize({ width: 1440, height: 1000 });
+		await createTestProject(page, "CLI Export Benchmark");
+		for (const filePath of Object.values(sources)) {
+			await uploadTestMedia(page, filePath);
+		}
+		await waitForLocalPaths({
+			page,
+			videoNames: [
+				path.basename(sources.videoA),
+				path.basename(sources.videoB),
+				path.basename(sources.audioVideo),
+			],
+		});
+		// Filler clips are imported but never placed on a timeline. They exist to
+		// expose work that scales with the media library rather than the export.
+		const fillerPaths: string[] = [];
+		for (let index = 0; index < 8; index += 1) {
+			const fillerPath = path.join(workDir, `cli-filler-${index}.mp4`);
+			await generateSilentClip({ filePath: fillerPath, seconds: 2 });
+			fillerPaths.push(fillerPath);
+		}
+		for (const fillerPath of fillerPaths) {
+			await uploadTestMedia(page, fillerPath);
+		}
+		await waitForLocalPaths({
+			page,
+			videoNames: fillerPaths.map((fillerPath) => path.basename(fillerPath)),
+		});
+
+		const pristineTracks = await snapshotTimelineTracks({ page });
+
+		/**
+		 * The export panel owns `__exportActions`, and resetting the timeline
+		 * unmounts it, so the panel is re-opened before every export.
+		 */
+		const ensureExportActions = async () => {
+			const registered = await page.evaluate(() =>
+				Boolean(
+					(window as unknown as { __exportActions?: unknown }).__exportActions
+				)
+			);
+			if (registered) return;
+			await page.getByTestId("export-button").click();
+			await expect(page.getByTestId("export-dialog")).toBeVisible();
+			await page.waitForFunction(
+				() =>
+					Boolean(
+						(window as unknown as { __exportActions?: unknown }).__exportActions
+					),
+				undefined,
+				{ timeout: 15_000 }
+			);
+		};
+
+		// Discarded warm-up export absorbs session start-up cost.
+		await restoreTimelineTracks({ page, snapshot: pristineTracks });
+		const warmup = await buildCliTimeline({
+			page,
+			scenario: "single-video",
+			videoAName: path.basename(sources.videoA),
+			videoBName: path.basename(sources.videoB),
+			audioVideoName: path.basename(sources.audioVideo),
+			imageName: path.basename(sources.image),
+		});
+		await ensureExportActions();
+		await measureCliExport({
+			page,
+			electronApp,
+			projectId: warmup.projectId,
+			scenario: "single-video",
+			outputPath: path.join(workDir, "warmup.mp4"),
+		});
+
+		for (const scenario of SCENARIOS) {
+			await restoreTimelineTracks({ page, snapshot: pristineTracks });
+			const { projectId, duration } = await buildCliTimeline({
+				page,
+				scenario,
+				videoAName: path.basename(sources.videoA),
+				videoBName: path.basename(sources.videoB),
+				audioVideoName: path.basename(sources.audioVideo),
+				imageName: path.basename(sources.image),
+			});
+			expect(duration).toBeCloseTo(CLI_BENCHMARK_SECONDS, 2);
+
+			await ensureExportActions();
+			const loadProbe = await probeVideoElementLoad({ page });
+			const trailFrom = consoleTrail.length;
+			const engineLogBefore = engineLog.length;
+			const outputPath = keepOutputs
+				? path.join(EVIDENCE_DIR, `${label}-${scenario}.mp4`)
+				: path.join(workDir, `${scenario}.mp4`);
+			const run = await measureCliExport({
+				page,
+				electronApp,
+				projectId,
+				scenario,
+				outputPath,
+			});
+			let widestGapMs = 0;
+			let widestGapAfter = "";
+			for (let index = trailFrom + 1; index < consoleTrail.length; index += 1) {
+				const gap = consoleTrail[index].atMs - consoleTrail[index - 1].atMs;
+				if (gap > widestGapMs) {
+					widestGapMs = gap;
+					widestGapAfter = consoleTrail[index - 1].text.slice(0, 90);
+				}
+			}
+
+			const selectedEngine = resolveSelectedEngine({
+				lines: engineLog.slice(engineLogBefore),
+			});
+			expect(
+				selectedEngine,
+				`${scenario} did not run on the CLI engine; captured: ${JSON.stringify(engineLog.slice(engineLogBefore))}`
+			).toBe("cli");
+
+			expect(existsSync(outputPath)).toBe(true);
+			const probe = await probeVideo({ filePath: outputPath });
+			const audio = probe.hasAudio
+				? await probeExportedAudio({ filePath: outputPath })
+				: null;
+			measurements.push({
+				scenario,
+				wallMs: run.wallMs,
+				videoLoadProbeMs: loadProbe.loadMs,
+				loadedVideoCount: loadProbe.count,
+				selectedEngine,
+				peakMemoryMbByType: run.peakMemoryMbByType,
+				memorySampleCount: run.memorySampleCount,
+				probe: {
+					audioChannels: audio?.channels ?? null,
+					audioSampleRate: audio?.sampleRate ?? null,
+					durationSeconds: probe.durationSeconds,
+					frameCount: probe.frameCount,
+					fps: probe.fps,
+					hasAudio: probe.hasAudio,
+					height: probe.height,
+					width: probe.width,
+				},
+			});
+			console.log(
+				`[cli-bench] ${scenario}: engine=${selectedEngine} wall=${run.wallMs}ms ` +
+					`videoLoadProbe=${loadProbe.loadMs}ms over ${loadProbe.count} videos ` +
+					`frames=${probe.frameCount} dur=${probe.durationSeconds.toFixed(3)}s ` +
+					`audio=${probe.hasAudio ? `${audio?.sampleRate}Hz/${audio?.channels}ch` : "none"} ` +
+					`peakTab=${run.peakMemoryMbByType.Tab ?? 0}MB ` +
+					`widestGap=${widestGapMs}ms after "${widestGapAfter}"`
+			);
+
+			// Output contract: geometry, timing and audio must not move.
+			expect(probe.width).toBe(CLI_BENCHMARK_WIDTH);
+			expect(probe.height).toBe(CLI_BENCHMARK_HEIGHT);
+			expect(probe.fps).toBeCloseTo(CLI_BENCHMARK_FPS, 1);
+			expect(probe.frameCount).toBeGreaterThanOrEqual(CLI_BENCHMARK_FRAMES - 2);
+			expect(probe.frameCount).toBeLessThanOrEqual(CLI_BENCHMARK_FRAMES + 2);
+			expect(probe.durationSeconds).toBeGreaterThan(
+				CLI_BENCHMARK_SECONDS - 0.15
+			);
+			expect(probe.durationSeconds).toBeLessThan(CLI_BENCHMARK_SECONDS + 0.35);
+			if (scenario === "video-with-audio") {
+				expect(probe.hasAudio).toBe(true);
+				expect(audio?.sampleRate).toBeGreaterThan(0);
+				expect(audio?.channels).toBeGreaterThan(0);
+			}
+
+			// Key-frame pixel probe: the picture is real, not black frames.
+			for (const frameIndex of [5, 90, 170]) {
+				const frame = await decodeFrame({
+					filePath: outputPath,
+					timeSeconds: frameSelectTime({
+						frameIndex,
+						fps: CLI_BENCHMARK_FPS,
+					}),
+				});
+				const mean = meanColorRect({ frame, rect: FRAME_REGION });
+				expect(
+					mean.r + mean.g + mean.b,
+					`${scenario} frame ${frameIndex} is black`
+				).toBeGreaterThan(20);
+			}
+		}
+
+		const reportPath = await writeCliBenchmarkReport({
+			directory: EVIDENCE_DIR,
+			fileName: `cli-benchmark-${label}.json`,
+			label,
+			measurements,
+		});
+		console.log(`[cli-bench] report: ${reportPath}`);
+	} finally {
+		await rm(workDir, { force: true, recursive: true });
+	}
+});

--- a/qcut/apps/web/src/test/e2e/helpers/__tests__/cli-export-engine-resolution.test.ts
+++ b/qcut/apps/web/src/test/e2e/helpers/__tests__/cli-export-engine-resolution.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { resolveSelectedEngine } from "../cli-export-benchmark";
+
+describe("export engine resolution from renderer logs", () => {
+	it("reads the engine the factory actually chose", () => {
+		expect(
+			resolveSelectedEngine({
+				lines: [
+					"🚀 EXPORT ENGINE SELECTION: CLI FFmpeg chosen for Electron environment",
+				],
+			})
+		).toBe("cli");
+	});
+
+	it("ignores the panel's own selection line", () => {
+		// The desktop panel commonly reports `auto`, which the factory then
+		// resolves to CLI. A benchmark trusting this line would claim the wrong
+		// engine — this is the exact mistake the resolver exists to prevent.
+		expect(
+			resolveSelectedEngine({
+				lines: ["  - User selected engine: auto"],
+			})
+		).toBeNull();
+	});
+
+	it("uses the most recent selection when several exports ran", () => {
+		expect(
+			resolveSelectedEngine({
+				lines: [
+					"🚀 EXPORT ENGINE SELECTION: CLI FFmpeg chosen for Electron environment",
+					"🚀 EXPORT ENGINE SELECTION: Remotion engine chosen",
+				],
+			})
+		).toBe("remotion");
+	});
+
+	it("returns null when nothing announced an engine", () => {
+		expect(resolveSelectedEngine({ lines: [] })).toBeNull();
+		expect(
+			resolveSelectedEngine({ lines: ["some unrelated renderer log"] })
+		).toBeNull();
+	});
+
+	it("does not mistake one engine's line for another", () => {
+		expect(
+			resolveSelectedEngine({
+				lines: ["🚀 EXPORT ENGINE SELECTION: Standard canvas engine chosen"],
+			})
+		).toBe("standard");
+	});
+});

--- a/qcut/apps/web/src/test/e2e/helpers/cli-export-benchmark.ts
+++ b/qcut/apps/web/src/test/e2e/helpers/cli-export-benchmark.ts
@@ -1,0 +1,562 @@
+/**
+ * Reproducible benchmark for the desktop default export path.
+ *
+ * The desktop export panel pins the CLI engine (`use-export-settings` selects
+ * `"cli"` whenever `isElectron()`), so this harness drives exports through the
+ * renderer automation bridge with `engine: "cli"` and asserts from the
+ * renderer's own engine-selection log that the CLI engine really ran — a
+ * benchmark that silently fell back to another engine would measure nothing.
+ *
+ * Alongside wall time it records a direct probe of how long the project's
+ * video elements take to load, which is what attributes any delta to the
+ * engine's eager pre-load rather than to encoding.
+ */
+
+import { execFile } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { ElectronApplication, Page } from "@playwright/test";
+import {
+	getFFmpegPath,
+	getFFprobePath,
+} from "../../../../../../electron/ffmpeg/paths";
+import {
+	type MemorySnapshot,
+	peakByType,
+	sampleMemory,
+} from "./export-lifecycle-memory";
+import type { ExposedWindow } from "./sequential-decode-timeline";
+
+const execFileAsync = promisify(execFile);
+
+/** Audio stream facts an export must preserve exactly. */
+export async function probeExportedAudio({
+	filePath,
+}: {
+	filePath: string;
+}): Promise<{ channels: number; sampleRate: number; codecName: string }> {
+	const { stdout } = await execFileAsync(await getFFprobePath(), [
+		"-v",
+		"error",
+		"-select_streams",
+		"a:0",
+		"-show_entries",
+		"stream=codec_name,channels,sample_rate",
+		"-of",
+		"json",
+		filePath,
+	]);
+	const parsed = JSON.parse(stdout) as {
+		streams?: Array<{
+			channels?: number;
+			codec_name?: string;
+			sample_rate?: string;
+		}>;
+	};
+	const stream = parsed.streams?.[0];
+	if (!stream) throw new Error(`No audio stream in ${filePath}`);
+	return {
+		channels: stream.channels ?? 0,
+		codecName: stream.codec_name ?? "",
+		sampleRate: Number(stream.sample_rate ?? 0),
+	};
+}
+
+/**
+ * Resolves which engine actually ran from the factory's own selection log.
+ *
+ * The export panel's "user selected engine" line is not the answer: on desktop
+ * it commonly reads `auto`, which the factory then resolves to CLI. Only the
+ * factory's `EXPORT ENGINE SELECTION:` line names the engine that ran, so a
+ * benchmark asserting on the panel value would happily measure another engine.
+ */
+export function resolveSelectedEngine({
+	lines,
+}: {
+	lines: readonly string[];
+}): "cli" | "muxer" | "remotion" | "optimized" | "standard" | null {
+	const line = [...lines]
+		.reverse()
+		.find((candidate) => candidate.includes("EXPORT ENGINE SELECTION:"));
+	if (!line) return null;
+	if (line.includes("CLI FFmpeg")) return "cli";
+	if (line.includes("Remotion")) return "remotion";
+	if (line.includes("WebCodecs") || line.includes("Muxer")) return "muxer";
+	if (line.includes("Optimized")) return "optimized";
+	if (line.includes("Standard")) return "standard";
+	return null;
+}
+
+export const CLI_BENCHMARK_FPS = 30;
+export const CLI_BENCHMARK_WIDTH = 1280;
+export const CLI_BENCHMARK_HEIGHT = 720;
+export const CLI_BENCHMARK_SECONDS = 6;
+export const CLI_BENCHMARK_FRAMES = Math.round(
+	CLI_BENCHMARK_SECONDS * CLI_BENCHMARK_FPS
+);
+
+export type CliScenarioName =
+	| "single-video"
+	| "sequential-clips"
+	| "image-text-overlay"
+	| "video-with-audio"
+	/**
+	 * One clip on the timeline but a large media library. The engine's eager
+	 * pre-load walks every imported video rather than the ones actually used,
+	 * so this scenario is what shows whether that cost scales with the library.
+	 */
+	| "large-library";
+
+/** Still used by the overlay scenario. */
+export async function generateCliStill({
+	filePath,
+	color = "0x20c060",
+	size = 384,
+}: {
+	filePath: string;
+	color?: string;
+	size?: number;
+}): Promise<void> {
+	await execFileAsync(getFFmpegPath(), [
+		"-y",
+		"-f",
+		"lavfi",
+		"-i",
+		`color=c=${color}:s=${size}x${size}`,
+		"-frames:v",
+		"1",
+		filePath,
+	]);
+}
+
+/** Clip with no audio stream, so the audio scenario is the only one with sound. */
+export async function generateSilentClip({
+	filePath,
+	seconds,
+	pattern = "testsrc2",
+}: {
+	filePath: string;
+	seconds: number;
+	pattern?: string;
+}): Promise<void> {
+	await execFileAsync(getFFmpegPath(), [
+		"-y",
+		"-f",
+		"lavfi",
+		"-i",
+		`${pattern}=size=${CLI_BENCHMARK_WIDTH}x${CLI_BENCHMARK_HEIGHT}:rate=${CLI_BENCHMARK_FPS}:duration=${seconds}`,
+		"-c:v",
+		"libx264",
+		"-pix_fmt",
+		"yuv420p",
+		"-colorspace",
+		"bt709",
+		"-color_primaries",
+		"bt709",
+		"-color_trc",
+		"bt709",
+		"-an",
+		filePath,
+	]);
+}
+
+export interface CliBenchmarkMeasurement {
+	scenario: CliScenarioName;
+	wallMs: number;
+	/** Direct cost of loading every project video element, measured in-page. */
+	videoLoadProbeMs: number;
+	loadedVideoCount: number;
+	selectedEngine: string | null;
+	peakMemoryMbByType: Record<string, number>;
+	memorySampleCount: number;
+	probe?: {
+		frameCount: number;
+		durationSeconds: number;
+		width: number;
+		height: number;
+		fps: number;
+		hasAudio: boolean;
+		audioSampleRate: number | null;
+		audioChannels: number | null;
+	};
+}
+
+export interface CliBenchmarkReport {
+	schemaVersion: 1;
+	kind: "qcut-cli-export-benchmark-v1";
+	label: string;
+	recordedAt: string;
+	settings: {
+		width: number;
+		height: number;
+		fps: number;
+		seconds: number;
+	};
+	measurements: CliBenchmarkMeasurement[];
+}
+
+interface TimelineStoreWithSetState {
+	getState: () => { tracks: unknown[] };
+	setState: (state: Record<string, unknown>) => void;
+}
+
+export async function snapshotTimelineTracks({
+	page,
+}: {
+	page: Page;
+}): Promise<string> {
+	return page.evaluate(() => {
+		const editorWindow = window as unknown as {
+			__timelineStore: TimelineStoreWithSetState;
+		};
+		return JSON.stringify(editorWindow.__timelineStore.getState().tracks);
+	});
+}
+
+export async function restoreTimelineTracks({
+	page,
+	snapshot,
+}: {
+	page: Page;
+	snapshot: string;
+}): Promise<void> {
+	await page.evaluate((serialized) => {
+		const editorWindow = window as unknown as {
+			__timelineStore: TimelineStoreWithSetState;
+		};
+		editorWindow.__timelineStore.setState({
+			_tracks: JSON.parse(serialized),
+			tracks: JSON.parse(serialized) as unknown[],
+			selectedElements: [],
+		});
+	}, snapshot);
+}
+
+/**
+ * Measures, in the page, how long every project video takes to reach
+ * `loadeddata` — the same work the engine's eager pre-load performs.
+ *
+ * This is a read-only probe: it creates its own elements and discards them, so
+ * it never disturbs the engine's own caches.
+ */
+export async function probeVideoElementLoad({
+	page,
+}: {
+	page: Page;
+}): Promise<{ loadMs: number; count: number }> {
+	return page.evaluate(async () => {
+		const editorWindow = window as unknown as ExposedWindow;
+		const items = editorWindow.__mediaStore.getState().mediaItems as Array<{
+			type?: string;
+			url?: string;
+		}>;
+		const urls = new Set<string>();
+		for (const item of items) {
+			if (item.type === "video" && item.url) urls.add(item.url);
+		}
+		const startedAt = performance.now();
+		await Promise.all(
+			Array.from(urls).map(
+				(url) =>
+					new Promise<void>((resolve, reject) => {
+						const video = document.createElement("video");
+						video.src = url;
+						video.crossOrigin = "anonymous";
+						video.onloadeddata = () => resolve();
+						video.onerror = () => reject(new Error(`load failed: ${url}`));
+					})
+			)
+		);
+		return {
+			count: urls.size,
+			loadMs: Number((performance.now() - startedAt).toFixed(1)),
+		};
+	});
+}
+
+export async function buildCliTimeline({
+	page,
+	scenario,
+	videoAName,
+	videoBName,
+	audioVideoName,
+	imageName,
+}: {
+	page: Page;
+	scenario: CliScenarioName;
+	videoAName: string;
+	videoBName: string;
+	audioVideoName: string;
+	imageName: string;
+}): Promise<{ projectId: string; duration: number }> {
+	return page.evaluate(
+		({
+			scenario,
+			videoAName,
+			videoBName,
+			audioVideoName,
+			imageName,
+			seconds,
+		}) => {
+			const editorWindow = window as unknown as ExposedWindow;
+			const projectId =
+				editorWindow.__projectStore.getState().activeProject?.id;
+			if (!projectId) throw new Error("No active project");
+			const items = editorWindow.__mediaStore.getState().mediaItems;
+			const byName = (name: string) => {
+				const item = items.find((candidate) => candidate.name === name);
+				if (!item) throw new Error(`Media ${name} was not imported`);
+				return item;
+			};
+
+			const timeline = editorWindow.__timelineStore.getState();
+			const mainTrack = timeline.tracks.find(
+				(candidate) => candidate.isMain || candidate.type === "media"
+			);
+			if (!mainTrack) throw new Error("Missing main media track");
+
+			const add = ({
+				trackId,
+				name,
+				mediaId,
+				startTime,
+				duration,
+				extra = {},
+			}: {
+				trackId: string;
+				name: string;
+				mediaId: string;
+				startTime: number;
+				duration: number;
+				extra?: Record<string, unknown>;
+			}) => {
+				const id = timeline.addElementToTrack(trackId, {
+					type: "media",
+					mediaId,
+					name,
+					startTime,
+					duration,
+					trimStart: 0,
+					trimEnd: 0,
+					...extra,
+				});
+				if (!id) throw new Error(`Failed to add ${name}`);
+				return id;
+			};
+
+			if (scenario === "sequential-clips") {
+				const third = seconds / 3;
+				add({
+					trackId: mainTrack.id,
+					name: "cli-a",
+					mediaId: byName(videoAName).id,
+					startTime: 0,
+					duration: third,
+				});
+				add({
+					trackId: mainTrack.id,
+					name: "cli-b",
+					mediaId: byName(videoBName).id,
+					startTime: third,
+					duration: third,
+				});
+				add({
+					trackId: mainTrack.id,
+					name: "cli-c",
+					mediaId: byName(videoAName).id,
+					startTime: third * 2,
+					duration: seconds - third * 2,
+				});
+			} else if (
+				scenario === "video-with-audio" ||
+				scenario === "large-library"
+			) {
+				add({
+					trackId: mainTrack.id,
+					name: "cli-audio-clip",
+					mediaId: byName(
+						scenario === "large-library" ? videoAName : audioVideoName
+					).id,
+					startTime: 0,
+					duration: seconds,
+				});
+			} else {
+				add({
+					trackId: mainTrack.id,
+					name: "cli-main",
+					mediaId: byName(videoAName).id,
+					startTime: 0,
+					duration: seconds,
+				});
+				if (scenario === "image-text-overlay") {
+					const imageTrack = timeline.insertTrackAt("media", 0);
+					add({
+						trackId: imageTrack,
+						name: "cli-still",
+						mediaId: byName(imageName).id,
+						startTime: 0,
+						duration: seconds,
+						extra: { x: -240, y: -120, scaleX: 0.35, scaleY: 0.35 },
+					});
+					const textTrack = timeline.insertTrackAt("text", 0);
+					const textId = timeline.addElementToTrack(textTrack, {
+						type: "text",
+						name: "cli-text",
+						content: "QCut CLI export benchmark",
+						startTime: 0,
+						duration: seconds,
+						trimStart: 0,
+						trimEnd: 0,
+						fontSize: 56,
+						fontFamily: "Arial",
+						color: "#ffffff",
+						backgroundColor: "transparent",
+						textAlign: "center",
+						fontWeight: "bold",
+						fontStyle: "normal",
+						textDecoration: "none",
+						x: 0,
+						y: 200,
+						rotation: 0,
+						opacity: 1,
+					});
+					if (!textId) throw new Error("Failed to add the text overlay");
+				}
+			}
+
+			return { projectId, duration: timeline.getTotalDuration() };
+		},
+		{
+			scenario,
+			videoAName,
+			videoBName,
+			audioVideoName,
+			imageName,
+			seconds: CLI_BENCHMARK_SECONDS,
+		}
+	);
+}
+
+/** Runs one CLI export end to end while sampling process memory. */
+export async function measureCliExport({
+	page,
+	electronApp,
+	projectId,
+	scenario,
+	outputPath,
+	memoryIntervalMs = 500,
+}: {
+	page: Page;
+	electronApp: ElectronApplication;
+	projectId: string;
+	scenario: CliScenarioName;
+	outputPath: string;
+	memoryIntervalMs?: number;
+}): Promise<{
+	wallMs: number;
+	peakMemoryMbByType: Record<string, number>;
+	memorySampleCount: number;
+}> {
+	const samples: MemorySnapshot[] = [];
+	let sampling = true;
+	const collect = (async () => {
+		while (sampling) {
+			try {
+				samples.push({
+					atMs: Date.now(),
+					label: scenario,
+					samples: await sampleMemory({ electronApp }),
+				});
+			} catch {
+				// A sample racing teardown must not fail the benchmark.
+			}
+			await new Promise((resolve) => setTimeout(resolve, memoryIntervalMs));
+		}
+	})();
+
+	const startedAt = Date.now();
+	try {
+		const result = await page.evaluate(
+			async ({ outputPath, projectId, fps, width, height }) => {
+				const actions = (
+					window as unknown as {
+						__exportActions?: {
+							exportLocalVideo: (
+								request: Record<string, unknown>
+							) => Promise<void>;
+						};
+					}
+				).__exportActions;
+				if (!actions) throw new Error("Export actions are not registered");
+				try {
+					await actions.exportLocalVideo({
+						engine: "cli",
+						filename: "cli-benchmark",
+						format: "mp4",
+						frameRate: fps,
+						height,
+						outputPath,
+						projectId,
+						quality: "720p",
+						width,
+					});
+					return { ok: true as const };
+				} catch (error) {
+					return {
+						ok: false as const,
+						error: error instanceof Error ? error.message : String(error),
+					};
+				}
+			},
+			{
+				fps: CLI_BENCHMARK_FPS,
+				height: CLI_BENCHMARK_HEIGHT,
+				outputPath,
+				projectId,
+				width: CLI_BENCHMARK_WIDTH,
+			}
+		);
+		if (!result.ok) {
+			throw new Error(`${scenario} CLI export failed: ${result.error}`);
+		}
+	} finally {
+		sampling = false;
+		await collect;
+	}
+
+	return {
+		memorySampleCount: samples.length,
+		peakMemoryMbByType: peakByType(samples),
+		wallMs: Date.now() - startedAt,
+	};
+}
+
+export async function writeCliBenchmarkReport({
+	directory,
+	fileName,
+	label,
+	measurements,
+}: {
+	directory: string;
+	fileName: string;
+	label: string;
+	measurements: CliBenchmarkMeasurement[];
+}): Promise<string> {
+	const report: CliBenchmarkReport = {
+		schemaVersion: 1,
+		kind: "qcut-cli-export-benchmark-v1",
+		label,
+		recordedAt: new Date().toISOString(),
+		settings: {
+			width: CLI_BENCHMARK_WIDTH,
+			height: CLI_BENCHMARK_HEIGHT,
+			fps: CLI_BENCHMARK_FPS,
+			seconds: CLI_BENCHMARK_SECONDS,
+		},
+		measurements,
+	};
+	const filePath = path.join(directory, fileName);
+	await writeFile(filePath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+	return filePath;
+}


### PR DESCRIPTION
## 摘要
桌面默认 CLI/FFmpeg 导出路径基准——**仅诊断，无优化**。

- 重点假设验证：\`preloadAllVideos\` 在 CLI 路径确为死代码（调用链证明：export-engine-cli 对 videoCache 零消费），**但**实测加载 11 个视频元素仅 5.7–11ms（blob URL 常驻内存），对 500–7000ms 的导出不构成瓶颈——按"调用链+数据双证明才动手"的门槛未做改动
- 真实发现：image-text-overlay 场景 7s vs 其他 ~1s（DIRECT COPY vs 重编码），已记录待查
- 每场景断言工厂 resolved engine=cli（修正了误读面板 user-selection 行的坑，resolveSelectedEngine 抽出并单测 5/5）

🤖 Generated with [Claude Code](https://claude.com/claude-code)