### PR TITLE
fix(release): verify the packaged RIFE host by signature, not by download hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,9 @@ jobs:
       - name: Build afterPack script
         run: cd scripts && bunx tsc
 
+      - name: Stage RIFE frame interpolation host
+        run: bun run stage-rife-binaries
+
       - name: Build Electron application
         run: |
           npx electron-builder --win --publish never --config.win.forceCodeSigning=false --config.win.verifyUpdateCodeSignature=false --config.publish.channel=${{ needs.prepare.outputs.channel }}
@@ -118,6 +121,9 @@ jobs:
 
       - name: Verify packaged dependencies
         run: bun run verify:packaged-dependencies
+
+      - name: Verify packaged RIFE host
+        run: bun run verify:packaged-rife
 
       - name: Verify update artifacts
         run: bun run verify:update-artifacts -- --manifest latest.yml
@@ -219,6 +225,9 @@ jobs:
           bun run stage-jianying-filter-local-bridge
           bun run stage-independent-filter-host
 
+      - name: Stage RIFE frame interpolation host
+        run: bun run stage-rife-binaries
+
       - name: Build Electron application
         run: |
           rm -rf dist-electron
@@ -240,6 +249,9 @@ jobs:
 
       - name: Verify packaged dependencies
         run: bun run verify:packaged-dependencies
+
+      - name: Verify packaged RIFE host
+        run: bun run verify:packaged-rife
 
       - name: Build macOS DMG (custom hdiutil-based, sidesteps dmg-builder Tahoe bug)
         run: bun run build:mac-dmg
@@ -345,6 +357,9 @@ jobs:
             exit 1
           fi
 
+      - name: Stage RIFE frame interpolation host
+        run: bun run stage-rife-binaries
+
       - name: Build Electron application
         run: |
           npx electron-builder --linux --publish never --config.publish.channel=${{ needs.prepare.outputs.channel }}
@@ -353,6 +368,9 @@ jobs:
 
       - name: Verify packaged dependencies
         run: bun run verify:packaged-dependencies
+
+      - name: Verify packaged RIFE host
+        run: bun run verify:packaged-rife
 
       - name: Verify update artifacts
         run: bun run verify:update-artifacts -- --manifest latest-linux.yml

--- a/qcut/scripts/verify-packaged-rife.ts
+++ b/qcut/scripts/verify-packaged-rife.ts
@@ -143,8 +143,16 @@ async function verifyPackagedRife(): Promise<void> {
 		stderr: error.stderr ?? "",
 	}));
 	if (!`${stdout}\n${stderr}`.includes("Usage: rife-ncnn-vulkan")) {
-		throw new Error(
-			`Packaged RIFE host did not print its usage: ${executablePath}`
+		// Only macOS has been verified to run the host on the build machine;
+		// headless Linux/Windows runners may lack a Vulkan loader, which is a
+		// runner limitation, not a packaging defect.
+		if (platform === "darwin") {
+			throw new Error(
+				`Packaged RIFE host did not print its usage: ${executablePath}`
+			);
+		}
+		console.warn(
+			`[verify-rife] ${platform}: packaged host could not run on this machine (${stderr.trim().split("\n").at(-1) || "no output"}); layout and model hashes verified`
 		);
 	}
 	console.log(

--- a/qcut/scripts/verify-packaged-rife.ts
+++ b/qcut/scripts/verify-packaged-rife.ts
@@ -6,9 +6,15 @@
  *
  * Finds the newest packaged resources directory under dist-electron (the same
  * rule scripts/verify-packaged-ffmpeg.ts uses), checks that the platform's
- * executable and model files are present with the pinned SHA-256, and on the
- * host platform also runs the executable so a broken binary fails the build
- * rather than the first export.
+ * model files are present with the pinned SHA-256, that the executable is
+ * present, executable and (on macOS) carries a valid code signature, and on
+ * the host platform also runs the executable so a broken binary fails the
+ * build rather than the first export.
+ *
+ * The executable itself is not hashed here: electron-builder re-signs every
+ * Mach-O (hardened runtime + notarization) and may sign Windows binaries, so
+ * its bytes legitimately differ from the download. Its pinned hash is checked
+ * once, before signing, by scripts/stage-rife-binaries.ts.
  */
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -100,15 +106,25 @@ async function verifyPackagedRife(): Promise<void> {
 	const platformDir = join(resourcesDir, "rife", platform);
 	const executableName = `${manifest.executableName}${platform === "win32" ? ".exe" : ""}`;
 	const executablePath = join(platformDir, executableName);
-	await expectHash({
-		filePath: executablePath,
-		expected: target.executableSha256,
-		label: executableName,
-	});
+	if (!existsSync(executablePath)) {
+		throw new Error(`Packaged RIFE host missing: ${executablePath}`);
+	}
 	if (platform !== "win32") {
 		await access(executablePath, constants.X_OK).catch(() => {
 			throw new Error(
 				`Packaged RIFE host is not executable: ${executablePath}`
+			);
+		});
+	}
+	if (platform === "darwin") {
+		// Signing rewrote the binary; the signature must still verify.
+		await execFileAsync("codesign", [
+			"--verify",
+			"--strict",
+			executablePath,
+		]).catch((error: { stderr?: string }) => {
+			throw new Error(
+				`Packaged RIFE host has an invalid code signature: ${executablePath}${error.stderr ? ` — ${String(error.stderr).trim()}` : ""}`
 			);
 		});
 	}


### PR DESCRIPTION
The first v2026.09.11.1 release attempt failed at `verify:packaged-rife`: electron-builder re-signs every Mach-O in the app (hardened runtime + notarization), so the packaged `rife-ncnn-vulkan` no longer matches the pinned download hash (`d11429c7…` expected, `19562909…` received). The FFmpeg verifier never hashed executables for the same reason.

## Changes

- `scripts/verify-packaged-rife.ts`: the packaged executable is checked for presence, executable bit, a valid `codesign --verify --strict` signature on macOS, and that it prints its usage. The usage run is strict only on macOS (the verified build machine); headless Linux/Windows runners may lack a Vulkan loader, which is logged as a warning rather than failing the build. Model files (`rife-v4.6/*.bin|*.param`) keep their pinned SHA-256 checks; the download/executable hash is still enforced once, before signing, in `scripts/stage-rife-binaries.ts`.
- `.github/workflows/release.yml`: the release jobs run electron-builder directly (not the `dist:*` scripts), so they never staged RIFE — CI-built installers would have shipped without the neural interpolation host. Each platform job now runs `bun run stage-rife-binaries` before electron-builder and `bun run verify:packaged-rife` after `verify:packaged-dependencies`.

## Verification

- `codesign --verify --strict` passes on a signed packaged binary from the installed QCut; the script type-checks; the workflow YAML parses with the expected six new steps.
- The full path is exercised by the release run (`dist:mac` locally, then `release.yml` on the tag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that executable hashes are checked before signing, while packaged verification checks executable presence, permissions, and macOS code signatures.

- **Bug Fixes**
  - Release packaging now stages frame-interpolation components before packaging and verifies them afterward across Windows, macOS, and Linux.
  - macOS verification now fails when the host cannot start; Linux and Windows tolerate missing Vulkan support with a warning.
  - Packaged verification now confirms required executables are present and correctly permissioned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->