### PR TITLE
test(transitions): pin outgoing-layer identity and window frame gates

### DIFF
--- a/qcut/apps/web/src/lib/export/__tests__/transition-outgoing-identity.test.ts
+++ b/qcut/apps/web/src/lib/export/__tests__/transition-outgoing-identity.test.ts
@@ -1,0 +1,158 @@
+import { getClipTransitionLayerPresentation } from "@qcut/editor-core/timeline";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Pins which transition families need a second composited layer for the
+ * OUTGOING ("from") clip and which do not.
+ *
+ * The export renderer already draws an outgoing clip straight onto the export
+ * canvas when its presentation is identity
+ * (export-clip-transitions.ts beginClipTransitionLayer). These tests document
+ * which families that actually applies to, so a future preset change cannot
+ * silently start paying for a group canvas that contributes nothing — or
+ * silently skip one that does contribute.
+ */
+
+const CANVAS = { canvasHeight: 1080, canvasWidth: 1920 };
+
+function transition({
+	type,
+	easing = "linear",
+}: {
+	type: string;
+	easing?: string;
+}): Parameters<typeof getClipTransitionLayerPresentation>[0]["transition"] {
+	return {
+		duration: 1,
+		easing,
+		fromElementId: "a",
+		id: "ab",
+		presetId: type,
+		toElementId: "b",
+		type,
+	} as unknown as Parameters<
+		typeof getClipTransitionLayerPresentation
+	>[0]["transition"];
+}
+
+/** Mirrors isIdentityPresentation in export-clip-transitions.ts. */
+function isIdentity(presentation: {
+	opacity: number;
+	contentOpacity: number;
+	offsetX: number;
+	offsetY: number;
+	scale?: number;
+	rotation?: number;
+	blur?: number;
+	brightness?: number;
+	saturation?: number;
+	hueRotate?: number;
+	backgroundColor?: string;
+	clipPath?: string;
+}): boolean {
+	return (
+		presentation.opacity === 1 &&
+		presentation.contentOpacity === 1 &&
+		presentation.offsetX === 0 &&
+		presentation.offsetY === 0 &&
+		(presentation.scale ?? 1) === 1 &&
+		(presentation.rotation ?? 0) === 0 &&
+		presentation.backgroundColor === undefined &&
+		presentation.clipPath === undefined &&
+		(presentation.blur ?? 0) === 0 &&
+		(presentation.brightness ?? 1) === 1 &&
+		(presentation.saturation ?? 1) === 1 &&
+		(presentation.hueRotate ?? 0) === 0
+	);
+}
+
+function outgoingAt({ type, progress }: { type: string; progress: number }) {
+	return getClipTransitionLayerPresentation({
+		...CANVAS,
+		progress,
+		role: "from",
+		transition: transition({ type }),
+	});
+}
+
+const MID_PROGRESS = [0.1, 0.25, 0.5, 0.75, 0.9];
+
+describe("transition outgoing layer identity", () => {
+	it("keeps the dissolve outgoing layer at identity for the whole window", () => {
+		for (const progress of [0, ...MID_PROGRESS, 1]) {
+			const presentation = outgoingAt({ progress, type: "dissolve" });
+			expect(isIdentity(presentation), `dissolve outgoing at ${progress}`).toBe(
+				true
+			);
+			// The incoming layer is what carries the crossfade.
+			const incoming = getClipTransitionLayerPresentation({
+				...CANVAS,
+				progress,
+				role: "to",
+				transition: transition({ type: "dissolve" }),
+			});
+			expect(incoming.opacity).toBeCloseTo(progress, 5);
+		}
+	});
+
+	it("keeps the slide outgoing layer at identity while the incoming moves", () => {
+		for (const progress of [0, ...MID_PROGRESS, 1]) {
+			expect(
+				isIdentity(outgoingAt({ progress, type: "slide" })),
+				`slide outgoing at ${progress}`
+			).toBe(true);
+		}
+		const incoming = getClipTransitionLayerPresentation({
+			...CANVAS,
+			progress: 0.5,
+			role: "to",
+			transition: transition({ type: "slide" }),
+		});
+		expect(
+			Math.abs(incoming.offsetX) + Math.abs(incoming.offsetY)
+		).toBeGreaterThan(0);
+	});
+
+	it("requires a real second layer for zoom-blur mid-window", () => {
+		// zoom-blur scales and blurs BOTH clips, so the outgoing layer genuinely
+		// contributes and cannot be short-circuited.
+		for (const progress of MID_PROGRESS) {
+			const presentation = outgoingAt({ progress, type: "zoom-blur" });
+			expect(
+				isIdentity(presentation),
+				`zoom-blur outgoing at ${progress} must not be identity`
+			).toBe(false);
+			expect(presentation.scale ?? 1).toBeGreaterThan(1);
+			expect(presentation.blur ?? 0).toBeGreaterThan(0);
+		}
+	});
+
+	it("returns zoom-blur to identity exactly at the window edges", () => {
+		// peak = 4p(1-p) is zero at both ends, so the boundary frames are
+		// untouched and must match the surrounding hard-cut frames.
+		for (const progress of [0, 1]) {
+			expect(
+				isIdentity(outgoingAt({ progress, type: "zoom-blur" })),
+				`zoom-blur outgoing at edge ${progress}`
+			).toBe(true);
+		}
+	});
+
+	it("never treats fade-black as identity, because it paints a plate", () => {
+		for (const progress of [0, ...MID_PROGRESS, 1]) {
+			const presentation = outgoingAt({ progress, type: "fade-black" });
+			expect(presentation.backgroundColor).toBe("#000000");
+			expect(isIdentity(presentation)).toBe(false);
+		}
+	});
+
+	it("moves the outgoing clip for push, unlike slide", () => {
+		// push and slide look similar but differ exactly here: push translates
+		// the outgoing clip, so it needs its own layer.
+		const pushed = outgoingAt({ progress: 0.5, type: "push" });
+		expect(isIdentity(pushed)).toBe(false);
+		expect(Math.abs(pushed.offsetX) + Math.abs(pushed.offsetY)).toBeGreaterThan(
+			0
+		);
+	});
+});

--- a/qcut/apps/web/src/test/e2e/transition-window-frames.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/transition-window-frames.e2e.ts
@@ -331,6 +331,21 @@ test.describe("transition window frames", () => {
 			).toBe(3);
 		}
 
+		// Identity-at-window-start contract: the presentation is identity at
+		// progress 0, and every frame before the window is identical across the
+		// three exports, so the window START frame must hash identically for all
+		// transition types. The window END frame cannot be asserted this way:
+		// H.264 predicts it from the preceding (per-type different) window
+		// interior, so its bytes legitimately differ between exports even though
+		// the source canvas frame is identical.
+		const startHashes = results.map(
+			(result) => result.hashes[windowStartFrame]
+		);
+		expect(
+			new Set(startHashes).size,
+			`window start frames must match across types, got ${JSON.stringify(startHashes)}`
+		).toBe(1);
+
 		// Every transition type must produce a different result from the others,
 		// otherwise the transition type is not reaching the renderer at all.
 		const midHashes = results.map((result) => result.hashes[midFrame]);

--- a/qcut/apps/web/src/test/e2e/transition-window-frames.e2e.ts
+++ b/qcut/apps/web/src/test/e2e/transition-window-frames.e2e.ts
@@ -1,0 +1,368 @@
+/**
+ * Transition window frame gate.
+ *
+ * Exports real timelines carrying a dissolve, a slide and a zoom-blur seam and
+ * checks the frames around and inside each transition window.
+ *
+ * The point is to have an output-level fixture for the transition layer
+ * question: the boundary frames of a window must match the surrounding hard
+ * cut (the presentation is identity at progress 0 and 1), while frames inside
+ * the window must differ from both neighbours. A change that wrongly
+ * short-circuits a contributing layer — or wrongly builds one that contributes
+ * nothing — moves exactly these frames.
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { expect } from "@playwright/test";
+import {
+	createTestProject,
+	stubExportSaveDialog,
+	test,
+	uploadTestMedia,
+} from "./helpers/electron-helpers";
+
+const EVIDENCE_DIR = path.resolve("output/playwright/transition-window");
+const FIXTURE_DIR = path.join(tmpdir(), "qcut-transition-fixtures");
+const CLIP_SECONDS = 2;
+const FPS = 30;
+const TRANSITION_SECONDS = 1;
+
+/** Distinct, per-frame-varying sources so frame hashes are meaningful. */
+function generateClip({ variant }: { variant: "a" | "b" }): string {
+	mkdirSync(FIXTURE_DIR, { recursive: true });
+	const filePath = path.join(FIXTURE_DIR, `transition-clip-${variant}.mp4`);
+	if (existsSync(filePath)) return filePath;
+	const source =
+		variant === "a"
+			? `testsrc2=size=640x360:rate=${FPS}:duration=${CLIP_SECONDS}`
+			: `smptebars=size=640x360:rate=${FPS}:duration=${CLIP_SECONDS}`;
+	execFileSync(
+		"ffmpeg",
+		[
+			"-y",
+			"-f",
+			"lavfi",
+			"-i",
+			source,
+			"-c:v",
+			"libx264",
+			"-preset",
+			"veryfast",
+			"-pix_fmt",
+			"yuv420p",
+			"-g",
+			String(FPS),
+			"-movflags",
+			"+faststart",
+			filePath,
+		],
+		{ stdio: "pipe" }
+	);
+	return filePath;
+}
+
+/** Per-frame SHA-256 of the decoded video, one entry per frame. */
+function frameHashes({ filePath }: { filePath: string }): string[] {
+	const raw = execFileSync(
+		"ffmpeg",
+		[
+			"-v",
+			"error",
+			"-i",
+			filePath,
+			"-map",
+			"v:0",
+			"-f",
+			"rawvideo",
+			"-pix_fmt",
+			"rgb24",
+			"-",
+		],
+		{ encoding: "buffer", maxBuffer: 1024 * 1024 * 1024 }
+	);
+	const probe = probeVideo({ filePath });
+	const frameBytes = probe.width * probe.height * 3;
+	const hashes: string[] = [];
+	for (
+		let offset = 0;
+		offset + frameBytes <= raw.length;
+		offset += frameBytes
+	) {
+		hashes.push(
+			createHash("sha256")
+				.update(raw.subarray(offset, offset + frameBytes))
+				.digest("hex")
+				.slice(0, 16)
+		);
+	}
+	return hashes;
+}
+
+function probeVideo({ filePath }: { filePath: string }): {
+	width: number;
+	height: number;
+	frames: number;
+	duration: number;
+	audioCodec: string;
+} {
+	const raw = execFileSync(
+		"ffprobe",
+		[
+			"-v",
+			"error",
+			"-count_frames",
+			"-show_entries",
+			"stream=codec_type,codec_name,width,height,nb_read_frames:format=duration",
+			"-of",
+			"json",
+			filePath,
+		],
+		{ encoding: "utf8" }
+	);
+	const parsed = JSON.parse(raw) as {
+		streams?: Array<{
+			codec_type?: string;
+			codec_name?: string;
+			width?: number;
+			height?: number;
+			nb_read_frames?: string;
+		}>;
+		format?: { duration?: string };
+	};
+	const video = parsed.streams?.find((s) => s.codec_type === "video");
+	const audio = parsed.streams?.find((s) => s.codec_type === "audio");
+	return {
+		audioCodec: audio?.codec_name ?? "none",
+		duration: Number(parsed.format?.duration ?? 0),
+		frames: Number(video?.nb_read_frames ?? 0),
+		height: video?.height ?? 0,
+		width: video?.width ?? 0,
+	};
+}
+
+const TRANSITIONS = [
+	{ label: "dissolve", type: "dissolve" },
+	{ label: "slide", type: "slide" },
+	{ label: "zoom-blur", type: "zoom-blur" },
+] as const;
+
+test.use({ captureScreenshotVideo: false });
+test.setTimeout(900_000);
+
+test.describe("transition window frames", () => {
+	test("keeps window boundaries stable and window interiors distinct", async ({
+		electronApp,
+		page,
+	}) => {
+		await mkdir(EVIDENCE_DIR, { recursive: true });
+		const clipA = generateClip({ variant: "a" });
+		const clipB = generateClip({ variant: "b" });
+
+		await createTestProject(page, "Transition Window Frames");
+		await uploadTestMedia(page, clipA);
+		await uploadTestMedia(page, clipB);
+
+		// Canvas per-frame engine: the CLI engine builds an FFmpeg filter graph
+		// and never exercises the transition layer code under test.
+		await page.evaluate(() => {
+			localStorage.setItem("qcut_force_regular_engine", "true");
+		});
+
+		const results: Array<{
+			label: string;
+			hashes: string[];
+			probe: ReturnType<typeof probeVideo>;
+		}> = [];
+
+		for (const entry of TRANSITIONS) {
+			const applied = await page.evaluate(
+				async (input) => {
+					const harness = window as unknown as {
+						__timelineStore: { getState: () => any };
+						__mediaStore: { getState: () => any };
+						__playbackStore: { getState: () => { seek: (t: number) => void } };
+					};
+					const timeline = harness.__timelineStore.getState();
+					const media = harness.__mediaStore.getState();
+					for (const track of [...timeline.tracks]) {
+						for (const element of [...track.elements]) {
+							timeline.removeElementFromTrack(track.id, element.id);
+						}
+					}
+					const items = media.mediaItems.filter(
+						(item: { type: string }) => item.type === "video"
+					);
+					const first = items.find((item: { name: string }) =>
+						item.name.includes("transition-clip-a")
+					);
+					const second = items.find((item: { name: string }) =>
+						item.name.includes("transition-clip-b")
+					);
+					if (!first || !second) throw new Error("Transition clips missing");
+
+					const state = harness.__timelineStore.getState();
+					const trackId =
+						state.tracks.find(
+							(track: { isMain?: boolean; type: string }) =>
+								track.isMain || track.type === "media"
+						)?.id ?? state.addTrack("media");
+
+					const ids: string[] = [];
+					for (const [index, item] of [first, second].entries()) {
+						const id = harness.__timelineStore.getState().addElementToTrack(
+							trackId,
+							{
+								duration: input.clipSeconds,
+								mediaId: item.id,
+								name: `seam-${index}`,
+								startTime: index * input.clipSeconds,
+								trimEnd: 0,
+								trimStart: 0,
+								type: "media",
+							},
+							{ pushHistory: false, selectElement: false }
+						);
+						if (id) ids.push(id);
+					}
+					if (ids.length !== 2) throw new Error("Could not place both clips");
+
+					const store = harness.__timelineStore.getState();
+					const videoMediaIds = new Set<string>([first.id, second.id]);
+					store.addTransition?.({
+						duration: input.transitionSeconds,
+						easing: "linear",
+						engine: "qcut",
+						fromElementId: ids[0],
+						presetId: input.type,
+						toElementId: ids[1],
+						trackId,
+						type: input.type,
+						videoMediaIds,
+					});
+					harness.__playbackStore.getState().seek(0);
+					const after = harness.__timelineStore.getState();
+					const track = after.tracks.find(
+						(candidate: { id: string }) => candidate.id === trackId
+					);
+					return track?.transitions?.length ?? 0;
+				},
+				{
+					clipSeconds: CLIP_SECONDS,
+					transitionSeconds: TRANSITION_SECONDS,
+					type: entry.type,
+				}
+			);
+			expect(applied, `${entry.label} transition attached`).toBeGreaterThan(0);
+
+			const outputPath = path.join(EVIDENCE_DIR, `${entry.label}.mp4`);
+			await stubExportSaveDialog({ electronApp, outputPath });
+			await ensureExportActions({ page });
+			await page.evaluate(async (target) => {
+				const actions = (
+					window as unknown as {
+						__exportActions?: {
+							exportLocalVideo: (
+								options: Record<string, unknown>
+							) => Promise<unknown>;
+						};
+					}
+				).__exportActions;
+				if (!actions) throw new Error("Export actions are not registered");
+				await actions.exportLocalVideo({
+					engine: "muxer",
+					filename: "transition.mp4",
+					format: "mp4",
+					frameRate: 30,
+					height: 360,
+					outputPath: target,
+					quality: "480p",
+					width: 640,
+				});
+			}, outputPath);
+			await expect
+				.poll(() => existsSync(outputPath), { timeout: 300_000 })
+				.toBe(true);
+
+			const probe = probeVideo({ filePath: outputPath });
+			const hashes = frameHashes({ filePath: outputPath });
+			results.push({ hashes, label: entry.label, probe });
+			console.log(
+				`[transition] ${entry.label.padEnd(10)} frames=${probe.frames} ` +
+					`hashed=${hashes.length} geometry=${probe.width}x${probe.height} ` +
+					`duration=${probe.duration.toFixed(3)} audio=${probe.audioCodec}`
+			);
+		}
+
+		// Window is [clipSeconds - transition/2, clipSeconds + transition/2].
+		const windowStartFrame = Math.round(
+			(CLIP_SECONDS - TRANSITION_SECONDS / 2) * FPS
+		);
+		const windowEndFrame = Math.round(
+			(CLIP_SECONDS + TRANSITION_SECONDS / 2) * FPS
+		);
+		const midFrame = Math.round(CLIP_SECONDS * FPS);
+
+		for (const result of results) {
+			// Container invariants.
+			expect(result.probe.width).toBe(640);
+			expect(result.probe.height).toBe(360);
+			expect(result.probe.duration).toBeGreaterThan(CLIP_SECONDS * 2 - 0.2);
+			expect(result.probe.duration).toBeLessThan(CLIP_SECONDS * 2 + 0.5);
+			expect(result.hashes.length).toBeGreaterThan(windowEndFrame);
+
+			const insideEarly = result.hashes[windowStartFrame + 3];
+			const insideMid = result.hashes[midFrame];
+			const insideLate = result.hashes[windowEndFrame - 3];
+			console.log(
+				`[transition] ${result.label} windowFrames ` +
+					`start=${result.hashes[windowStartFrame]} early=${insideEarly} ` +
+					`mid=${insideMid} late=${insideLate} end=${result.hashes[windowEndFrame]}`
+			);
+
+			// Inside the window the picture must actually be changing.
+			expect(
+				new Set([insideEarly, insideMid, insideLate]).size,
+				`${result.label} window interior must vary`
+			).toBe(3);
+		}
+
+		// Every transition type must produce a different result from the others,
+		// otherwise the transition type is not reaching the renderer at all.
+		const midHashes = results.map((result) => result.hashes[midFrame]);
+		expect(new Set(midHashes).size, "transition types must differ").toBe(
+			results.length
+		);
+		console.log(`[transition] MID_HASHES=${JSON.stringify(midHashes)}`);
+	});
+});
+
+/** Opens the export panel so `__exportActions` is registered. */
+async function ensureExportActions({
+	page,
+}: {
+	page: import("@playwright/test").Page;
+}): Promise<void> {
+	const registered = await page.evaluate(() =>
+		Boolean(
+			(window as unknown as { __exportActions?: unknown }).__exportActions
+		)
+	);
+	if (registered) return;
+	await page.locator('[data-testid="export-button"]').click();
+	await expect
+		.poll(
+			() =>
+				page.evaluate(() =>
+					Boolean(
+						(window as unknown as { __exportActions?: unknown }).__exportActions
+					)
+				),
+			{ timeout: 60_000 }
+		)
+		.toBe(true);
+}


### PR DESCRIPTION
## 摘要
转场 outgoing identity 调查——**仅测试，无生产改动**。

- **identity 短路已存在**（export-clip-transitions.ts:412，含文档注释），无冗余层可省
- **zoom-blur 双层是视觉公式必需**：outgoing 中窗 scale 1.18 / blur 12，窗口边缘回到 identity（单测 6/6 钉住 dissolve/slide=identity、zoom-blur/push/fade-black≠identity）
- **两个失败断言不是过时测试而是真回归的正确报警**：commit 2ead412fc 把 drawColorGradedSourceWithMasks 换成无 fast path 的 drawColorGradedSourceStack（DAG 祖先关系证明测试写时是绿的）——已在 #453 处理分配问题，fast path 恢复另行任务
- 真实导出 E2E：三种转场窗口起始帧 byte-identical（identity@p=0 实证），窗口内逐类型互异

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage validating visual behavior across dissolve, slide, zoom-blur, fade-to-black, and push transitions.
  * Added end-to-end checks confirming transition timing, video dimensions, duration, frame count, and distinct midpoint visuals.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->