### PR TITLE
fix(release): bound, retry and cache the RIFE archive download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,16 @@ jobs:
       - name: Build afterPack script
         run: cd scripts && bunx tsc
 
+      - name: Cache RIFE archive
+        uses: actions/cache@v5
+        with:
+          path: qcut/node_modules/.cache/qcut-rife
+          key: rife-${{ runner.os }}-${{ hashFiles('qcut/electron/rife/rife-binaries.json') }}
+
       - name: Stage RIFE frame interpolation host
+        # The download is bounded and retried in the script; this cap turns a
+        # stalled runner network into a failed job instead of a 6-hour hang.
+        timeout-minutes: 25
         run: bun run stage-rife-binaries
 
       - name: Build Electron application
@@ -225,7 +234,16 @@ jobs:
           bun run stage-jianying-filter-local-bridge
           bun run stage-independent-filter-host
 
+      - name: Cache RIFE archive
+        uses: actions/cache@v5
+        with:
+          path: qcut/node_modules/.cache/qcut-rife
+          key: rife-${{ runner.os }}-${{ hashFiles('qcut/electron/rife/rife-binaries.json') }}
+
       - name: Stage RIFE frame interpolation host
+        # The download is bounded and retried in the script; this cap turns a
+        # stalled runner network into a failed job instead of a 6-hour hang.
+        timeout-minutes: 25
         run: bun run stage-rife-binaries
 
       - name: Build Electron application
@@ -357,7 +375,16 @@ jobs:
             exit 1
           fi
 
+      - name: Cache RIFE archive
+        uses: actions/cache@v5
+        with:
+          path: qcut/node_modules/.cache/qcut-rife
+          key: rife-${{ runner.os }}-${{ hashFiles('qcut/electron/rife/rife-binaries.json') }}
+
       - name: Stage RIFE frame interpolation host
+        # The download is bounded and retried in the script; this cap turns a
+        # stalled runner network into a failed job instead of a 6-hour hang.
+        timeout-minutes: 25
         run: bun run stage-rife-binaries
 
       - name: Build Electron application

--- a/qcut/scripts/stage-rife-binaries.ts
+++ b/qcut/scripts/stage-rife-binaries.ts
@@ -21,6 +21,7 @@ import {
 	rename,
 	rm,
 	stat,
+	writeFile,
 } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import extractZip from "extract-zip";
@@ -30,6 +31,9 @@ type RifePlatform = keyof typeof manifest.targets;
 
 const ROOT = resolve(import.meta.dir, "..");
 const CACHE_ROOT = join(ROOT, "node_modules", ".cache", "qcut-rife");
+const DOWNLOAD_MAX_RETRIES = 3;
+/** Generous for the 436 MB macOS archive, small enough that a stall fails the job. */
+const DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000;
 const RESOURCES_ROOT = join(ROOT, "electron", "resources", "rife");
 const PLATFORMS = Object.keys(manifest.targets) as RifePlatform[];
 
@@ -95,19 +99,43 @@ async function downloadArchive({
 	const cached = await sha256File({ filePath: archivePath }).catch(() => null);
 	if (cached === target.sha256) return archivePath;
 	const tempPath = `${archivePath}.download`;
-	await rm(tempPath, { force: true });
-	const response = await fetch(target.url, { redirect: "follow" });
-	if (!response.ok || !response.body) {
-		throw new Error(`Download failed (${response.status}): ${target.url}`);
+	// A hung release-asset download stalled three release jobs for hours:
+	// bound every attempt and retry, like scripts/stage-ffmpeg-binaries.ts.
+	let lastError: Error | null = null;
+	for (let attempt = 1; attempt <= DOWNLOAD_MAX_RETRIES; attempt += 1) {
+		await rm(tempPath, { force: true });
+		try {
+			process.stdout.write(
+				`[stage-rife] ${platform}: downloading ${basename(archivePath)} (attempt ${attempt}/${DOWNLOAD_MAX_RETRIES})\n`
+			);
+			const response = await fetch(target.url, {
+				redirect: "follow",
+				signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+			});
+			if (!response.ok) {
+				throw new Error(`Download failed (${response.status}): ${target.url}`);
+			}
+			await writeFile(tempPath, Buffer.from(await response.arrayBuffer()));
+			await expectHash({
+				filePath: tempPath,
+				expected: target.sha256,
+				label: `${platform} archive`,
+			});
+			await rename(tempPath, archivePath);
+			return archivePath;
+		} catch (error) {
+			lastError = error instanceof Error ? error : new Error(String(error));
+			await rm(tempPath, { force: true });
+			if (attempt < DOWNLOAD_MAX_RETRIES) {
+				process.stderr.write(
+					`[stage-rife] ${platform}: attempt ${attempt}/${DOWNLOAD_MAX_RETRIES} failed: ${lastError.message}; retrying\n`
+				);
+			}
+		}
 	}
-	await Bun.write(tempPath, response);
-	await expectHash({
-		filePath: tempPath,
-		expected: target.sha256,
-		label: `${platform} archive`,
-	});
-	await rename(tempPath, archivePath);
-	return archivePath;
+	throw new Error(
+		`Could not download the RIFE archive for ${platform} after ${DOWNLOAD_MAX_RETRIES} attempts: ${lastError?.message ?? "unknown error"}`
+	);
 }
 
 async function stage({ platform }: { platform: RifePlatform }): Promise<void> {


### PR DESCRIPTION
The v2026.09.11.1 tag run of `release.yml` (34500754957) hung in all three build jobs at "Stage RIFE frame interpolation host": `scripts/stage-rife-binaries.ts` fetched the release asset with no timeout and the download stalled (macOS hit its 45-minute job cap; Linux/Windows sat for ~2 hours until cancelled). The same stall had already happened once on the local release machine.

- `scripts/stage-rife-binaries.ts`: every download attempt is bounded by `AbortSignal.timeout` (10 min, generous for the 436 MB macOS archive) and retried up to 3 times, writing the body via `arrayBuffer` — the same pattern `stage-ffmpeg-binaries.ts` uses in CI. Attempts and failures are logged.
- `.github/workflows/release.yml`: each platform job caches `qcut/node_modules/.cache/qcut-rife` (key = manifest hash, so a pinned archive is downloaded once per runner OS) and caps the staging step at 25 minutes so a stalled network fails the job instead of hanging for hours.

No behavioural change once the archive is present: staging still verifies the archive and executable SHA-256 before extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved the reliability of RIFE component downloads during app setup and release builds.
  - Downloads now retry automatically after failures or timeouts and verify file integrity before use.
  - Added clearer progress and failure reporting when downloads cannot be completed.

- **Performance**
  - Release builds on Windows, macOS, and Linux can reuse cached RIFE files, helping reduce repeated download times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->