### PR TITLE
test(preview): benchmark 1080p60 playback against master clock rate

### DIFF
--- a/qcut/apps/web/src/test/e2e/helpers/__tests__/high-fps-frame-rates.test.ts
+++ b/qcut/apps/web/src/test/e2e/helpers/__tests__/high-fps-frame-rates.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+	deriveFrameRates,
+	PRESENTED_RING_CAPACITY,
+} from "../high-fps-preview-benchmark";
+
+/**
+ * These tests pin the two measurement traps that make healthy 60fps playback
+ * look like it collapsed to 30fps. Both produced a convincing false regression
+ * while this benchmark was being built.
+ */
+
+function video({
+	videoId,
+	total,
+	dropped = 0,
+}: {
+	videoId: string;
+	total: number | null;
+	dropped?: number | null;
+}) {
+	return {
+		droppedVideoFrames: dropped,
+		totalVideoFrames: total,
+		videoId,
+	};
+}
+
+function records({
+	videoIds,
+	count,
+}: {
+	videoIds: string[];
+	count: number;
+}): Array<{ videoId: string }> {
+	return Array.from({ length: count }, (_unused, index) => ({
+		videoId: videoIds[index % videoIds.length],
+	}));
+}
+
+describe("deriveFrameRates", () => {
+	it("reports both rates for an unsaturated single-layer window", () => {
+		const rates = deriveFrameRates({
+			elapsedSeconds: 4,
+			presentedRecords: records({ count: 240, videoIds: ["a"] }),
+			videosAfter: [video({ total: 240, videoId: "a" })],
+			videosBefore: [video({ total: 0, videoId: "a" })],
+		});
+
+		expect(rates.presentedRecordsSaturated).toBe(false);
+		expect(rates.presentedFpsByVideo.a).toBe(60);
+		expect(rates.presentedFpsByQuality.a).toBe(60);
+		expect(rates.totalFrames).toBe(240);
+	});
+
+	it("flags saturation when two 60fps layers fill the ring", () => {
+		// Two layers at 60fps over 4s would produce 480 records, but the ring
+		// only keeps 300 — so each layer appears to present at ~37fps.
+		const rates = deriveFrameRates({
+			elapsedSeconds: 4,
+			presentedRecords: records({
+				count: PRESENTED_RING_CAPACITY,
+				videoIds: ["a", "b"],
+			}),
+			videosAfter: [
+				video({ total: 240, videoId: "a" }),
+				video({ total: 240, videoId: "b" }),
+			],
+			videosBefore: [
+				video({ total: 0, videoId: "a" }),
+				video({ total: 0, videoId: "b" }),
+			],
+		});
+
+		expect(rates.presentedRecordsSaturated).toBe(true);
+		// The truncated view understates badly...
+		expect(rates.presentedFpsByVideo.a).toBeCloseTo(37.5, 1);
+		expect(rates.presentedFpsByVideo.b).toBeCloseTo(37.5, 1);
+		// ...while the authoritative counter shows real 60fps presentation.
+		expect(rates.presentedFpsByQuality.a).toBe(60);
+		expect(rates.presentedFpsByQuality.b).toBe(60);
+	});
+
+	it("keeps the quality rate intact when a busy main thread suppresses callbacks", () => {
+		// requestVideoFrameCallback runs on the main thread, so under load the
+		// records thin out even though the compositor keeps presenting.
+		const rates = deriveFrameRates({
+			elapsedSeconds: 4,
+			presentedRecords: records({ count: 140, videoIds: ["a"] }),
+			videosAfter: [video({ total: 240, videoId: "a" })],
+			videosBefore: [video({ total: 0, videoId: "a" })],
+		});
+
+		expect(rates.presentedRecordsSaturated).toBe(false);
+		expect(rates.presentedFpsByVideo.a).toBe(35);
+		expect(rates.presentedFpsByQuality.a).toBe(60);
+	});
+
+	it("subtracts the baseline instead of reporting cumulative totals", () => {
+		const rates = deriveFrameRates({
+			elapsedSeconds: 2,
+			presentedRecords: [],
+			videosAfter: [video({ dropped: 7, total: 1120, videoId: "a" })],
+			videosBefore: [video({ dropped: 5, total: 1000, videoId: "a" })],
+		});
+
+		expect(rates.presentedFpsByQuality.a).toBe(60);
+		expect(rates.totalFrames).toBe(120);
+		expect(rates.droppedFrames).toBe(2);
+	});
+
+	it("ignores videos that report no frame statistics", () => {
+		const rates = deriveFrameRates({
+			elapsedSeconds: 4,
+			presentedRecords: records({ count: 100, videoIds: ["a"] }),
+			videosAfter: [video({ dropped: null, total: null, videoId: "a" })],
+			videosBefore: [video({ dropped: null, total: null, videoId: "a" })],
+		});
+
+		expect(rates.presentedFpsByQuality).toEqual({});
+		expect(rates.totalFrames).toBe(0);
+		expect(rates.droppedFrames).toBe(0);
+	});
+
+	it("does not divide by zero on an empty window", () => {
+		const rates = deriveFrameRates({
+			elapsedSeconds: 0,
+			presentedRecords: [],
+			videosAfter: [],
+			videosBefore: [],
+		});
+
+		expect(rates.totalFrames).toBe(0);
+		expect(Number.isFinite(rates.droppedFrames)).toBe(true);
+	});
+});

--- a/qcut/apps/web/src/test/e2e/helpers/high-fps-preview-benchmark.ts
+++ b/qcut/apps/web/src/test/e2e/helpers/high-fps-preview-benchmark.ts
@@ -1,0 +1,517 @@
+/**
+ * High-frame-rate preview benchmark helpers.
+ *
+ * Drives real playback in the editor and reads the app's own playback
+ * diagnostics collector (`window.__qcutPlaybackDiagnostics`), the same data
+ * source `scripts/playback-diagnose.ts` reports over HTTP, so the numbers here
+ * are comparable to that tool rather than a parallel implementation.
+ *
+ * Media fixtures are generated with ffmpeg at test time and kept out of the
+ * repository.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import type { ElectronApplication, Page } from "@playwright/test";
+
+export interface PreviewClipSpec {
+	fps: number;
+	seconds: number;
+	width: number;
+	height: number;
+	/** Distinguishes layers visually and by content hash. */
+	variant: "primary" | "secondary";
+}
+
+/** Generates a deterministic clip. Cached by filename across runs. */
+export function generatePreviewClip({
+	directory,
+	spec,
+}: {
+	directory: string;
+	spec: PreviewClipSpec;
+}): string {
+	mkdirSync(directory, { recursive: true });
+	const filePath = path.join(
+		directory,
+		`preview-${spec.width}x${spec.height}p${spec.fps}-${spec.variant}.mp4`
+	);
+	if (existsSync(filePath)) return filePath;
+	// testsrc2 gives per-frame-distinct content, which makes frame identity and
+	// presented-frame counts meaningful; the hue split separates the layers.
+	const source =
+		spec.variant === "primary"
+			? `testsrc2=size=${spec.width}x${spec.height}:rate=${spec.fps}:duration=${spec.seconds}`
+			: `smptebars=size=${spec.width}x${spec.height}:rate=${spec.fps}:duration=${spec.seconds}`;
+	execFileSync(
+		"ffmpeg",
+		[
+			"-y",
+			"-f",
+			"lavfi",
+			"-i",
+			source,
+			"-c:v",
+			"libx264",
+			"-preset",
+			"veryfast",
+			"-pix_fmt",
+			"yuv420p",
+			"-g",
+			String(spec.fps),
+			"-colorspace",
+			"bt709",
+			"-color_primaries",
+			"bt709",
+			"-color_trc",
+			"bt709",
+			"-movflags",
+			"+faststart",
+			filePath,
+		],
+		{ stdio: "pipe" }
+	);
+	return filePath;
+}
+
+export interface DiagnosticsSnapshot {
+	installed: boolean;
+	now: number;
+	clockIntervalsMs: number[];
+	presentedFrames: Array<{
+		at: number;
+		videoId: string;
+		intervalMs: number | null;
+	}>;
+	previewRenderTotalCount: number;
+	longTaskTotalCount: number;
+	longTaskTotalDurationMs: number;
+	mediaEvents: Array<{ at: number; type: string; videoId: string }>;
+	videos: Array<{
+		videoId: string;
+		droppedVideoFrames: number | null;
+		totalVideoFrames: number | null;
+		currentTime: number;
+		playbackRate: number;
+		paused: boolean;
+		readyState: number;
+	}>;
+	smoothTimeReason: string | null;
+	playbackStore: { isPlaying: boolean; currentTime: number } | null;
+}
+
+/** Reads the app's diagnostics snapshot. */
+export async function snapshotDiagnostics({
+	page,
+}: {
+	page: Page;
+}): Promise<DiagnosticsSnapshot> {
+	return await page.evaluate(() => {
+		const api = (
+			window as unknown as {
+				__qcutPlaybackDiagnostics?: { snapshot: () => unknown };
+			}
+		).__qcutPlaybackDiagnostics;
+		if (!api) {
+			throw new Error(
+				"Playback diagnostics collector is not installed — is the editor open?"
+			);
+		}
+		return api.snapshot() as unknown as DiagnosticsSnapshot;
+	});
+}
+
+/** Clears the collector's ring buffers. */
+export async function resetDiagnostics({
+	page,
+}: {
+	page: Page;
+}): Promise<void> {
+	await page.evaluate(() => {
+		const api = (
+			window as unknown as {
+				__qcutPlaybackDiagnostics?: { reset: () => void };
+			}
+		).__qcutPlaybackDiagnostics;
+		api?.reset();
+	});
+}
+
+export interface PlaybackMetrics {
+	scenario: string;
+	windowSeconds: number;
+	/** Master clock ticks per second, from the rAF loop's dispatch intervals. */
+	clockHz: number;
+	clockIntervalP50Ms: number;
+	clockIntervalP95Ms: number;
+	/**
+	 * Presented video frames per second, per video element, derived from the
+	 * collector's requestVideoFrameCallback records.
+	 *
+	 * The collector keeps those records in a 300-entry ring, so with two 60fps
+	 * layers it saturates in about 2.5s and under-reports. `saturated` says when
+	 * that happened; prefer `presentedFpsByQuality` in that case.
+	 */
+	presentedFpsByVideo: Record<string, number>;
+	bestPresentedFps: number;
+	presentedRecordsSaturated: boolean;
+	/**
+	 * Presented video frames per second from getVideoPlaybackQuality's
+	 * cumulative totalVideoFrames counter, which no ring buffer truncates.
+	 * This is the authoritative presentation rate.
+	 */
+	presentedFpsByQuality: Record<string, number>;
+	bestQualityFps: number;
+	presentIntervalP50Ms: number;
+	presentIntervalP95Ms: number;
+	droppedFrames: number;
+	totalFrames: number;
+	stalls: number;
+	seeks: number;
+	longTasks: number;
+	longTaskMs: number;
+	previewRenders: number;
+	smoothTimeReason: string | null;
+	cpuPercent: number;
+	peakMemoryMb: number;
+}
+
+/** The collector's presented-frame ring capacity (PRESENTED_RING_SIZE). */
+export const PRESENTED_RING_CAPACITY = 300;
+
+export interface FrameRateInputs {
+	presentedRecords: ReadonlyArray<{ videoId: string }>;
+	videosBefore: ReadonlyArray<{
+		videoId: string;
+		totalVideoFrames: number | null;
+		droppedVideoFrames: number | null;
+	}>;
+	videosAfter: ReadonlyArray<{
+		videoId: string;
+		totalVideoFrames: number | null;
+		droppedVideoFrames: number | null;
+	}>;
+	elapsedSeconds: number;
+	ringCapacity?: number;
+}
+
+export interface FrameRates {
+	/** From requestVideoFrameCallback records — truncated by the ring buffer. */
+	presentedFpsByVideo: Record<string, number>;
+	/** From getVideoPlaybackQuality totals — authoritative. */
+	presentedFpsByQuality: Record<string, number>;
+	presentedRecordsSaturated: boolean;
+	droppedFrames: number;
+	totalFrames: number;
+}
+
+/**
+ * Derives presentation rates from a diagnostics window.
+ *
+ * Two traps this encodes, both of which produce a convincing but false "60fps
+ * collapsed to 30fps" reading:
+ *  - the collector's presented-frame ring holds only `ringCapacity` records, so
+ *    two 60fps layers saturate it in a few seconds and each appears to present
+ *    at half rate;
+ *  - requestVideoFrameCallback runs on the main thread, so a busy main thread
+ *    suppresses the callbacks without suppressing presentation.
+ * `getVideoPlaybackQuality` is immune to both, so it is the authority.
+ */
+export function deriveFrameRates({
+	presentedRecords,
+	videosBefore,
+	videosAfter,
+	elapsedSeconds,
+	ringCapacity = PRESENTED_RING_CAPACITY,
+}: FrameRateInputs): FrameRates {
+	const seconds = Math.max(0.001, elapsedSeconds);
+	const counts: Record<string, number> = {};
+	for (const record of presentedRecords) {
+		counts[record.videoId] = (counts[record.videoId] ?? 0) + 1;
+	}
+	const presentedFpsByVideo: Record<string, number> = {};
+	for (const [videoId, count] of Object.entries(counts)) {
+		presentedFpsByVideo[videoId] = Number((count / seconds).toFixed(2));
+	}
+
+	const baseline = new Map(
+		videosBefore.map((video) => [video.videoId, video] as const)
+	);
+	const presentedFpsByQuality: Record<string, number> = {};
+	let droppedFrames = 0;
+	let totalFrames = 0;
+	for (const video of videosAfter) {
+		const before = baseline.get(video.videoId);
+		if (video.droppedVideoFrames !== null) {
+			droppedFrames +=
+				video.droppedVideoFrames - (before?.droppedVideoFrames ?? 0);
+		}
+		if (video.totalVideoFrames !== null) {
+			const delta = video.totalVideoFrames - (before?.totalVideoFrames ?? 0);
+			totalFrames += delta;
+			presentedFpsByQuality[video.videoId] = Number(
+				(delta / seconds).toFixed(2)
+			);
+		}
+	}
+
+	return {
+		droppedFrames,
+		presentedFpsByQuality,
+		presentedFpsByVideo,
+		presentedRecordsSaturated: presentedRecords.length >= ringCapacity,
+		totalFrames,
+	};
+}
+
+function percentile(values: readonly number[], fraction: number): number {
+	if (values.length === 0) return 0;
+	const sorted = [...values].sort((a, b) => a - b);
+	const index = Math.min(
+		sorted.length - 1,
+		Math.floor(sorted.length * fraction)
+	);
+	return Number(sorted[index].toFixed(2));
+}
+
+/** Sums renderer CPU and memory across Electron's processes. */
+export async function readProcessMetrics({
+	electronApp,
+}: {
+	electronApp: ElectronApplication;
+}): Promise<{ cpuPercent: number; memoryMb: number }> {
+	return await electronApp.evaluate(({ app }) => {
+		const metrics = app.getAppMetrics();
+		let cpuPercent = 0;
+		let memoryKb = 0;
+		for (const entry of metrics) {
+			cpuPercent += entry.cpu?.percentCPUUsage ?? 0;
+			memoryKb += entry.memory?.workingSetSize ?? 0;
+		}
+		return { cpuPercent, memoryMb: memoryKb / 1024 };
+	});
+}
+
+/**
+ * Plays from `startTime` for `windowSeconds` and derives playback health from
+ * the app's own collector.
+ */
+export async function measurePlaybackWindow({
+	page,
+	electronApp,
+	scenario,
+	windowSeconds,
+	startTime = 0,
+}: {
+	page: Page;
+	electronApp: ElectronApplication;
+	scenario: string;
+	windowSeconds: number;
+	startTime?: number;
+}): Promise<PlaybackMetrics> {
+	await page.evaluate((seekTo) => {
+		const playback = (
+			window as unknown as {
+				__playbackStore: {
+					getState: () => { seek: (t: number) => void; pause: () => void };
+				};
+			}
+		).__playbackStore.getState();
+		playback.pause();
+		playback.seek(seekTo);
+	}, startTime);
+	// Let the seek settle before the measurement window opens.
+	await page.waitForTimeout(600);
+	await resetDiagnostics({ page });
+
+	const before = await snapshotDiagnostics({ page });
+	const beforeVideos = new Map(
+		before.videos.map((video) => [video.videoId, video])
+	);
+
+	await page.evaluate((durationMs) => {
+		const playback = (
+			window as unknown as {
+				__playbackStore: {
+					getState: () => { play: () => void; pause: () => void };
+				};
+			}
+		).__playbackStore.getState();
+		playback.play();
+		return new Promise<void>((resolve) => {
+			setTimeout(() => {
+				(
+					window as unknown as {
+						__playbackStore: { getState: () => { pause: () => void } };
+					}
+				).__playbackStore
+					.getState()
+					.pause();
+				resolve();
+			}, durationMs);
+		});
+	}, windowSeconds * 1000);
+
+	const after = await snapshotDiagnostics({ page });
+	const processMetrics = await readProcessMetrics({ electronApp });
+
+	const elapsedSeconds = Math.max(0.001, (after.now - before.now) / 1000);
+	const clockIntervals = after.clockIntervalsMs;
+	const presentIntervals = after.presentedFrames
+		.map((record) => record.intervalMs)
+		.filter((value): value is number => typeof value === "number");
+
+	const rates = deriveFrameRates({
+		elapsedSeconds,
+		presentedRecords: after.presentedFrames,
+		videosAfter: after.videos,
+		videosBefore: before.videos,
+	});
+
+	const stalls = after.mediaEvents.filter((event) =>
+		["waiting", "stalled"].includes(event.type)
+	).length;
+	const seeks = after.mediaEvents.filter((event) =>
+		["seeking", "seeked"].includes(event.type)
+	).length;
+
+	return {
+		bestPresentedFps: Math.max(0, ...Object.values(rates.presentedFpsByVideo)),
+		bestQualityFps: Math.max(0, ...Object.values(rates.presentedFpsByQuality)),
+		presentedFpsByQuality: rates.presentedFpsByQuality,
+		presentedRecordsSaturated: rates.presentedRecordsSaturated,
+		clockHz: Number((clockIntervals.length / elapsedSeconds).toFixed(2)),
+		clockIntervalP50Ms: percentile(clockIntervals, 0.5),
+		clockIntervalP95Ms: percentile(clockIntervals, 0.95),
+		cpuPercent: Number(processMetrics.cpuPercent.toFixed(1)),
+		droppedFrames: rates.droppedFrames,
+		longTaskMs: Number(after.longTaskTotalDurationMs.toFixed(1)),
+		longTasks: after.longTaskTotalCount,
+		peakMemoryMb: Number(processMetrics.memoryMb.toFixed(1)),
+		presentIntervalP50Ms: percentile(presentIntervals, 0.5),
+		presentIntervalP95Ms: percentile(presentIntervals, 0.95),
+		presentedFpsByVideo: rates.presentedFpsByVideo,
+		previewRenders: after.previewRenderTotalCount,
+		scenario,
+		seeks,
+		smoothTimeReason: after.smoothTimeReason,
+		stalls,
+		totalFrames: rates.totalFrames,
+		windowSeconds: Number(elapsedSeconds.toFixed(2)),
+	};
+}
+
+/**
+ * Attaches a test-only `playback-update` listener that burns `busyMs` of main
+ * thread per tick, which halves (or worse) the rAF master clock rate.
+ *
+ * This exists to answer the causal question directly: if a slow master clock
+ * genuinely throttled video presentation, forcing the clock down would drag
+ * presented FPS down with it. Production code is untouched; the listener is
+ * added and removed from the test.
+ */
+export async function installClockLoad({
+	page,
+	busyMs,
+}: {
+	page: Page;
+	busyMs: number;
+}): Promise<void> {
+	await page.evaluate((budget) => {
+		const target = window as unknown as {
+			__hifpsClockLoad?: (event: Event) => void;
+		};
+		if (target.__hifpsClockLoad) {
+			window.removeEventListener("playback-update", target.__hifpsClockLoad);
+		}
+		const listener = (): void => {
+			const until = performance.now() + budget;
+			// Deliberate busy-wait: a sleep would yield and not stretch the tick.
+			while (performance.now() < until) {
+				// spin
+			}
+		};
+		target.__hifpsClockLoad = listener;
+		window.addEventListener("playback-update", listener);
+	}, busyMs);
+}
+
+/** Removes the synthetic main-thread load. */
+export async function removeClockLoad({ page }: { page: Page }): Promise<void> {
+	await page.evaluate(() => {
+		const target = window as unknown as {
+			__hifpsClockLoad?: (event: Event) => void;
+		};
+		if (!target.__hifpsClockLoad) return;
+		window.removeEventListener("playback-update", target.__hifpsClockLoad);
+		target.__hifpsClockLoad = undefined;
+	});
+}
+
+/**
+ * Seeks to each time and hashes a screenshot of the preview surface.
+ *
+ * The fixtures are per-frame distinct, so these hashes are a frame-identity
+ * fixture: the same time must always show the same frame, and different times
+ * must show different frames.
+ */
+export async function capturePreviewFrameHashes({
+	page,
+	times,
+}: {
+	page: Page;
+	times: readonly number[];
+}): Promise<Array<{ time: number; hash: string }>> {
+	const { createHash } = await import("node:crypto");
+	const results: Array<{ time: number; hash: string }> = [];
+	const surface = page.getByTestId("preview-panel");
+	for (const time of times) {
+		await page.evaluate((seekTo) => {
+			(
+				window as unknown as {
+					__playbackStore: { getState: () => { seek: (t: number) => void } };
+				}
+			).__playbackStore
+				.getState()
+				.seek(seekTo);
+		}, time);
+		await page.evaluate(
+			() =>
+				new Promise<void>((resolve) => {
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+				})
+		);
+		// Give the decoder a moment to present the seeked frame.
+		await page.waitForTimeout(250);
+		const shot = await surface.screenshot({ animations: "disabled" });
+		results.push({
+			hash: createHash("sha256").update(shot).digest("hex").slice(0, 16),
+			time,
+		});
+	}
+	return results;
+}
+
+/** Formats one measurement for the test log. */
+export function formatPlaybackMetrics({
+	metrics,
+}: {
+	metrics: PlaybackMetrics;
+}): string {
+	return (
+		`[hifps] ${metrics.scenario.padEnd(24)} ` +
+		`clockHz=${metrics.clockHz.toFixed(1).padStart(6)} ` +
+		`qualityFps=${metrics.bestQualityFps.toFixed(1).padStart(6)} ` +
+		`rvfcFps=${metrics.bestPresentedFps.toFixed(1).padStart(6)}${metrics.presentedRecordsSaturated ? "(SAT)" : "     "} ` +
+		`window=${metrics.windowSeconds.toFixed(2)}s ` +
+		`presentP50=${metrics.presentIntervalP50Ms.toFixed(1).padStart(6)}ms ` +
+		`presentP95=${metrics.presentIntervalP95Ms.toFixed(1).padStart(6)}ms ` +
+		`clockP50=${metrics.clockIntervalP50Ms.toFixed(1).padStart(6)}ms ` +
+		`clockP95=${metrics.clockIntervalP95Ms.toFixed(1).padStart(6)}ms ` +
+		`dropped=${metrics.droppedFrames} total=${metrics.totalFrames} ` +
+		`stalls=${metrics.stalls} longTasks=${metrics.longTasks}(${metrics.longTaskMs}ms) ` +
+		`renders=${metrics.previewRenders} cpu=${metrics.cpuPercent}% mem=${metrics.peakMemoryMb}MB ` +
+		`smooth=${metrics.smoothTimeReason ?? "none"}`
+	);
+}

--- a/qcut/apps/web/src/test/e2e/high-fps-preview-benchmark.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/high-fps-preview-benchmark.e2e.ts
@@ -1,0 +1,354 @@
+/**
+ * High-frame-rate preview benchmark.
+ *
+ * Compares real playback of a 30 fps control, a single 1080p60 layer, and two
+ * stacked 1080p60 layers, over both continuous playback and seeking.
+ *
+ * Runs with the GPU ENABLED. The shared E2E fixture forces
+ * ELECTRON_DISABLE_GPU=1, which would put video decode and compositing on a
+ * software path and invalidate any conclusion about 60 fps presentation, so
+ * this spec launches its own Electron instance.
+ *
+ * The central question is whether the rAF master clock dropping toward ~30 Hz
+ * on the two-layer timeline actually reduces how many 60 fps source frames
+ * reach the screen. Presented-frame counts come from the app's own
+ * requestVideoFrameCallback reporting, so clock rate and presentation rate are
+ * measured independently rather than inferred from one another.
+ */
+
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { expect } from "@playwright/test";
+import { _electron as electron } from "playwright";
+import {
+	createTestProject,
+	test as qcutTest,
+	uploadTestMedia,
+} from "./helpers/electron-helpers";
+import {
+	capturePreviewFrameHashes,
+	formatPlaybackMetrics,
+	generatePreviewClip,
+	installClockLoad,
+	measurePlaybackWindow,
+	removeClockLoad,
+	type PlaybackMetrics,
+	snapshotDiagnostics,
+} from "./helpers/high-fps-preview-benchmark";
+
+const FIXTURE_DIR = path.join(tmpdir(), "qcut-high-fps-fixtures");
+const CLIP_SECONDS = 6;
+const PLAY_WINDOW_SECONDS = 4;
+const SEEK_TIMES = [0.5, 1.5, 2.5, 3.5, 4.5] as const;
+
+/** GPU-enabled Electron, unlike the shared fixture. */
+const test = qcutTest.extend({
+	// biome-ignore lint/correctness/noEmptyPattern: Playwright fixtures require empty destructuring
+	electronApp: async ({}, use) => {
+		const userDataDirectory = await mkdtemp(
+			path.join(tmpdir(), "qcut-high-fps-e2e-")
+		);
+		const electronApp = await electron.launch({
+			args: ["dist/electron/main.js", `--user-data-dir=${userDataDirectory}`],
+			env: {
+				...process.env,
+				NODE_ENV: "test",
+				// Deliberately no ELECTRON_DISABLE_GPU: this benchmark is about the
+				// GPU presentation path.
+			},
+		});
+		try {
+			await use(electronApp);
+		} finally {
+			await electronApp.close();
+			await rm(userDataDirectory, { force: true, recursive: true });
+		}
+	},
+});
+
+test.use({ captureScreenshotVideo: false });
+test.setTimeout(900_000);
+
+interface ScenarioResult {
+	playback: PlaybackMetrics;
+	seek: PlaybackMetrics | null;
+	positions: number[];
+}
+
+test.describe("high fps preview", () => {
+	test("compares 30fps, single 1080p60 and dual 1080p60 playback", async ({
+		electronApp,
+		page,
+	}) => {
+		const clip30 = generatePreviewClip({
+			directory: FIXTURE_DIR,
+			spec: {
+				fps: 30,
+				height: 1080,
+				seconds: CLIP_SECONDS,
+				variant: "primary",
+				width: 1920,
+			},
+		});
+		const clip60 = generatePreviewClip({
+			directory: FIXTURE_DIR,
+			spec: {
+				fps: 60,
+				height: 1080,
+				seconds: CLIP_SECONDS,
+				variant: "primary",
+				width: 1920,
+			},
+		});
+		const clip60b = generatePreviewClip({
+			directory: FIXTURE_DIR,
+			spec: {
+				fps: 60,
+				height: 1080,
+				seconds: CLIP_SECONDS,
+				variant: "secondary",
+				width: 1920,
+			},
+		});
+
+		await electronApp.evaluate(({ BrowserWindow }) => {
+			BrowserWindow.getAllWindows()[0]?.setSize(1600, 1000);
+		});
+		await createTestProject(page, "High FPS Preview");
+		await uploadTestMedia(page, clip30);
+		await uploadTestMedia(page, clip60);
+		await uploadTestMedia(page, clip60b);
+
+		// Confirm the GPU path is actually active; a software fallback would make
+		// every presentation number meaningless.
+		const gpuInfo = await electronApp.evaluate(async ({ app }) => {
+			const status = app.getGPUFeatureStatus();
+			return {
+				videoDecode: status.video_decode ?? "unknown",
+				webgl: status.webgl ?? "unknown",
+			};
+		});
+		console.log(
+			`[hifps] gpu videoDecode=${gpuInfo.videoDecode} webgl=${gpuInfo.webgl}`
+		);
+
+		const results: Record<string, ScenarioResult> = {};
+
+		const buildTimeline = async ({
+			clips,
+		}: {
+			clips: string[];
+		}): Promise<number> => {
+			return await page.evaluate(async (fileNames) => {
+				const harness = window as unknown as {
+					__timelineStore: { getState: () => any };
+					__mediaStore: { getState: () => any };
+					__playbackStore: { getState: () => { seek: (t: number) => void } };
+				};
+				const timeline = harness.__timelineStore.getState();
+				const media = harness.__mediaStore.getState();
+
+				for (const track of [...timeline.tracks]) {
+					for (const element of [...track.elements]) {
+						timeline.removeElementFromTrack(track.id, element.id);
+					}
+				}
+
+				let placed = 0;
+				for (const [index, fileName] of fileNames.entries()) {
+					const item = media.mediaItems.find((candidate: { name: string }) =>
+						candidate.name.includes(fileName)
+					);
+					if (!item) throw new Error(`Media not found: ${fileName}`);
+					const state = harness.__timelineStore.getState();
+					const trackId =
+						index === 0
+							? (state.tracks.find(
+									(track: { isMain?: boolean; type: string }) =>
+										track.isMain || track.type === "media"
+								)?.id ?? state.addTrack("media"))
+							: state.insertTrackAt("media", 0);
+					const added = harness.__timelineStore.getState().addElementToTrack(
+						trackId,
+						{
+							duration: item.duration ?? 6,
+							mediaId: item.id,
+							name: `layer-${index}`,
+							startTime: 0,
+							trimEnd: 0,
+							trimStart: 0,
+							type: "media",
+						},
+						{ pushHistory: false, selectElement: false }
+					);
+					if (added) placed += 1;
+				}
+				harness.__playbackStore.getState().seek(0);
+				return placed;
+			}, clips);
+		};
+
+		const runScenario = async ({
+			scenario,
+			clips,
+		}: {
+			scenario: string;
+			clips: string[];
+		}): Promise<void> => {
+			const placed = await buildTimeline({ clips });
+			expect(placed).toBe(clips.length);
+			await page.waitForTimeout(1200);
+
+			const playback = await measurePlaybackWindow({
+				electronApp,
+				page,
+				scenario,
+				windowSeconds: PLAY_WINDOW_SECONDS,
+			});
+			console.log(formatPlaybackMetrics({ metrics: playback }));
+			console.log(
+				`[hifps] ${scenario} qualityByVideo=${JSON.stringify(playback.presentedFpsByQuality)} rvfcByVideo=${JSON.stringify(playback.presentedFpsByVideo)} saturated=${playback.presentedRecordsSaturated}`
+			);
+
+			// Seek workload: fixed points, each settled, then the resulting
+			// playback position recorded.
+			const positions: number[] = [];
+			for (const time of SEEK_TIMES) {
+				const position = await page.evaluate(async (seekTo) => {
+					const playbackStore = (
+						window as unknown as {
+							__playbackStore: {
+								getState: () => {
+									seek: (t: number) => void;
+									currentTime: number;
+								};
+							};
+						}
+					).__playbackStore;
+					playbackStore.getState().seek(seekTo);
+					await new Promise<void>((resolve) => {
+						requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+					});
+					return playbackStore.getState().currentTime;
+				}, time);
+				positions.push(Number(position.toFixed(3)));
+			}
+			console.log(
+				`[hifps] ${scenario} seekPositions=${JSON.stringify(positions)}`
+			);
+
+			results[scenario] = { playback, positions, seek: null };
+		};
+
+		await runScenario({
+			clips: ["preview-1920x1080p30-primary"],
+			scenario: "control-1080p30",
+		});
+		await runScenario({
+			clips: ["preview-1920x1080p60-primary"],
+			scenario: "single-1080p60",
+		});
+		await runScenario({
+			clips: ["preview-1920x1080p60-primary", "preview-1920x1080p60-secondary"],
+			scenario: "dual-1080p60",
+		});
+
+		// --- Causal test: force the master clock down and watch presentation ---
+		// The two-layer timeline did not slow the clock on its own, so drive the
+		// clock down deliberately and see whether 60fps presentation follows it.
+		await buildTimeline({
+			clips: ["preview-1920x1080p60-primary", "preview-1920x1080p60-secondary"],
+		});
+		await page.waitForTimeout(1200);
+		await installClockLoad({ busyMs: 24, page });
+		const loaded = await measurePlaybackWindow({
+			electronApp,
+			page,
+			scenario: "dual-1080p60-slowclock",
+			windowSeconds: PLAY_WINDOW_SECONDS,
+		});
+		await removeClockLoad({ page });
+		console.log(formatPlaybackMetrics({ metrics: loaded }));
+		console.log(
+			`[hifps] dual-1080p60-slowclock qualityByVideo=${JSON.stringify(loaded.presentedFpsByQuality)}`
+		);
+		results["dual-1080p60-slowclock"] = {
+			playback: loaded,
+			positions: [],
+			seek: null,
+		};
+
+		// --- The question this benchmark exists to answer ---------------------
+		const single = results["single-1080p60"].playback;
+		const dual = results["dual-1080p60"].playback;
+		const control = results["control-1080p30"].playback;
+		const slow = results["dual-1080p60-slowclock"].playback;
+		console.log(
+			`[hifps] CAUSAL forcing clock ${dual.clockHz.toFixed(1)}Hz -> ${slow.clockHz.toFixed(1)}Hz ` +
+				`changed presented ${dual.bestQualityFps.toFixed(1)}fps -> ${slow.bestQualityFps.toFixed(1)}fps ` +
+				`(dropped ${dual.droppedFrames} -> ${slow.droppedFrames})`
+		);
+		console.log(
+			`[hifps] VERDICT clock ${single.clockHz.toFixed(1)}Hz -> ${dual.clockHz.toFixed(1)}Hz | ` +
+				`presented(quality) ${single.bestQualityFps.toFixed(1)}fps -> ${dual.bestQualityFps.toFixed(1)}fps | ` +
+				`dropped ${single.droppedFrames} -> ${dual.droppedFrames} | ` +
+				`control30 clock=${control.clockHz.toFixed(1)}Hz presented=${control.bestPresentedFps.toFixed(1)}fps`
+		);
+
+		// Sanity gates: the harness must have actually played real media.
+		for (const [scenario, result] of Object.entries(results)) {
+			expect(result.playback.windowSeconds).toBeGreaterThan(1);
+			expect(
+				result.playback.bestQualityFps,
+				`${scenario} presented no frames`
+			).toBeGreaterThan(0);
+			// Seeks must land where they were asked to.
+			for (const [index, position] of result.positions.entries()) {
+				expect(position).toBeCloseTo(SEEK_TIMES[index], 1);
+			}
+		}
+
+		// Frame-identity gate on the dual-layer timeline: fixed times must show
+		// distinct frames, proving the preview is showing the seeked frame rather
+		// than a stale or blank surface.
+		const frameHashes = await capturePreviewFrameHashes({
+			page,
+			times: SEEK_TIMES,
+		});
+		console.log(`[hifps] FRAME_HASHES=${JSON.stringify(frameHashes)}`);
+		expect(new Set(frameHashes.map((entry) => entry.hash)).size).toBe(
+			SEEK_TIMES.length
+		);
+
+		// Playback health gates.
+		for (const scenario of [
+			"control-1080p30",
+			"single-1080p60",
+			"dual-1080p60",
+		]) {
+			const metrics = results[scenario].playback;
+			// The master clock must stay near display rate without synthetic load.
+			expect(metrics.clockHz, `${scenario} clock rate`).toBeGreaterThan(45);
+			// Drops must stay negligible relative to frames presented.
+			expect(
+				metrics.droppedFrames / Math.max(1, metrics.totalFrames),
+				`${scenario} drop ratio`
+			).toBeLessThan(0.02);
+		}
+		for (const scenario of ["single-1080p60", "dual-1080p60"]) {
+			expect(
+				results[scenario].playback.bestQualityFps,
+				`${scenario} presented fps`
+			).toBeGreaterThan(55);
+		}
+
+		// The causal result: a forced-slow master clock must not drag 60fps
+		// presentation down with it.
+		expect(slow.clockHz).toBeLessThan(45);
+		expect(slow.bestQualityFps).toBeGreaterThan(55);
+
+		const snapshot = await snapshotDiagnostics({ page });
+		expect(snapshot.installed).toBe(true);
+	});
+});


### PR DESCRIPTION
## 摘要
真实 60FPS 素材预览/播放调查——**仅诊断，无优化**（无瓶颈）。

- **因果实验**：人为把主时钟压到 34.7Hz，呈现帧率仍 61fps 不变——rAF 时钟是时间轴时钟/纠偏器，不是帧泵；原生 video 由合成器按媒体时钟呈现
- 双层 1080p60 时主时钟保持 59.6Hz（未复现"降到 30Hz"），smooth=none
- 揪出两个会伪造"60→30fps 回归"的测量陷阱：诊断收集器 presented-frame ring 只有 300 条（双层 2.5s 饱和）；rVFC 在主线程忙时被压制而呈现不受影响——getVideoPlaybackQuality 才是权威。单测 6/6 钉住
- 五个固定时间点帧哈希互异 + seek 落点门禁

🤖 Generated with [Claude Code](https://claude.com/claude-code)